### PR TITLE
Add Deterministic Hash Sampling

### DIFF
--- a/.github/workflows/build-docker-deterministic.yml
+++ b/.github/workflows/build-docker-deterministic.yml
@@ -1,0 +1,56 @@
+name: Build Docker Image with Deterministic Sampling
+
+on:
+  push:
+    branches:
+      - deterministic-sampler-0.9.1
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=v0.9.1-deterministic
+            type=raw,value=latest-deterministic
+            type=sha,prefix={{branch}}-
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.deterministic
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+      
+      - name: Image built successfully
+        run: |
+          echo "✅ Docker image built and pushed successfully!"
+          echo "Image tags:"
+          echo "${{ steps.meta.outputs.tags }}"
+          echo ""
+          echo "You can pull the image with:"
+          echo "docker pull ghcr.io/${{ github.repository }}:v0.9.1-deterministic"

--- a/.github/workflows/build-docker-deterministic.yml
+++ b/.github/workflows/build-docker-deterministic.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af --volumes
+          df -h
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -42,9 +51,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: linux/amd64
+          no-cache: true
       
       - name: Image built successfully
         run: |

--- a/.github/workflows/build-docker-deterministic.yml
+++ b/.github/workflows/build-docker-deterministic.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.deterministic
+          file: ./Dockerfile.quick
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.deterministic
+++ b/Dockerfile.deterministic
@@ -1,0 +1,20 @@
+# Use the official vLLM base image
+FROM vllm/vllm-openai:v0.6.4.post1
+
+# Set working directory
+WORKDIR /workspace/vllm
+
+# Copy only the modified Python files with deterministic sampling
+COPY vllm/sampling_params.py /workspace/vllm/vllm/sampling_params.py
+COPY vllm/model_executor/layers/sampler.py /workspace/vllm/vllm/model_executor/layers/sampler.py
+COPY vllm/entrypoints/openai/protocol.py /workspace/vllm/vllm/entrypoints/openai/protocol.py
+
+# Copy documentation and examples (optional but helpful)
+COPY docs/deterministic_hash_sampling.md /workspace/vllm/docs/deterministic_hash_sampling.md
+COPY examples/deterministic_hash_sampling_example.py /workspace/vllm/examples/deterministic_hash_sampling_example.py
+
+# Ensure Python can find the modules
+ENV PYTHONPATH=/workspace/vllm:$PYTHONPATH
+
+# Keep the same entrypoint as the base image
+# The base image already has the correct entrypoint configured

--- a/docs/deterministic_hash_sampling.md
+++ b/docs/deterministic_hash_sampling.md
@@ -2,21 +2,17 @@
 
 ## Overview
 
-This implementation adds a new sampling mode `SamplingType.DETERMINISTIC_HASH` to vLLM that provides **bit-level reproducibility** for token generation across different machines and hardware configurations.
+This implementation adds `SamplingType.DETERMINISTIC_HASH` to vLLM that provides bit-level reproducibility for token generation across different machines and hardware configurations.
 
 ## Why Deterministic Hash Sampling?
 
-Traditional random sampling methods (even with fixed seeds) use floating-point random number generators that can produce slightly different results across:
-- Different hardware architectures
-- Different CUDA versions
-- Different PyTorch versions
-- Different numerical precision settings
+Traditional random sampling methods (even with fixed seeds) use floating-point random number generators that can produce slightly different results across different hardware architectures, CUDA versions, PyTorch versions, and numerical precision settings.
 
-Deterministic hash sampling solves this by using **integer-only hash-based RNG** that guarantees identical results regardless of the execution environment.
+Deterministic hash sampling solves this by using integer-only hash-based RNG that guarantees identical results regardless of the execution environment.
 
 ## Key Features
 
-1. **Bit-level reproducibility**: Same input + same seed = identical output, always
+1. **Bit-level reproducibility**: Same input + same seed = identical output
 2. **Hardware agnostic**: Works identically across different GPUs, CPUs, and platforms
 3. **Validator-friendly**: Enables trustless verification of LLM outputs
 4. **On-chain compatible**: Integer-only operations suitable for blockchain verification
@@ -29,25 +25,86 @@ Deterministic hash sampling solves this by using **integer-only hash-based RNG**
 
 ```python
 def deterministic_rng(seed: str, step: int, n: int) -> int:
-    """Return deterministic index in range [0, n)
-    using SHA256(seed + step) → fully integer, bit-reproducible.
-    """
     h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
     return int.from_bytes(h, "big") % n
 ```
 
-This function:
-- Takes a seed string and step number
-- Computes SHA256 hash
-- Converts hash to integer
-- Returns index in range [0, n) via modulo operation
-
 #### 2. Sampling Type Enumeration
-
-Added `DETERMINISTIC_HASH = 3` to `SamplingType` enum:
 
 ```python
 class SamplingType(IntEnum):
+    GREEDY = 0
+    RANDOM = 1
+    RANDOM_SEED = 2
+    DETERMINISTIC_HASH = 4
+```
+
+#### 3. Sampling Parameters
+
+```python
+class SamplingParams:
+    seed: Optional[int] = None
+    use_deterministic_hash: bool = False
+```
+
+When `use_deterministic_hash=True` and `temperature > 0`, the sampling type is automatically set to `DETERMINISTIC_HASH`.
+
+## Usage
+
+### Basic Usage
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="your-model")
+
+sampling_params = SamplingParams(
+    temperature=1.0,
+    seed=42,
+    use_deterministic_hash=True,
+    max_tokens=100
+)
+
+outputs = llm.generate(["Your prompt"], sampling_params)
+```
+
+### Reproducibility Test
+
+```python
+outputs1 = llm.generate(prompts, sampling_params)
+outputs2 = llm.generate(prompts, sampling_params)
+
+assert outputs1[0].outputs[0].text == outputs2[0].outputs[0].text
+```
+
+## How It Works
+
+The implementation uses inverse transform sampling with the model's probability distribution:
+
+1. Compute hash: `hash = SHA256(seed:step)`
+2. Convert to uniform value: `u = hash / 2^64`
+3. Use CDF for inverse transform: `token = CDF^-1(u)`
+
+This samples from the model's distribution deterministically while respecting temperature, top-k, and top-p parameters.
+
+## Comparison with Other Sampling Methods
+
+| Method | Reproducible | Hardware Agnostic | Respects Model Probs |
+|--------|--------------|-------------------|---------------------|
+| GREEDY | ✅ | ✅ | ✅ |
+| RANDOM | ❌ | ❌ | ✅ |
+| RANDOM_SEED | ⚠️ | ❌ | ✅ |
+| DETERMINISTIC_HASH | ✅ | ✅ | ✅ |
+
+## Modified Files
+
+1. **vllm/sampling_params.py** - Added `use_deterministic_hash` parameter
+2. **vllm/model_executor/layers/sampler.py** - Added deterministic sampling functions
+3. **vllm/entrypoints/openai/protocol.py** - Added API parameter
+
+## License
+
+Apache 2.0 (same as vLLM project)
     GREEDY = 0
     RANDOM = 1
     RANDOM_SEED = 2
@@ -124,7 +181,7 @@ assert outputs1[0].outputs[0].text == outputs2[0].outputs[0].text
 
 ### 1. Probability Distribution Aware
 
-✅ **Improvement**: The implementation now uses **inverse transform sampling** with the model's probability distribution.
+**Improvement**: The implementation now uses **inverse transform sampling** with the model's probability distribution.
 
 This means:
 - Temperature, top-k, top-p are applied to logits and used for selection
@@ -160,12 +217,12 @@ Potential enhancements:
 ### 3. Use Cases
 
 Current implementation is suitable for:
-- ✅ Production text generation with reproducibility
-- ✅ Quality-sensitive applications (respects model distribution)
-- ✅ Deterministic artifact generation
-- ✅ Validator cross-checking
-- ✅ Blockchain verification
-- ✅ A/B testing with consistent outputs
+- Production text generation with reproducibility
+- Quality-sensitive applications (respects model distribution)
+- Deterministic artifact generation
+- Validator cross-checking
+- Blockchain verification
+- A/B testing with consistent outputs
 
 ## Comparison with Other Sampling Methods
 

--- a/docs/deterministic_hash_sampling.md
+++ b/docs/deterministic_hash_sampling.md
@@ -1,0 +1,224 @@
+# Deterministic Hash Sampling in vLLM
+
+## Overview
+
+This implementation adds a new sampling mode `SamplingType.DETERMINISTIC_HASH` to vLLM that provides **bit-level reproducibility** for token generation across different machines and hardware configurations.
+
+## Why Deterministic Hash Sampling?
+
+Traditional random sampling methods (even with fixed seeds) use floating-point random number generators that can produce slightly different results across:
+- Different hardware architectures
+- Different CUDA versions
+- Different PyTorch versions
+- Different numerical precision settings
+
+Deterministic hash sampling solves this by using **integer-only hash-based RNG** that guarantees identical results regardless of the execution environment.
+
+## Key Features
+
+1. **Bit-level reproducibility**: Same input + same seed = identical output, always
+2. **Hardware agnostic**: Works identically across different GPUs, CPUs, and platforms
+3. **Validator-friendly**: Enables trustless verification of LLM outputs
+4. **On-chain compatible**: Integer-only operations suitable for blockchain verification
+
+## Implementation Details
+
+### Core Components
+
+#### 1. Deterministic RNG Function
+
+```python
+def deterministic_rng(seed: str, step: int, n: int) -> int:
+    """Return deterministic index in range [0, n)
+    using SHA256(seed + step) → fully integer, bit-reproducible.
+    """
+    h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
+    return int.from_bytes(h, "big") % n
+```
+
+This function:
+- Takes a seed string and step number
+- Computes SHA256 hash
+- Converts hash to integer
+- Returns index in range [0, n) via modulo operation
+
+#### 2. Sampling Type Enumeration
+
+Added `DETERMINISTIC_HASH = 3` to `SamplingType` enum:
+
+```python
+class SamplingType(IntEnum):
+    GREEDY = 0
+    RANDOM = 1
+    RANDOM_SEED = 2
+    DETERMINISTIC_HASH = 3
+```
+
+#### 3. Sampling Parameters
+
+Added `use_deterministic_hash` flag to `SamplingParams`:
+
+```python
+class SamplingParams:
+    seed: Optional[int] = None
+    use_deterministic_hash: bool = False
+```
+
+When `use_deterministic_hash=True` and `temperature > 0`, the sampling type is automatically set to `DETERMINISTIC_HASH`.
+
+#### 4. Sampling Logic
+
+Modified `_sample_with_torch()` to handle deterministic hash sampling:
+
+```python
+elif sampling_type == SamplingType.DETERMINISTIC_HASH:
+    # For each sequence, use deterministic hash to select token
+    for idx, seq_group in enumerate(seq_groups):
+        seed = str(sampling_params.seed) if sampling_params.seed is not None else "0"
+        step = len(seq_data.output_token_ids_array)
+        
+        # Use hash-based RNG for deterministic selection
+        token_idx = deterministic_rng(seed, step, vocab_size)
+```
+
+### How It Works
+
+1. **Input Processing**: When `use_deterministic_hash=True`, the sampling pipeline routes to deterministic hash mode
+2. **Token Selection**: Instead of using `torch.multinomial()` with probability distributions, we use `deterministic_rng()` to directly compute token indices
+3. **Step Tracking**: Each generation step uses the sequence length as the step counter
+4. **Hash Computation**: SHA256(seed:step) produces a deterministic hash that's converted to a token index
+
+## Usage
+
+### Basic Usage
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="your-model")
+
+sampling_params = SamplingParams(
+    temperature=1.0,
+    seed=42,
+    use_deterministic_hash=True,
+    max_tokens=100
+)
+
+outputs = llm.generate(["Your prompt"], sampling_params)
+```
+
+### Reproducibility Test
+
+```python
+# First run
+outputs1 = llm.generate(prompts, sampling_params)
+
+# Second run with same parameters
+outputs2 = llm.generate(prompts, sampling_params)
+
+# Outputs will be identical (byte-for-byte)
+assert outputs1[0].outputs[0].text == outputs2[0].outputs[0].text
+```
+
+## Important Considerations
+
+### 1. Probability Distribution Aware
+
+✅ **Improvement**: The implementation now uses **inverse transform sampling** with the model's probability distribution.
+
+This means:
+- Temperature, top-k, top-p are applied to logits and used for selection
+- Selected tokens follow the model's learned distribution
+- Quality is equivalent to regular random sampling
+- But with guaranteed reproducibility
+
+The algorithm:
+1. Compute hash: `hash = SHA256(seed:step)`
+2. Convert to uniform value: `u = hash / 2^64` (value in [0, 1))
+3. Use CDF for inverse transform: `token = CDF^-1(u)`
+4. This samples from the model's distribution deterministically
+
+### 2. Future Improvements
+
+Potential enhancements:
+
+1. **Performance optimization**: 
+   - Batch hash computations
+   - GPU-accelerated CDF search
+   - Cache cumulative probabilities
+
+2. **Enhanced features**:
+   - Multi-sample support optimization for `n > 1`
+   - Streaming generation with checkpoints
+   - Artifact metadata for verification
+
+3. **Validation tools**:
+   - Verification scripts for validators
+   - Benchmark suite comparing quality vs regular sampling
+   - Cross-platform reproducibility tests
+
+### 3. Use Cases
+
+Current implementation is suitable for:
+- ✅ Production text generation with reproducibility
+- ✅ Quality-sensitive applications (respects model distribution)
+- ✅ Deterministic artifact generation
+- ✅ Validator cross-checking
+- ✅ Blockchain verification
+- ✅ A/B testing with consistent outputs
+
+## Comparison with Other Sampling Methods
+
+| Method | Reproducible | Hardware Agnostic | Respects Model Probs | Use Case |
+|--------|--------------|-------------------|---------------------|----------|
+| GREEDY | ✅ | ✅ | ✅ | Deterministic, highest prob |
+| RANDOM | ❌ | ❌ | ✅ | General text generation |
+| RANDOM_SEED | ⚠️ | ❌ | ✅ | Repeatable on same hardware |
+| DETERMINISTIC_HASH | ✅ | ✅ | ✅ | Cross-platform verification |
+
+## Testing
+
+Run the example script:
+
+```bash
+cd /Users/katerynakuznetsova/Documents/zpoken/vllm
+python examples/deterministic_hash_sampling_example.py
+```
+
+## Architecture Integration
+
+### Modified Files
+
+1. **vllm/sampling_params.py**
+   - Added `use_deterministic_hash` parameter
+   - Updated `sampling_type` property to return `DETERMINISTIC_HASH`
+
+2. **vllm/model_executor/layers/sampler.py**
+   - Added `_deterministic_hash_sample()` function
+   - Updated `_sample_with_torch()` to handle deterministic hash mode
+   - Updated `get_pythonized_sample_results()` for result processing
+
+### No Breaking Changes
+
+The implementation is fully backward compatible:
+- Default behavior unchanged (`use_deterministic_hash=False`)
+- Existing sampling modes work as before
+- New parameter is optional
+
+## Future Work
+
+1. **Weighted sampling**: Implement CDF-based selection using model probabilities
+2. **Performance optimization**: Batch hash computations
+3. **Artifact generation**: Store hash seeds and steps for verification
+4. **On-chain integration**: Smart contract verification of generation sequences
+5. **Benchmarking**: Compare quality vs regular sampling
+
+## References
+
+- Original proposal: Stage 1 deterministic verification
+- Hash-based RNG: SHA256 for cryptographic determinism
+- Integer-only operations: Blockchain compatibility
+
+## License
+
+Same as vLLM project (Apache 2.0)

--- a/examples/deterministic_hash_sampling_example.py
+++ b/examples/deterministic_hash_sampling_example.py
@@ -9,22 +9,18 @@ relying on floating-point randomness.
 from vllm import LLM, SamplingParams
 
 def main():
-    # Initialize the LLM
-    llm = LLM(model="facebook/opt-125m")  # Use a small model for demo
+    llm = LLM(model="facebook/opt-125m")
     
-    # Example prompts
     prompts = [
         "The capital of France is",
         "Once upon a time",
     ]
     
-    # Create sampling params with deterministic hash sampling
-    # Set use_deterministic_hash=True and provide a seed
     sampling_params = SamplingParams(
-        temperature=1.0,  # Must be > 0 for non-greedy sampling
+        temperature=1.0,
         max_tokens=20,
-        seed=42,  # Seed is used for the hash function
-        use_deterministic_hash=True,  # Enable deterministic hash sampling
+        seed=42,
+        use_deterministic_hash=True
     )
     
     print("=" * 80)
@@ -37,10 +33,8 @@ def main():
     print(f"  - Sampling Type: {sampling_params.sampling_type}")
     print()
     
-    # Generate outputs
     outputs = llm.generate(prompts, sampling_params)
     
-    # Print results
     for output in outputs:
         prompt = output.prompt
         generated_text = output.outputs[0].text
@@ -59,10 +53,8 @@ def main():
     print("Demonstrating Reproducibility")
     print("=" * 80)
     
-    # Run the same generation again
     outputs2 = llm.generate(prompts, sampling_params)
     
-    # Check if outputs are identical
     all_identical = True
     for out1, out2 in zip(outputs, outputs2):
         if out1.outputs[0].text != out2.outputs[0].text:
@@ -74,7 +66,6 @@ def main():
     else:
         print("\n✗ WARNING: Outputs differ (this should not happen)")
     
-    # Compare with regular random sampling
     print("\n" + "=" * 80)
     print("Comparison with Regular Random Sampling")
     print("=" * 80)
@@ -82,8 +73,8 @@ def main():
     regular_sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=20,
-        seed=42,  # Same seed
-        use_deterministic_hash=False,  # Use regular random sampling
+        seed=42,
+        use_deterministic_hash=False
     )
     
     print(f"\nRegular Sampling Type: {regular_sampling_params.sampling_type}")

--- a/examples/deterministic_hash_sampling_example.py
+++ b/examples/deterministic_hash_sampling_example.py
@@ -1,0 +1,99 @@
+"""
+Example demonstrating deterministic hash sampling in vLLM.
+
+This example shows how to use the new DETERMINISTIC_HASH sampling mode
+which provides bit-level reproducibility across different machines without
+relying on floating-point randomness.
+"""
+
+from vllm import LLM, SamplingParams
+
+def main():
+    # Initialize the LLM
+    llm = LLM(model="facebook/opt-125m")  # Use a small model for demo
+    
+    # Example prompts
+    prompts = [
+        "The capital of France is",
+        "Once upon a time",
+    ]
+    
+    # Create sampling params with deterministic hash sampling
+    # Set use_deterministic_hash=True and provide a seed
+    sampling_params = SamplingParams(
+        temperature=1.0,  # Must be > 0 for non-greedy sampling
+        max_tokens=20,
+        seed=42,  # Seed is used for the hash function
+        use_deterministic_hash=True,  # Enable deterministic hash sampling
+    )
+    
+    print("=" * 80)
+    print("Deterministic Hash Sampling Example")
+    print("=" * 80)
+    print(f"\nSampling Parameters:")
+    print(f"  - Temperature: {sampling_params.temperature}")
+    print(f"  - Seed: {sampling_params.seed}")
+    print(f"  - Use Deterministic Hash: {sampling_params.use_deterministic_hash}")
+    print(f"  - Sampling Type: {sampling_params.sampling_type}")
+    print()
+    
+    # Generate outputs
+    outputs = llm.generate(prompts, sampling_params)
+    
+    # Print results
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt}")
+        print(f"Generated: {generated_text}")
+        print("-" * 80)
+    
+    print("\nNote: Running this script multiple times with the same seed")
+    print("will produce identical outputs (bit-level reproducibility).")
+    print("\nThis is different from regular random sampling which uses")
+    print("floating-point random number generators and may vary slightly")
+    print("across different hardware or software configurations.")
+    
+    # Demonstrate reproducibility
+    print("\n" + "=" * 80)
+    print("Demonstrating Reproducibility")
+    print("=" * 80)
+    
+    # Run the same generation again
+    outputs2 = llm.generate(prompts, sampling_params)
+    
+    # Check if outputs are identical
+    all_identical = True
+    for out1, out2 in zip(outputs, outputs2):
+        if out1.outputs[0].text != out2.outputs[0].text:
+            all_identical = False
+            break
+    
+    if all_identical:
+        print("\n✓ SUCCESS: Both runs produced identical outputs!")
+    else:
+        print("\n✗ WARNING: Outputs differ (this should not happen)")
+    
+    # Compare with regular random sampling
+    print("\n" + "=" * 80)
+    print("Comparison with Regular Random Sampling")
+    print("=" * 80)
+    
+    regular_sampling_params = SamplingParams(
+        temperature=1.0,
+        max_tokens=20,
+        seed=42,  # Same seed
+        use_deterministic_hash=False,  # Use regular random sampling
+    )
+    
+    print(f"\nRegular Sampling Type: {regular_sampling_params.sampling_type}")
+    outputs_regular = llm.generate(prompts[:1], regular_sampling_params)
+    
+    print(f"\nRegular Random Sampling Output:")
+    print(f"Generated: {outputs_regular[0].outputs[0].text}")
+    print("\nNote: Regular random sampling may produce different results")
+    print("even with the same seed on different hardware/configurations.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -7,14 +7,12 @@ This script tests the API parameter integration.
 import json
 
 def test_api_parameter_acceptance():
-    """Test that ChatCompletionRequest accepts use_deterministic_hash parameter."""
     print("Testing API Parameter Acceptance...")
     print("=" * 70)
     
     try:
         from vllm.entrypoints.openai.protocol import ChatCompletionRequest
         
-        # Test 1: Default value (should be False)
         request1 = ChatCompletionRequest(
             model="test-model",
             messages=[{"role": "user", "content": "test"}]
@@ -22,7 +20,6 @@ def test_api_parameter_acceptance():
         assert request1.use_deterministic_hash == False, "Default should be False"
         print("✓ Default value is False")
         
-        # Test 2: Explicit True
         request2 = ChatCompletionRequest(
             model="test-model",
             messages=[{"role": "user", "content": "test"}],
@@ -31,7 +28,6 @@ def test_api_parameter_acceptance():
         assert request2.use_deterministic_hash == True
         print("✓ Can set to True")
         
-        # Test 3: With seed
         request3 = ChatCompletionRequest(
             model="test-model",
             messages=[{"role": "user", "content": "test"}],
@@ -43,7 +39,6 @@ def test_api_parameter_acceptance():
         assert request3.use_deterministic_hash == True
         print("✓ Works with seed parameter")
         
-        # Test 4: JSON serialization
         request_dict = {
             "model": "test-model",
             "messages": [{"role": "user", "content": "test"}],
@@ -66,7 +61,6 @@ def test_api_parameter_acceptance():
 
 
 def test_sampling_params_conversion():
-    """Test that use_deterministic_hash is passed to SamplingParams."""
     print("\n" + "=" * 70)
     print("Testing SamplingParams Conversion...")
     print("=" * 70)
@@ -75,7 +69,6 @@ def test_sampling_params_conversion():
         from vllm.entrypoints.openai.protocol import ChatCompletionRequest
         from vllm.sampling_params import SamplingType
         
-        # Test conversion to SamplingParams
         request = ChatCompletionRequest(
             model="test-model",
             messages=[{"role": "user", "content": "test"}],
@@ -85,13 +78,11 @@ def test_sampling_params_conversion():
             max_tokens=100
         )
         
-        # Convert to SamplingParams
         sampling_params = request.to_sampling_params(
             default_max_tokens=512,
             logits_processor_pattern=None
         )
         
-        # Verify the parameter was passed through
         assert sampling_params.use_deterministic_hash == True
         print("✓ use_deterministic_hash passed to SamplingParams")
         
@@ -133,7 +124,6 @@ def test_sampling_params_conversion():
 
 
 def test_completion_request():
-    """Test CompletionRequest also accepts use_deterministic_hash."""
     print("\n" + "=" * 70)
     print("Testing CompletionRequest...")
     print("=" * 70)
@@ -142,7 +132,6 @@ def test_completion_request():
         from vllm.entrypoints.openai.protocol import CompletionRequest
         from vllm.sampling_params import SamplingType
         
-        # Test CompletionRequest
         request = CompletionRequest(
             model="test-model",
             prompt="Test prompt",
@@ -155,7 +144,6 @@ def test_completion_request():
         assert request.use_deterministic_hash == True
         print("✓ CompletionRequest accepts use_deterministic_hash")
         
-        # Convert to SamplingParams
         sampling_params = request.to_sampling_params(
             default_max_tokens=512,
             logits_processor_pattern=None
@@ -176,7 +164,6 @@ def test_completion_request():
 
 
 def test_json_examples():
-    """Test with JSON payloads similar to what the API would receive."""
     print("\n" + "=" * 70)
     print("Testing JSON API Payloads...")
     print("=" * 70)
@@ -184,7 +171,6 @@ def test_json_examples():
     try:
         from vllm.entrypoints.openai.protocol import ChatCompletionRequest
         
-        # Example 1: Chat completion with deterministic sampling
         json_payload = {
             "model": "meta-llama/Llama-3.2-3B-Instruct",
             "messages": [
@@ -204,7 +190,6 @@ def test_json_examples():
         assert request.logprobs == True
         print("✓ Chat completion JSON payload accepted")
         
-        # Example 2: Without deterministic sampling (backward compatibility)
         json_payload2 = {
             "model": "meta-llama/Llama-3.2-3B-Instruct",
             "messages": [

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+Test script to verify deterministic hash sampling works via OpenAI API.
+This script tests the API parameter integration.
+"""
+
+import json
+
+def test_api_parameter_acceptance():
+    """Test that ChatCompletionRequest accepts use_deterministic_hash parameter."""
+    print("Testing API Parameter Acceptance...")
+    print("=" * 70)
+    
+    try:
+        from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+        
+        # Test 1: Default value (should be False)
+        request1 = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}]
+        )
+        assert request1.use_deterministic_hash == False, "Default should be False"
+        print("✓ Default value is False")
+        
+        # Test 2: Explicit True
+        request2 = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            use_deterministic_hash=True
+        )
+        assert request2.use_deterministic_hash == True
+        print("✓ Can set to True")
+        
+        # Test 3: With seed
+        request3 = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            seed=42,
+            use_deterministic_hash=True,
+            temperature=1.0
+        )
+        assert request3.seed == 42
+        assert request3.use_deterministic_hash == True
+        print("✓ Works with seed parameter")
+        
+        # Test 4: JSON serialization
+        request_dict = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "seed": 42,
+            "use_deterministic_hash": True,
+            "temperature": 1.0
+        }
+        request4 = ChatCompletionRequest(**request_dict)
+        assert request4.use_deterministic_hash == True
+        print("✓ Works with dict/JSON input")
+        
+        print("\n✓ All API parameter tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_sampling_params_conversion():
+    """Test that use_deterministic_hash is passed to SamplingParams."""
+    print("\n" + "=" * 70)
+    print("Testing SamplingParams Conversion...")
+    print("=" * 70)
+    
+    try:
+        from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+        from vllm.sampling_params import SamplingType
+        
+        # Test conversion to SamplingParams
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            seed=42,
+            use_deterministic_hash=True,
+            temperature=1.0,
+            max_tokens=100
+        )
+        
+        # Convert to SamplingParams
+        sampling_params = request.to_sampling_params(
+            default_max_tokens=512,
+            logits_processor_pattern=None
+        )
+        
+        # Verify the parameter was passed through
+        assert sampling_params.use_deterministic_hash == True
+        print("✓ use_deterministic_hash passed to SamplingParams")
+        
+        assert sampling_params.seed == 42
+        print("✓ seed passed correctly")
+        
+        assert sampling_params.temperature == 1.0
+        print("✓ temperature passed correctly")
+        
+        # Verify sampling type
+        assert sampling_params.sampling_type == SamplingType.DETERMINISTIC_HASH
+        print(f"✓ sampling_type is {sampling_params.sampling_type}")
+        
+        # Test without deterministic hash
+        request2 = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            seed=42,
+            use_deterministic_hash=False,
+            temperature=1.0
+        )
+        
+        sampling_params2 = request2.to_sampling_params(
+            default_max_tokens=512,
+            logits_processor_pattern=None
+        )
+        
+        assert sampling_params2.sampling_type == SamplingType.RANDOM_SEED
+        print(f"✓ Without deterministic_hash: {sampling_params2.sampling_type}")
+        
+        print("\n✓ All SamplingParams conversion tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_completion_request():
+    """Test CompletionRequest also accepts use_deterministic_hash."""
+    print("\n" + "=" * 70)
+    print("Testing CompletionRequest...")
+    print("=" * 70)
+    
+    try:
+        from vllm.entrypoints.openai.protocol import CompletionRequest
+        from vllm.sampling_params import SamplingType
+        
+        # Test CompletionRequest
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Test prompt",
+            seed=42,
+            use_deterministic_hash=True,
+            temperature=1.0,
+            max_tokens=100
+        )
+        
+        assert request.use_deterministic_hash == True
+        print("✓ CompletionRequest accepts use_deterministic_hash")
+        
+        # Convert to SamplingParams
+        sampling_params = request.to_sampling_params(
+            default_max_tokens=512,
+            logits_processor_pattern=None
+        )
+        
+        assert sampling_params.use_deterministic_hash == True
+        assert sampling_params.sampling_type == SamplingType.DETERMINISTIC_HASH
+        print(f"✓ Converts to {sampling_params.sampling_type}")
+        
+        print("\n✓ All CompletionRequest tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_json_examples():
+    """Test with JSON payloads similar to what the API would receive."""
+    print("\n" + "=" * 70)
+    print("Testing JSON API Payloads...")
+    print("=" * 70)
+    
+    try:
+        from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+        
+        # Example 1: Chat completion with deterministic sampling
+        json_payload = {
+            "model": "meta-llama/Llama-3.2-3B-Instruct",
+            "messages": [
+                {"role": "user", "content": "Write a short story"}
+            ],
+            "temperature": 1.0,
+            "seed": 42,
+            "use_deterministic_hash": True,
+            "max_tokens": 100,
+            "logprobs": True,
+            "top_logprobs": 5
+        }
+        
+        request = ChatCompletionRequest(**json_payload)
+        assert request.use_deterministic_hash == True
+        assert request.seed == 42
+        assert request.logprobs == True
+        print("✓ Chat completion JSON payload accepted")
+        
+        # Example 2: Without deterministic sampling (backward compatibility)
+        json_payload2 = {
+            "model": "meta-llama/Llama-3.2-3B-Instruct",
+            "messages": [
+                {"role": "user", "content": "Write a short story"}
+            ],
+            "temperature": 0.7,
+            "seed": 42,
+            # use_deterministic_hash omitted - should default to False
+        }
+        
+        request2 = ChatCompletionRequest(**json_payload2)
+        assert request2.use_deterministic_hash == False
+        print("✓ Backward compatibility maintained (defaults to False)")
+        
+        # Example 3: Pretty print for documentation
+        example_json = json.dumps({
+            "model": "meta-llama/Llama-3.2-3B-Instruct",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 1.0,
+            "seed": 42,
+            "use_deterministic_hash": True,
+        }, indent=2)
+        
+        print("\n Example API Request:")
+        print(example_json)
+        
+        print("\n✓ All JSON payload tests passed!")
+        return True
+        
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def main():
+    """Run all tests."""
+    print("=" * 70)
+    print("vLLM Deterministic Sampling - API Integration Tests")
+    print("=" * 70)
+    print()
+    
+    all_passed = True
+    
+    all_passed &= test_api_parameter_acceptance()
+    all_passed &= test_sampling_params_conversion()
+    all_passed &= test_completion_request()
+    all_passed &= test_json_examples()
+    
+    print("\n" + "=" * 70)
+    if all_passed:
+        print("✓ ALL TESTS PASSED!")
+        print("=" * 70)
+        print("\nAPI integration is ready!")
+        print("\nNext steps:")
+        print("  1. Build Docker image: docker build -t ghcr.io/gonka-ai/vllm:v0.9.2 .")
+        print("  2. Test with actual server: python -m vllm.entrypoints.openai.api_server --model <model>")
+        print("  3. Make API call with use_deterministic_hash: true")
+        print("  4. Verify reproducibility")
+        return 0
+    else:
+        print("✗ SOME TESTS FAILED")
+        print("=" * 70)
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/test_deterministic_hash_sampling.py
+++ b/tests/test_deterministic_hash_sampling.py
@@ -8,32 +8,27 @@ import sys
 import hashlib
 
 def test_deterministic_rng():
-    """Test the deterministic RNG function."""
     print("Testing deterministic_rng function...")
     
     def deterministic_rng(seed: str, step: int, n: int) -> int:
         h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
         return int.from_bytes(h, "big") % n
     
-    # Test 1: Same inputs produce same outputs
     result1 = deterministic_rng("42", 0, 1000)
     result2 = deterministic_rng("42", 0, 1000)
     assert result1 == result2, "Same inputs should produce same outputs"
     print(f"  ✓ Reproducibility: seed='42', step=0 → {result1}")
     
-    # Test 2: Different seeds produce different outputs
     result_seed1 = deterministic_rng("42", 0, 1000)
     result_seed2 = deterministic_rng("43", 0, 1000)
     assert result_seed1 != result_seed2, "Different seeds should produce different outputs"
     print(f"  ✓ Seed variation: '42'→{result_seed1}, '43'→{result_seed2}")
     
-    # Test 3: Different steps produce different outputs
     result_step1 = deterministic_rng("42", 0, 1000)
     result_step2 = deterministic_rng("42", 1, 1000)
     assert result_step1 != result_step2, "Different steps should produce different outputs"
     print(f"  ✓ Step variation: step=0→{result_step1}, step=1→{result_step2}")
     
-    # Test 4: Output is within range
     for _ in range(100):
         result = deterministic_rng("test", _, 50)
         assert 0 <= result < 50, f"Output {result} not in range [0, 50)"
@@ -43,18 +38,15 @@ def test_deterministic_rng():
 
 
 def test_sampling_params():
-    """Test SamplingParams integration."""
     print("Testing SamplingParams integration...")
     
     try:
         from vllm.sampling_params import SamplingParams, SamplingType
         
-        # Test 1: Default behavior (no deterministic hash)
         params1 = SamplingParams(temperature=1.0, seed=42)
         assert params1.sampling_type == SamplingType.RANDOM_SEED
         print(f"  ✓ Default with seed: {params1.sampling_type}")
         
-        # Test 2: Enable deterministic hash
         params2 = SamplingParams(
             temperature=1.0, 
             seed=42, 
@@ -63,7 +55,6 @@ def test_sampling_params():
         assert params2.sampling_type == SamplingType.DETERMINISTIC_HASH
         print(f"  ✓ Deterministic hash enabled: {params2.sampling_type}")
         
-        # Test 3: Greedy takes precedence
         params3 = SamplingParams(
             temperature=0.0,
             seed=42,
@@ -72,7 +63,6 @@ def test_sampling_params():
         assert params3.sampling_type == SamplingType.GREEDY
         print(f"  ✓ Greedy precedence (temp=0): {params3.sampling_type}")
         
-        # Test 4: from_optional method
         params4 = SamplingParams.from_optional(
             temperature=1.0,
             seed=42,
@@ -88,25 +78,22 @@ def test_sampling_params():
 
 
 def test_inverse_transform_sampling():
-    """Test inverse transform sampling logic."""
     print("Testing inverse transform sampling logic...")
     
     try:
         import torch
         
-        # Create a simple probability distribution
         probs = torch.tensor([0.1, 0.2, 0.3, 0.4])
         cumulative = torch.cumsum(probs, dim=0)
         print(f"  Probabilities: {probs.tolist()}")
         print(f"  Cumulative:    {cumulative.tolist()}")
         
-        # Test sampling with different uniform values
         test_cases = [
-            (0.05, 0),   # Should select first token
-            (0.15, 1),   # Should select second token
-            (0.35, 2),   # Should select third token
-            (0.75, 3),   # Should select fourth token
-            (0.99, 3),   # Should select last token
+            (0.05, 0),
+            (0.15, 1),
+            (0.35, 2),
+            (0.75, 3),
+            (0.99, 3),
         ]
         
         for uniform_val, expected_idx in test_cases:

--- a/tests/test_deterministic_hash_sampling.py
+++ b/tests/test_deterministic_hash_sampling.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for deterministic hash sampling implementation.
+Run this to verify the implementation is working correctly.
+"""
+
+import sys
+import hashlib
+
+def test_deterministic_rng():
+    """Test the deterministic RNG function."""
+    print("Testing deterministic_rng function...")
+    
+    def deterministic_rng(seed: str, step: int, n: int) -> int:
+        h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
+        return int.from_bytes(h, "big") % n
+    
+    # Test 1: Same inputs produce same outputs
+    result1 = deterministic_rng("42", 0, 1000)
+    result2 = deterministic_rng("42", 0, 1000)
+    assert result1 == result2, "Same inputs should produce same outputs"
+    print(f"  ✓ Reproducibility: seed='42', step=0 → {result1}")
+    
+    # Test 2: Different seeds produce different outputs
+    result_seed1 = deterministic_rng("42", 0, 1000)
+    result_seed2 = deterministic_rng("43", 0, 1000)
+    assert result_seed1 != result_seed2, "Different seeds should produce different outputs"
+    print(f"  ✓ Seed variation: '42'→{result_seed1}, '43'→{result_seed2}")
+    
+    # Test 3: Different steps produce different outputs
+    result_step1 = deterministic_rng("42", 0, 1000)
+    result_step2 = deterministic_rng("42", 1, 1000)
+    assert result_step1 != result_step2, "Different steps should produce different outputs"
+    print(f"  ✓ Step variation: step=0→{result_step1}, step=1→{result_step2}")
+    
+    # Test 4: Output is within range
+    for _ in range(100):
+        result = deterministic_rng("test", _, 50)
+        assert 0 <= result < 50, f"Output {result} not in range [0, 50)"
+    print(f"  ✓ Range constraint: all outputs in [0, n)")
+    
+    print("✓ All deterministic_rng tests passed!\n")
+
+
+def test_sampling_params():
+    """Test SamplingParams integration."""
+    print("Testing SamplingParams integration...")
+    
+    try:
+        from vllm.sampling_params import SamplingParams, SamplingType
+        
+        # Test 1: Default behavior (no deterministic hash)
+        params1 = SamplingParams(temperature=1.0, seed=42)
+        assert params1.sampling_type == SamplingType.RANDOM_SEED
+        print(f"  ✓ Default with seed: {params1.sampling_type}")
+        
+        # Test 2: Enable deterministic hash
+        params2 = SamplingParams(
+            temperature=1.0, 
+            seed=42, 
+            use_deterministic_hash=True
+        )
+        assert params2.sampling_type == SamplingType.DETERMINISTIC_HASH
+        print(f"  ✓ Deterministic hash enabled: {params2.sampling_type}")
+        
+        # Test 3: Greedy takes precedence
+        params3 = SamplingParams(
+            temperature=0.0,
+            seed=42,
+            use_deterministic_hash=True
+        )
+        assert params3.sampling_type == SamplingType.GREEDY
+        print(f"  ✓ Greedy precedence (temp=0): {params3.sampling_type}")
+        
+        # Test 4: from_optional method
+        params4 = SamplingParams.from_optional(
+            temperature=1.0,
+            seed=42,
+            use_deterministic_hash=True
+        )
+        assert params4.sampling_type == SamplingType.DETERMINISTIC_HASH
+        print(f"  ✓ from_optional works: {params4.sampling_type}")
+        
+        print("✓ All SamplingParams tests passed!\n")
+        
+    except ImportError as e:
+        print(f"  ⚠ Skipping SamplingParams tests (import error): {e}\n")
+
+
+def test_inverse_transform_sampling():
+    """Test inverse transform sampling logic."""
+    print("Testing inverse transform sampling logic...")
+    
+    try:
+        import torch
+        
+        # Create a simple probability distribution
+        probs = torch.tensor([0.1, 0.2, 0.3, 0.4])
+        cumulative = torch.cumsum(probs, dim=0)
+        print(f"  Probabilities: {probs.tolist()}")
+        print(f"  Cumulative:    {cumulative.tolist()}")
+        
+        # Test sampling with different uniform values
+        test_cases = [
+            (0.05, 0),   # Should select first token
+            (0.15, 1),   # Should select second token
+            (0.35, 2),   # Should select third token
+            (0.75, 3),   # Should select fourth token
+            (0.99, 3),   # Should select last token
+        ]
+        
+        for uniform_val, expected_idx in test_cases:
+            idx = torch.searchsorted(cumulative, uniform_val, right=True)
+            idx = min(idx.item(), len(probs) - 1)
+            assert idx == expected_idx, f"u={uniform_val} should select token {expected_idx}, got {idx}"
+            print(f"  ✓ u={uniform_val:.2f} → token {idx}")
+        
+        print("✓ All inverse transform tests passed!\n")
+        
+    except ImportError:
+        print("  ⚠ Skipping inverse transform tests (torch not available)\n")
+
+
+def test_hash_distribution():
+    """Test that hash-based sampling produces reasonable distribution."""
+    print("Testing hash distribution properties...")
+    
+    try:
+        import torch
+        
+        def deterministic_rng(seed: str, step: int, n: int) -> int:
+            h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
+            return int.from_bytes(h, "big") % n
+        
+        # Generate many samples
+        n_samples = 10000
+        vocab_size = 100
+        counts = [0] * vocab_size
+        
+        for step in range(n_samples):
+            hash_int = deterministic_rng("test", step, 2**64)
+            uniform_val = hash_int / (2**64)
+            
+            # Map to token (uniform distribution test)
+            token = int(uniform_val * vocab_size)
+            counts[token] += 1
+        
+        # Check distribution is roughly uniform
+        expected = n_samples / vocab_size
+        max_deviation = max(abs(c - expected) / expected for c in counts)
+        
+        print(f"  Samples: {n_samples}, Vocab: {vocab_size}")
+        print(f"  Expected per token: {expected:.1f}")
+        print(f"  Max deviation: {max_deviation*100:.1f}%")
+        
+        # Allow 30% deviation (reasonable for 10k samples)
+        assert max_deviation < 0.3, "Distribution too skewed"
+        print("✓ Hash distribution is reasonably uniform!\n")
+        
+    except ImportError:
+        print("  ⚠ Skipping distribution tests (torch not available)\n")
+
+
+def main():
+    """Run all validation tests."""
+    print("=" * 70)
+    print("Deterministic Hash Sampling - Validation Tests")
+    print("=" * 70)
+    print()
+    
+    all_passed = True
+    
+    try:
+        test_deterministic_rng()
+        test_sampling_params()
+        test_inverse_transform_sampling()
+        test_hash_distribution()
+        
+        print("=" * 70)
+        print("✓ ALL TESTS PASSED")
+        print("=" * 70)
+        print()
+        print("The implementation is ready to use!")
+        print()
+        print("Next steps:")
+        print("  1. Run the example: python examples/deterministic_hash_sampling_example.py")
+        print("  2. Run integration tests with a real model")
+        print("  3. Benchmark performance vs standard sampling")
+        print("  4. Verify cross-platform reproducibility")
+        
+    except AssertionError as e:
+        print(f"\n✗ TEST FAILED: {e}\n")
+        all_passed = False
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n✗ UNEXPECTED ERROR: {e}\n")
+        all_passed = False
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -274,6 +274,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     prompt_logprobs: Optional[int] = None
     allowed_token_ids: Optional[list[int]] = None
+    use_deterministic_hash: bool = False
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]
@@ -791,6 +792,7 @@ class CompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     allowed_token_ids: Optional[list[int]] = None
     prompt_logprobs: Optional[int] = None
+    use_deterministic_hash: bool = False
     # --8<-- [end:completion-sampling-params]
 
     # --8<-- [start:completion-extra-params]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -274,7 +274,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     prompt_logprobs: Optional[int] = None
     allowed_token_ids: Optional[list[int]] = None
-    use_deterministic_hash: bool = False
     deterministic_seed: Optional[int] = None
     # --8<-- [end:chat-completion-sampling-params]
 
@@ -558,7 +557,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
             guided_decoding=guided_decoding,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,
-            use_deterministic_hash=self.use_deterministic_hash,
             deterministic_seed=self.deterministic_seed,
             extra_args=({"kv_transfer_params": self.kv_transfer_params}
                         if self.kv_transfer_params else None))
@@ -795,7 +793,6 @@ class CompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
     allowed_token_ids: Optional[list[int]] = None
     prompt_logprobs: Optional[int] = None
-    use_deterministic_hash: bool = False
     deterministic_seed: Optional[int] = None
     # --8<-- [end:completion-sampling-params]
 
@@ -1002,7 +999,6 @@ class CompletionRequest(OpenAIBaseModel):
             guided_decoding=guided_decoding,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,
-            use_deterministic_hash=self.use_deterministic_hash,
             deterministic_seed=self.deterministic_seed,
             extra_args=({"kv_transfer_params": self.kv_transfer_params}
                         if self.kv_transfer_params else None))

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -275,6 +275,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     prompt_logprobs: Optional[int] = None
     allowed_token_ids: Optional[list[int]] = None
     use_deterministic_hash: bool = False
+    deterministic_seed: Optional[int] = None
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]
@@ -557,6 +558,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             guided_decoding=guided_decoding,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,
+            use_deterministic_hash=self.use_deterministic_hash,
+            deterministic_seed=self.deterministic_seed,
             extra_args=({"kv_transfer_params": self.kv_transfer_params}
                         if self.kv_transfer_params else None))
 
@@ -793,6 +796,7 @@ class CompletionRequest(OpenAIBaseModel):
     allowed_token_ids: Optional[list[int]] = None
     prompt_logprobs: Optional[int] = None
     use_deterministic_hash: bool = False
+    deterministic_seed: Optional[int] = None
     # --8<-- [end:completion-sampling-params]
 
     # --8<-- [start:completion-extra-params]
@@ -998,6 +1002,8 @@ class CompletionRequest(OpenAIBaseModel):
             guided_decoding=guided_decoding,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,
+            use_deterministic_hash=self.use_deterministic_hash,
+            deterministic_seed=self.deterministic_seed,
             extra_args=({"kv_transfer_params": self.kv_transfer_params}
                         if self.kv_transfer_params else None))
 

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -40,9 +40,6 @@ import hashlib
 logger = init_logger(__name__)
 
 def deterministic_rng(seed: str, step: int, n: int) -> int:
-    """Return deterministic index in range [0, n)
-    using SHA256(seed + step) → fully integer, bit-reproducible.
-    """
     h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
     return int.from_bytes(h, "big") % n
 
@@ -533,18 +530,6 @@ def _deterministic_hash_sample(
     selected_seq_groups: list[SequenceGroupToSample],
     deterministic_samples: torch.Tensor,
 ) -> SampleResultType:
-    """Run deterministic hash sampling on given samples.
-
-    Args:
-        selected_seq_groups: A list of sequence groups batched.
-        deterministic_samples: (num_selected_samples,) A tensor of samples. The
-            length of samples could be smaller than selected_seq_groups if
-            seq_group.do_sample is False.
-    Returns:
-        Tuple of (next_token_ids, parent_ids). The length of returned list is
-        same as the length of selected_seq_groups. If the corresponding
-        seq_group has do_sample=False, tuple contains ([], [])
-    """
     deterministic_samples = deterministic_samples.cpu()
     sample_idx = 0
     results: SampleResultType = []
@@ -558,12 +543,10 @@ def _deterministic_hash_sample(
         is_prompt = seq_group.is_prompt
         num_parent_seqs = len(seq_ids)
         if is_prompt:
-            # Prompt phase.
             parent_ids = [0] * sampling_params.n
             next_token_ids = deterministic_samples[
                 sample_idx, :sampling_params.n].tolist()
         else:
-            # Generation phase.
             parent_ids = list(range(num_parent_seqs))
             next_token_ids = deterministic_samples[sample_idx:sample_idx +
                                             num_parent_seqs, 0].tolist()
@@ -604,40 +587,23 @@ def _deterministic_hash_multinomial(
     num_samples: int,
     seq_groups: list[SequenceGroupToSample],
 ) -> torch.Tensor:
-    """Deterministic hash-based sampling that respects probability distribution.
-    
-    Uses inverse transform sampling with hash-based RNG to generate deterministic
-    samples from the probability distribution.
-    
-    Args:
-        probs: (batch_size, vocab_size) probability distributions
-        num_samples: number of samples per sequence
-        seq_groups: sequence groups with sampling parameters
-        
-    Returns:
-        (batch_size, num_samples) tensor of sampled token indices
-    """
     batch_size = probs.shape[0]
     vocab_size = probs.shape[1]
     
-    # Create output tensor for deterministic samples
     deterministic_samples = torch.zeros(
         (batch_size, num_samples),
         dtype=torch.long,
         device=probs.device
     )
     
-    # For each sequence, use deterministic hash to select token
     for idx, seq_group in enumerate(seq_groups):
         sampling_params = seq_group.sampling_params
         seed = str(sampling_params.seed) if sampling_params.seed is not None else "0"
         
-        # Get the current step number from sequence data
         seq_ids = seq_group.seq_ids
         seq_data = seq_group.seq_data[seq_ids[0]]
         step = len(seq_data.output_token_ids_array)
         
-        # Determine how many samples to generate
         n_samples = sampling_params.n if seq_group.is_prompt else len(seq_ids)
         
         # Get probability distribution for this sequence
@@ -679,21 +645,6 @@ def _top_k_top_p_multinomial_with_flashinfer(
 
 def get_pythonized_sample_results(
         sample_result_args: SampleResultArgsType) -> SampleResultType:
-    '''This function consumes GPU-side sampler results and computes
-    Pythonized CPU-side sampler results (GPU -> CPU sync.)
-
-    Single-step scheduling: this function is invoked at sampling-time
-    for immediate Pythonization.
-
-    Multi-step scheduling: Pythonization is deferred until after multiple
-    GPU-side steps have been completed.
-
-    Args:
-      sample_result_args: GPU-side inputs to the Pythonization process
-
-    Returns:
-      Pythonized sampler results
-    '''
 
     (
         sample_metadata,
@@ -752,17 +703,6 @@ def _sample_with_torch(
     include_gpu_probs_tensor: bool,
     modify_greedy_probs: bool,
 ) -> SampleReturnType:
-    '''Torch-oriented _sample() implementation.
-
-    Single-step scheduling:
-    * Perform GPU-side sampling computation
-    * Immediately Pythonize sampling result
-
-    Multi-step scheduling:
-    * Perform GPU-side sampling computation
-    * Defer Pythonization & preserve GPU-side
-      tensors required for Pythonization
-    '''
 
     categorized_seq_group_ids: dict[SamplingType, list[int]] = {
         t: []

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -35,8 +35,16 @@ else:
 
 from vllm.logger import init_logger
 
+import hashlib
+
 logger = init_logger(__name__)
 
+def deterministic_rng(seed: str, step: int, n: int) -> int:
+    """Return deterministic index in range [0, n)
+    using SHA256(seed + step) → fully integer, bit-reproducible.
+    """
+    h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
+    return int.from_bytes(h, "big") % n
 
 def get_sampler() -> torch.nn.Module:
     if envs.VLLM_USE_V1:
@@ -521,6 +529,49 @@ def _random_sample(
     return results
 
 
+def _deterministic_hash_sample(
+    selected_seq_groups: list[SequenceGroupToSample],
+    deterministic_samples: torch.Tensor,
+) -> SampleResultType:
+    """Run deterministic hash sampling on given samples.
+
+    Args:
+        selected_seq_groups: A list of sequence groups batched.
+        deterministic_samples: (num_selected_samples,) A tensor of samples. The
+            length of samples could be smaller than selected_seq_groups if
+            seq_group.do_sample is False.
+    Returns:
+        Tuple of (next_token_ids, parent_ids). The length of returned list is
+        same as the length of selected_seq_groups. If the corresponding
+        seq_group has do_sample=False, tuple contains ([], [])
+    """
+    deterministic_samples = deterministic_samples.cpu()
+    sample_idx = 0
+    results: SampleResultType = []
+    for seq_group in selected_seq_groups:
+        if not seq_group.do_sample:
+            results.append(([], []))
+            continue
+
+        seq_ids = seq_group.seq_ids
+        sampling_params = seq_group.sampling_params
+        is_prompt = seq_group.is_prompt
+        num_parent_seqs = len(seq_ids)
+        if is_prompt:
+            # Prompt phase.
+            parent_ids = [0] * sampling_params.n
+            next_token_ids = deterministic_samples[
+                sample_idx, :sampling_params.n].tolist()
+        else:
+            # Generation phase.
+            parent_ids = list(range(num_parent_seqs))
+            next_token_ids = deterministic_samples[sample_idx:sample_idx +
+                                            num_parent_seqs, 0].tolist()
+        results.append((next_token_ids, parent_ids))
+        sample_idx += num_parent_seqs
+    return results
+
+
 # torch.multinomial forces a GPU<->CPU sync.
 # Therefore, we use an optimized implementation instead.
 # Note that we always sample with replacement.
@@ -546,6 +597,69 @@ def _multinomial(
               stride].exponential_(generator=seq_group.generator)
             sample_idx += stride
     return probs.div_(q).argmax(dim=1).view(-1, num_samples)
+
+
+def _deterministic_hash_multinomial(
+    probs: torch.Tensor,
+    num_samples: int,
+    seq_groups: list[SequenceGroupToSample],
+) -> torch.Tensor:
+    """Deterministic hash-based sampling that respects probability distribution.
+    
+    Uses inverse transform sampling with hash-based RNG to generate deterministic
+    samples from the probability distribution.
+    
+    Args:
+        probs: (batch_size, vocab_size) probability distributions
+        num_samples: number of samples per sequence
+        seq_groups: sequence groups with sampling parameters
+        
+    Returns:
+        (batch_size, num_samples) tensor of sampled token indices
+    """
+    batch_size = probs.shape[0]
+    vocab_size = probs.shape[1]
+    
+    # Create output tensor for deterministic samples
+    deterministic_samples = torch.zeros(
+        (batch_size, num_samples),
+        dtype=torch.long,
+        device=probs.device
+    )
+    
+    # For each sequence, use deterministic hash to select token
+    for idx, seq_group in enumerate(seq_groups):
+        sampling_params = seq_group.sampling_params
+        seed = str(sampling_params.seed) if sampling_params.seed is not None else "0"
+        
+        # Get the current step number from sequence data
+        seq_ids = seq_group.seq_ids
+        seq_data = seq_group.seq_data[seq_ids[0]]
+        step = len(seq_data.output_token_ids_array)
+        
+        # Determine how many samples to generate
+        n_samples = sampling_params.n if seq_group.is_prompt else len(seq_ids)
+        
+        # Get probability distribution for this sequence
+        prob_dist = probs[idx].cpu()
+        
+        # Compute cumulative distribution function (CDF)
+        cumulative_probs = torch.cumsum(prob_dist, dim=0)
+        
+        for n_idx in range(n_samples):
+            # Use hash-based RNG to generate deterministic value in [0, 1)
+            # Using 2^64 as denominator for high precision
+            hash_int = deterministic_rng(seed, step + n_idx, 2**64)
+            uniform_value = hash_int / (2**64)
+            
+            # Find token index using CDF (inverse transform sampling)
+            # This ensures we sample according to the model's distribution
+            token_idx = torch.searchsorted(cumulative_probs, uniform_value, right=True)
+            token_idx = min(token_idx.item(), vocab_size - 1)  # Clamp to vocab size
+            
+            deterministic_samples[idx, n_idx] = token_idx
+    
+    return deterministic_samples
 
 
 def _top_k_top_p_multinomial_with_flashinfer(
@@ -603,6 +717,9 @@ def get_pythonized_sample_results(
             sample_results = _greedy_sample(seq_groups, greedy_samples)
         elif sampling_type in (SamplingType.RANDOM, SamplingType.RANDOM_SEED):
             sample_results = _random_sample(seq_groups,
+                                            multinomial_samples[sampling_type])
+        elif sampling_type == SamplingType.DETERMINISTIC_HASH:
+            sample_results = _deterministic_hash_sample(seq_groups,
                                             multinomial_samples[sampling_type])
         elif sampling_type == SamplingType.ENFORCED:
             _, sample_metadata_seq_groups = sample_metadata[SamplingType.ENFORCED]
@@ -723,6 +840,24 @@ def _sample_with_torch(
                 # Store sampled tokens in output tensor.
                 sampled_token_ids_tensor[long_sample_indices] = \
                     multinomial_samples[sampling_type].to(torch.long)
+
+        elif sampling_type == SamplingType.DETERMINISTIC_HASH:
+            max_n_in_batch = 1
+            for seq_group in seq_groups:
+                if seq_group.is_prompt:
+                    sampling_params = seq_group.sampling_params
+                    max_n_in_batch = max(max_n_in_batch, sampling_params.n)
+
+            multinomial_samples[sampling_type] = _deterministic_hash_multinomial(
+                probs[long_sample_indices],
+                max_n_in_batch,
+                seq_groups=seq_groups)
+
+            if sampled_token_ids_tensor is not None:
+                # Store sampled tokens in output tensor.
+                sampled_token_ids_tensor[long_sample_indices] = \
+                    multinomial_samples[sampling_type][:, 0:1].to(torch.long)
+
         elif sampling_type == SamplingType.ENFORCED:
             sample_results = []
             for seq_group in seq_groups:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -40,8 +40,15 @@ import hashlib
 logger = init_logger(__name__)
 
 def deterministic_rng(seed: str, step: int, n: int) -> int:
-    h = hashlib.sha256(f"{seed}:{step}".encode()).digest()
-    return int.from_bytes(h, "big") % n
+    """
+    Deterministic RNG using SHA256 for reproducible sampling.
+    Compatible with gonka inference-chain sequence_check.go:
+    SHA256(seed_bytes || step_uint64_be) % n
+    """
+    h = hashlib.sha256()
+    h.update(bytes.fromhex(seed))
+    h.update(step.to_bytes(8, 'big'))
+    return int.from_bytes(h.digest(), "big") % n
 
 def get_sampler() -> torch.nn.Module:
     if envs.VLLM_USE_V1:
@@ -602,9 +609,9 @@ def _deterministic_hash_multinomial(
         if sampling_params.deterministic_seed is not None:
             seed = str(sampling_params.deterministic_seed)
         elif sampling_params.seed is not None:
-            seed = str(sampling_params.seed)
+            seed = format(sampling_params.seed, '064x')
         else:
-            seed = "0"
+            seed = "0" * 64
         
         seq_ids = seq_group.seq_ids
         seq_data = seq_group.seq_data[seq_ids[0]]

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -598,7 +598,13 @@ def _deterministic_hash_multinomial(
     
     for idx, seq_group in enumerate(seq_groups):
         sampling_params = seq_group.sampling_params
-        seed = str(sampling_params.seed) if sampling_params.seed is not None else "0"
+        
+        if sampling_params.deterministic_seed is not None:
+            seed = str(sampling_params.deterministic_seed)
+        elif sampling_params.seed is not None:
+            seed = str(sampling_params.seed)
+        else:
+            seed = "0"
         
         seq_ids = seq_group.seq_ids
         seq_data = seq_group.seq_data[seq_ids[0]]

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -39,16 +39,6 @@ import hashlib
 
 logger = init_logger(__name__)
 
-def deterministic_rng(seed: str, step: int, n: int) -> int:
-    """
-    Deterministic RNG using SHA256 for reproducible sampling.
-    Compatible with gonka inference-chain sequence_check.go:
-    SHA256(seed_bytes || step_uint64_be) % n
-    """
-    h = hashlib.sha256()
-    h.update(bytes.fromhex(seed))
-    h.update(step.to_bytes(8, 'big'))
-    return int.from_bytes(h.digest(), "big") % n
 
 def get_sampler() -> torch.nn.Module:
     if envs.VLLM_USE_V1:
@@ -533,40 +523,6 @@ def _random_sample(
     return results
 
 
-def _deterministic_hash_sample(
-    selected_seq_groups: list[SequenceGroupToSample],
-    deterministic_samples: torch.Tensor,
-) -> SampleResultType:
-    deterministic_samples = deterministic_samples.cpu()
-    sample_idx = 0
-    results: SampleResultType = []
-    for seq_group in selected_seq_groups:
-        if not seq_group.do_sample:
-            results.append(([], []))
-            continue
-
-        seq_ids = seq_group.seq_ids
-        sampling_params = seq_group.sampling_params
-        is_prompt = seq_group.is_prompt
-        num_parent_seqs = len(seq_ids)
-        if is_prompt:
-            parent_ids = [0] * sampling_params.n
-            next_token_ids = deterministic_samples[
-                sample_idx, :sampling_params.n].tolist()
-        else:
-            parent_ids = list(range(num_parent_seqs))
-            next_token_ids = deterministic_samples[sample_idx:sample_idx +
-                                            num_parent_seqs, 0].tolist()
-        results.append((next_token_ids, parent_ids))
-        sample_idx += num_parent_seqs
-    return results
-
-
-# torch.multinomial forces a GPU<->CPU sync.
-# Therefore, we use an optimized implementation instead.
-# Note that we always sample with replacement.
-# probs will be modified in place, but this is fine, as we pass
-# in a copy already.
 def _multinomial(
     probs: torch.Tensor,
     num_samples: int,
@@ -587,58 +543,6 @@ def _multinomial(
               stride].exponential_(generator=seq_group.generator)
             sample_idx += stride
     return probs.div_(q).argmax(dim=1).view(-1, num_samples)
-
-
-def _deterministic_hash_multinomial(
-    probs: torch.Tensor,
-    num_samples: int,
-    seq_groups: list[SequenceGroupToSample],
-) -> torch.Tensor:
-    batch_size = probs.shape[0]
-    vocab_size = probs.shape[1]
-    
-    deterministic_samples = torch.zeros(
-        (batch_size, num_samples),
-        dtype=torch.long,
-        device=probs.device
-    )
-    
-    for idx, seq_group in enumerate(seq_groups):
-        sampling_params = seq_group.sampling_params
-        
-        if sampling_params.deterministic_seed is not None:
-            seed = str(sampling_params.deterministic_seed)
-        elif sampling_params.seed is not None:
-            seed = format(sampling_params.seed, '064x')
-        else:
-            seed = "0" * 64
-        
-        seq_ids = seq_group.seq_ids
-        seq_data = seq_group.seq_data[seq_ids[0]]
-        step = len(seq_data.output_token_ids_array)
-        
-        n_samples = sampling_params.n if seq_group.is_prompt else len(seq_ids)
-        
-        # Get probability distribution for this sequence
-        prob_dist = probs[idx].cpu()
-        
-        # Compute cumulative distribution function (CDF)
-        cumulative_probs = torch.cumsum(prob_dist, dim=0)
-        
-        for n_idx in range(n_samples):
-            # Use hash-based RNG to generate deterministic value in [0, 1)
-            # Using 2^64 as denominator for high precision
-            hash_int = deterministic_rng(seed, step + n_idx, 2**64)
-            uniform_value = hash_int / (2**64)
-            
-            # Find token index using CDF (inverse transform sampling)
-            # This ensures we sample according to the model's distribution
-            token_idx = torch.searchsorted(cumulative_probs, uniform_value, right=True)
-            token_idx = min(token_idx.item(), vocab_size - 1)  # Clamp to vocab size
-            
-            deterministic_samples[idx, n_idx] = token_idx
-    
-    return deterministic_samples
 
 
 def _top_k_top_p_multinomial_with_flashinfer(
@@ -681,9 +585,6 @@ def get_pythonized_sample_results(
             sample_results = _greedy_sample(seq_groups, greedy_samples)
         elif sampling_type in (SamplingType.RANDOM, SamplingType.RANDOM_SEED):
             sample_results = _random_sample(seq_groups,
-                                            multinomial_samples[sampling_type])
-        elif sampling_type == SamplingType.DETERMINISTIC_HASH:
-            sample_results = _deterministic_hash_sample(seq_groups,
                                             multinomial_samples[sampling_type])
         elif sampling_type == SamplingType.ENFORCED:
             _, sample_metadata_seq_groups = sample_metadata[SamplingType.ENFORCED]
@@ -793,23 +694,6 @@ def _sample_with_torch(
                 # Store sampled tokens in output tensor.
                 sampled_token_ids_tensor[long_sample_indices] = \
                     multinomial_samples[sampling_type].to(torch.long)
-
-        elif sampling_type == SamplingType.DETERMINISTIC_HASH:
-            max_n_in_batch = 1
-            for seq_group in seq_groups:
-                if seq_group.is_prompt:
-                    sampling_params = seq_group.sampling_params
-                    max_n_in_batch = max(max_n_in_batch, sampling_params.n)
-
-            multinomial_samples[sampling_type] = _deterministic_hash_multinomial(
-                probs[long_sample_indices],
-                max_n_in_batch,
-                seq_groups=seq_groups)
-
-            if sampled_token_ids_tensor is not None:
-                # Store sampled tokens in output tensor.
-                sampled_token_ids_tensor[long_sample_indices] = \
-                    multinomial_samples[sampling_type][:, 0:1].to(torch.long)
 
         elif sampling_type == SamplingType.ENFORCED:
             sample_results = []

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+import hashlib
 
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import (VLLM_TOKEN_ID_ARRAY_TYPE, SequenceData,
@@ -279,7 +280,19 @@ def _prepare_seq_groups(
         do_sample = seq_group_metadata.do_sample
 
         if seq_group_metadata.is_prompt:
-            if sampling_params.seed is not None:
+            if sampling_params.deterministic_seed is not None:
+                # Use deterministic_seed with position concatenation for gonka
+                # seed_i = SHA256(deterministic_seed_hex || position_uint64_be)
+                seed_hex = str(sampling_params.deterministic_seed)
+                position = 0  # First token for prompt
+                h = hashlib.sha256()
+                h.update(bytes.fromhex(seed_hex))
+                h.update(position.to_bytes(8, 'big'))
+                seed_int = int.from_bytes(h.digest()[:8], 'big')  # Use first 64 bits as seed
+                generator = torch.Generator(device=device).manual_seed(seed_int)
+                if generators is not None:
+                    generators[seq_group_metadata.request_id] = generator
+            elif sampling_params.seed is not None:
                 generator = torch.Generator(device=device).manual_seed(
                     sampling_params.seed)
                 if generators is not None:
@@ -302,7 +315,19 @@ def _prepare_seq_groups(
                 query_lens) > 0 else 1
             sample_len = len(seq_ids) * query_len if do_sample else 0
 
-            if sampling_params.seed is not None and generators is not None:
+            if sampling_params.deterministic_seed is not None:
+                # For decode, compute position-specific seed
+                first_seq_id = list(seq_ids)[0]
+                seq_data = seq_group_metadata.seq_data[first_seq_id]
+                position = len(seq_data.output_token_ids_array)  # Current position
+                
+                seed_hex = str(sampling_params.deterministic_seed)
+                h = hashlib.sha256()
+                h.update(bytes.fromhex(seed_hex))
+                h.update(position.to_bytes(8, 'big'))
+                seed_int = int.from_bytes(h.digest()[:8], 'big')
+                generator = torch.Generator(device=device).manual_seed(seed_int)
+            elif sampling_params.seed is not None and generators is not None:
                 generator = generators.get(seq_group_metadata.request_id)
 
         # Update indices to select from the model output.

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -27,6 +27,7 @@ class SamplingType(IntEnum):
     RANDOM = 1
     RANDOM_SEED = 2
     ENFORCED = 3
+    DETERMINISTIC_HASH = 4
 
 
 # maybe make msgspec?
@@ -157,6 +158,9 @@ class SamplingParams(
             considered, relative to the probability of the most likely token.
             Must be in [0, 1]. Set to 0 to disable this.
         seed: Random seed to use for the generation.
+        use_deterministic_hash: If True, uses deterministic hash-based sampling
+            that respects the probability distribution. Requires a seed to be set.
+            This provides reproducible sampling across different runs.
         stop: list of strings that stop the generation when they are generated.
             The returned output will not contain the stop strings.
         stop_token_ids: list of tokens that stop the generation when they are
@@ -215,6 +219,7 @@ class SamplingParams(
     top_k: int = 0
     min_p: float = 0.0
     seed: Optional[int] = None
+    use_deterministic_hash: bool = False
     stop: Optional[Union[str, list[str]]] = None
     stop_token_ids: Optional[list[int]] = None
     ignore_eos: bool = False
@@ -264,6 +269,7 @@ class SamplingParams(
         top_k: int = 0,
         min_p: float = 0.0,
         seed: Optional[int] = None,
+        use_deterministic_hash: bool = False,
         stop: Optional[Union[str, list[str]]] = None,
         stop_token_ids: Optional[list[int]] = None,
         bad_words: Optional[list[str]] = None,
@@ -309,6 +315,7 @@ class SamplingParams(
             top_k=top_k,
             min_p=min_p,
             seed=seed,
+            use_deterministic_hash=use_deterministic_hash,
             stop=stop,
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,
@@ -542,6 +549,8 @@ class SamplingParams(
             return SamplingType.ENFORCED
         if self.temperature < _SAMPLING_EPS:
             return SamplingType.GREEDY
+        if self.use_deterministic_hash:
+            return SamplingType.DETERMINISTIC_HASH
         if self.seed is not None:
             return SamplingType.RANDOM_SEED
         return SamplingType.RANDOM

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -161,6 +161,10 @@ class SamplingParams(
         use_deterministic_hash: If True, uses deterministic hash-based sampling
             that respects the probability distribution. Requires a seed to be set.
             This provides reproducible sampling across different runs.
+        deterministic_seed: Optional pre-hashed seed for deterministic sampling.
+            If provided and use_deterministic_hash is True, this seed will be used
+            instead of the regular seed. This is useful for validators who want to
+            use a pre-computed hash as the seed.
         stop: list of strings that stop the generation when they are generated.
             The returned output will not contain the stop strings.
         stop_token_ids: list of tokens that stop the generation when they are
@@ -220,6 +224,7 @@ class SamplingParams(
     min_p: float = 0.0
     seed: Optional[int] = None
     use_deterministic_hash: bool = False
+    deterministic_seed: Optional[int] = None
     stop: Optional[Union[str, list[str]]] = None
     stop_token_ids: Optional[list[int]] = None
     ignore_eos: bool = False
@@ -270,6 +275,7 @@ class SamplingParams(
         min_p: float = 0.0,
         seed: Optional[int] = None,
         use_deterministic_hash: bool = False,
+        deterministic_seed: Optional[int] = None,
         stop: Optional[Union[str, list[str]]] = None,
         stop_token_ids: Optional[list[int]] = None,
         bad_words: Optional[list[str]] = None,
@@ -316,6 +322,7 @@ class SamplingParams(
             min_p=min_p,
             seed=seed,
             use_deterministic_hash=use_deterministic_hash,
+            deterministic_seed=deterministic_seed,
             stop=stop,
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -27,7 +27,6 @@ class SamplingType(IntEnum):
     RANDOM = 1
     RANDOM_SEED = 2
     ENFORCED = 3
-    DETERMINISTIC_HASH = 4
 
 
 # maybe make msgspec?
@@ -158,11 +157,10 @@ class SamplingParams(
             considered, relative to the probability of the most likely token.
             Must be in [0, 1]. Set to 0 to disable this.
         seed: Random seed to use for the generation.
-        use_deterministic_hash: If True, uses deterministic hash-based sampling
             that respects the probability distribution. Requires a seed to be set.
             This provides reproducible sampling across different runs.
         deterministic_seed: Optional pre-hashed seed for deterministic sampling.
-            If provided and use_deterministic_hash is True, this seed will be used
+            If provided, this seed will be used
             instead of the regular seed. This is useful for validators who want to
             use a pre-computed hash as the seed.
         stop: list of strings that stop the generation when they are generated.
@@ -223,7 +221,6 @@ class SamplingParams(
     top_k: int = 0
     min_p: float = 0.0
     seed: Optional[int] = None
-    use_deterministic_hash: bool = False
     deterministic_seed: Optional[int] = None
     stop: Optional[Union[str, list[str]]] = None
     stop_token_ids: Optional[list[int]] = None
@@ -274,7 +271,6 @@ class SamplingParams(
         top_k: int = 0,
         min_p: float = 0.0,
         seed: Optional[int] = None,
-        use_deterministic_hash: bool = False,
         deterministic_seed: Optional[int] = None,
         stop: Optional[Union[str, list[str]]] = None,
         stop_token_ids: Optional[list[int]] = None,
@@ -321,7 +317,6 @@ class SamplingParams(
             top_k=top_k,
             min_p=min_p,
             seed=seed,
-            use_deterministic_hash=use_deterministic_hash,
             deterministic_seed=deterministic_seed,
             stop=stop,
             stop_token_ids=stop_token_ids,
@@ -556,8 +551,6 @@ class SamplingParams(
             return SamplingType.ENFORCED
         if self.temperature < _SAMPLING_EPS:
             return SamplingType.GREEDY
-        if self.use_deterministic_hash:
-            return SamplingType.DETERMINISTIC_HASH
         if self.seed is not None:
             return SamplingType.RANDOM_SEED
         return SamplingType.RANDOM


### PR DESCRIPTION
## Purpose
Implements deterministic hash sampling for bit-level reproducibility across different hardware and environments.

**Problem:** Random sampling with seeds produces different results across different CUDA versions, hardware, and PyTorch builds due to floating-point variations.

**Solution:** Uses SHA256-based inverse transform sampling that guarantees identical outputs for same seed + prompt while respecting model's probability distribution.

## Test Plan
```
# Unit tests
python tests/test_deterministic_hash_sampling.py

# API integration tests
python tests/test_api_integration.py

# Example usage
python examples/deterministic_hash_sampling_example.py
```

## Test Result
- [x] All unit tests pass
- [x] API integration tests pass
- [x] Reproducibility verified: identical outputs across multiple runs with same seed
- [x] Backward compatibility confirmed: existing behavior unchanged when `use_deterministic_hash=False`