### PR TITLE
feat: Implement PoC state management and priority handling across components

### DIFF
--- a/tests/poc/test_coexist.py
+++ b/tests/poc/test_coexist.py
@@ -1,16 +1,11 @@
 """Tests for PoC+Chat coexistence and priority modes."""
-import os
-import pytest
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
-from vllm.poc.routes import (
-    router, _generation_loop,
-    POC_CHAT_BUSY_BACKOFF_SEC,
-)
-from vllm.poc.config import PoCState
+import pytest
+
+from vllm.poc.routes import _generation_loop
+from vllm.poc.state import is_poc_active, set_poc_active
 
 
 @pytest.fixture
@@ -24,210 +19,246 @@ def mock_engine_client():
     return client
 
 
+@pytest.fixture(autouse=True)
+def _reset_poc_state():
+    """Ensure PoC state is clean before/after every test."""
+    set_poc_active(False)
+    yield
+    set_poc_active(False)
+
+
 class TestPoCPriorityMode:
-    """Tests for default PoC priority mode (PoC has priority, aborts chat)."""
-    
+    """PoC always aborts active chat requests before running GPU work."""
+
     def test_generate_artifacts_aborts_chat_requests(self):
-        """Test that PoC aborts active chat requests by default."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "0"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            from vllm.poc.data import Artifact
-            
-            mock_llm_engine = MagicMock()
-            mock_scheduler = MagicMock()
-            mock_seq_group = MagicMock()
-            mock_seq_group.request_id = "req-123"
-            mock_scheduler.waiting = [mock_seq_group]
-            mock_scheduler.running = []
-            mock_scheduler.swapped = []
-            mock_llm_engine.scheduler = [mock_scheduler]
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = False
-            mq_engine._abort_all_chat_requests = MQLLMEngine._abort_all_chat_requests.__get__(mq_engine, MQLLMEngine)
-            
-            mock_manager = MagicMock()
-            mock_manager.generate_artifacts.return_value = [
-                Artifact(nonce=0, vector_b64="AAA="),
-            ]
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
+        """PoC must abort every chat request in the scheduler."""
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+        from vllm.poc.data import Artifact
+
+        mock_llm_engine = MagicMock()
+        mock_llm_engine.has_unfinished_requests.return_value = False
+        mock_scheduler = MagicMock()
+        mock_seq_group = MagicMock()
+        mock_seq_group.request_id = "req-123"
+        mock_scheduler.waiting = [mock_seq_group]
+        mock_scheduler.running = []
+        mock_scheduler.swapped = []
+        mock_llm_engine.scheduler = [mock_scheduler]
+
+        mq_engine = MagicMock()
+        mq_engine.engine = mock_llm_engine
+        mq_engine._engine_step_in_progress = False
+        mq_engine.input_socket.poll.return_value = 0
+        mq_engine._abort_all_chat_requests = (
+            MQLLMEngine._abort_all_chat_requests.__get__(
+                mq_engine, MQLLMEngine))
+
+        mock_manager = MagicMock()
+        mock_manager.generate_artifacts.return_value = [
+            Artifact(nonce=0, vector_b64="AAA="),
+        ]
+        mq_engine._poc_manager = mock_manager
+        mq_engine._get_poc_manager = lambda: mock_manager
+
+        result = MQLLMEngine._process_poc_action(
+            mq_engine, "generate_artifacts", {
                 "nonces": [0],
                 "block_hash": "hash",
                 "public_key": "key",
                 "seq_len": 256,
                 "k_dim": 12,
             })
-            
-            mock_llm_engine.abort_request.assert_called_with("req-123")
-            mock_manager.generate_artifacts.assert_called_once()
-            assert "skipped" not in result or result.get("skipped") is not True
-    
+
+        mock_llm_engine.abort_request.assert_called_with("req-123")
+        mock_manager.generate_artifacts.assert_called_once()
+        assert "skipped" not in result or result.get("skipped") is not True
+
     def test_generate_artifacts_skips_when_engine_step_in_progress(self):
-        """Test PoC skips when engine.step() is running (safety check preserved)."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "0"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            
-            mock_llm_engine = MagicMock()
-            mock_llm_engine.scheduler = []
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = True
-            mq_engine._abort_all_chat_requests = MQLLMEngine._abort_all_chat_requests.__get__(mq_engine, MQLLMEngine)
-            
-            mock_manager = MagicMock()
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
-                "nonces": [0, 1, 2],
+        """Safety: PoC must not run on GPU while engine.step() is active."""
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+
+        mock_llm_engine = MagicMock()
+        mock_llm_engine.has_unfinished_requests.return_value = False
+        mock_llm_engine.scheduler = []
+
+        mq_engine = MagicMock()
+        mq_engine.engine = mock_llm_engine
+        mq_engine._engine_step_in_progress = True
+        mq_engine.input_socket.poll.return_value = 0
+        mq_engine._abort_all_chat_requests = (
+            MQLLMEngine._abort_all_chat_requests.__get__(
+                mq_engine, MQLLMEngine))
+
+        mock_manager = MagicMock()
+        mq_engine._poc_manager = mock_manager
+        mq_engine._get_poc_manager = lambda: mock_manager
+
+        result = MQLLMEngine._process_poc_action(
+            mq_engine, "generate_artifacts", {"nonces": [0, 1, 2]})
+
+        assert result["skipped"] is True
+        assert result["reason"] == "engine_step_in_progress"
+        mock_manager.generate_artifacts.assert_not_called()
+
+    def test_generate_artifacts_sets_poc_active(self):
+        """_process_poc_action must set the PoC-active flag."""
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+        from vllm.poc.data import Artifact
+
+        mock_llm_engine = MagicMock()
+        mock_llm_engine.has_unfinished_requests.return_value = False
+        mock_llm_engine.scheduler = []
+        mq_engine = MagicMock()
+        mq_engine.engine = mock_llm_engine
+        mq_engine._engine_step_in_progress = False
+        mq_engine.input_socket.poll.return_value = 0
+        mq_engine._abort_all_chat_requests = (
+            MQLLMEngine._abort_all_chat_requests.__get__(
+                mq_engine, MQLLMEngine))
+
+        mock_manager = MagicMock()
+        mock_manager.generate_artifacts.return_value = [
+            Artifact(nonce=0, vector_b64="AAA=")]
+        mq_engine._poc_manager = mock_manager
+        mq_engine._get_poc_manager = lambda: mock_manager
+
+        assert not is_poc_active()
+        MQLLMEngine._process_poc_action(
+            mq_engine, "generate_artifacts", {
+                "nonces": [0], "block_hash": "h", "public_key": "k",
+                "seq_len": 256, "k_dim": 12,
             })
-            
-            assert result["skipped"] is True
-            assert result["reason"] == "engine_step_in_progress"
-            mock_manager.generate_artifacts.assert_not_called()
+        assert is_poc_active()
 
 
-class TestLegacyChatPriorityMode:
-    """Tests for legacy chat-priority mode (POC_ENABLE_CHAT_PRIORITY=1)."""
-    
+class TestEndSession:
+    """The ``end_session`` action clears the PoC flag in the engine process."""
+
+    def test_end_session_clears_flag(self):
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+
+        mq_engine = MagicMock()
+        set_poc_active(True)
+        assert is_poc_active()
+
+        result = MQLLMEngine._process_poc_action(
+            mq_engine, "end_session", {})
+
+        assert result.get("ok") is True
+        assert not is_poc_active()
+
+
+class TestPoCConditions:
+    """PoC must return skip reasons for all guard conditions."""
+
     def test_generate_artifacts_skips_when_pending_input(self):
-        """Test generate_artifacts returns skip when there's pending input (chat waiting)."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "1"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            
-            mock_llm_engine = MagicMock()
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = False
-            mq_engine.input_socket.poll.return_value = 1  # Pending input
-            
-            mock_manager = MagicMock()
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
-                "nonces": [0, 1, 2],
-            })
-            
-            assert result["skipped"] is True
-            assert result["reason"] == "pending_input"
-            mock_manager.generate_artifacts.assert_not_called()
-    
-    def test_generate_artifacts_skips_when_engine_step_in_progress(self):
-        """Test generate_artifacts returns skip when _engine_step_in_progress is True."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "1"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            
-            mock_llm_engine = MagicMock()
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = True
-            mq_engine.input_socket.poll.return_value = 0  # No pending input
-            
-            mock_manager = MagicMock()
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
-                "nonces": [0, 1, 2],
-            })
-            
-            assert result["skipped"] is True
-            assert result["reason"] == "engine_step_in_progress"
-            mock_manager.generate_artifacts.assert_not_called()
-    
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+
+        mock_llm_engine = MagicMock()
+        mock_llm_engine.scheduler = []
+
+        mq_engine = MagicMock()
+        mq_engine.engine = mock_llm_engine
+        mq_engine._engine_step_in_progress = False
+        mq_engine.input_socket.poll.return_value = 1
+        mq_engine._abort_all_chat_requests = (
+            MQLLMEngine._abort_all_chat_requests.__get__(
+                mq_engine, MQLLMEngine))
+
+        mock_manager = MagicMock()
+        mq_engine._poc_manager = mock_manager
+        mq_engine._get_poc_manager = lambda: mock_manager
+
+        result = MQLLMEngine._process_poc_action(
+            mq_engine, "generate_artifacts", {"nonces": [0, 1, 2]})
+
+        assert result["skipped"] is True
+        assert result["reason"] == "pending_input"
+        mock_manager.generate_artifacts.assert_not_called()
+
     def test_generate_artifacts_skips_when_chat_unfinished(self):
-        """Test generate_artifacts returns skip when chat has unfinished requests."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "1"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            
-            mock_llm_engine = MagicMock()
-            mock_llm_engine.has_unfinished_requests.return_value = True
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = False
-            mq_engine.input_socket.poll.return_value = 0  # No pending input
-            
-            mock_manager = MagicMock()
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
-                "nonces": [0, 1, 2],
-            })
-            
-            assert result["skipped"] is True
-            assert result["reason"] == "chat_unfinished"
-            mock_manager.generate_artifacts.assert_not_called()
-    
-    def test_generate_artifacts_proceeds_when_all_checks_pass(self):
-        """Test generate_artifacts proceeds when no pending input, not in step, and no chat."""
-        with patch.dict(os.environ, {"POC_ENABLE_CHAT_PRIORITY": "1"}):
-            import importlib
-            import vllm.engine.multiprocessing.engine as engine_module
-            importlib.reload(engine_module)
-            from vllm.engine.multiprocessing.engine import MQLLMEngine
-            from vllm.poc.data import Artifact
-            
-            mock_llm_engine = MagicMock()
-            mock_llm_engine.has_unfinished_requests.return_value = False
-            
-            mq_engine = MagicMock()
-            mq_engine.engine = mock_llm_engine
-            mq_engine._engine_step_in_progress = False
-            mq_engine.input_socket.poll.return_value = 0  # No pending input
-            
-            mock_manager = MagicMock()
-            mock_manager.generate_artifacts.return_value = [
-                Artifact(nonce=0, vector_b64="AAA="),
-                Artifact(nonce=1, vector_b64="BBB="),
-            ]
-            mq_engine._poc_manager = mock_manager
-            mq_engine._get_poc_manager = lambda: mock_manager
-            
-            result = MQLLMEngine._process_poc_action(mq_engine, "generate_artifacts", {
-                "nonces": [0, 1],
-                "block_hash": "hash",
-                "public_key": "key",
-                "seq_len": 256,
-                "k_dim": 12,
-            })
-            
-            mq_engine._prepare_for_poc_gpu_work.assert_called_once()
-            mock_manager.generate_artifacts.assert_called_once()
-            assert "skipped" not in result or result.get("skipped") is not True
-            assert len(result["artifacts"]) == 2
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+
+        mock_llm_engine = MagicMock()
+        mock_llm_engine.scheduler = []
+        mock_llm_engine.has_unfinished_requests.return_value = True
+
+        mq_engine = MagicMock()
+        mq_engine.engine = mock_llm_engine
+        mq_engine._engine_step_in_progress = False
+        mq_engine.input_socket.poll.return_value = 0
+        mq_engine._abort_all_chat_requests = (
+            MQLLMEngine._abort_all_chat_requests.__get__(
+                mq_engine, MQLLMEngine))
+
+        mock_manager = MagicMock()
+        mq_engine._poc_manager = mock_manager
+        mq_engine._get_poc_manager = lambda: mock_manager
+
+        result = MQLLMEngine._process_poc_action(
+            mq_engine, "generate_artifacts", {"nonces": [0, 1, 2]})
+
+        assert result["skipped"] is True
+        assert result["reason"] == "chat_unfinished"
+        mock_manager.generate_artifacts.assert_not_called()
+
+
+class TestChatRejectionWhilePoC:
+    """_handle_process_request must reject chat RPCs when PoC is active."""
+
+    def test_handle_process_request_rejects_during_poc(self):
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+        from vllm.engine.multiprocessing import RPCProcessRequest, RPCError
+
+        set_poc_active(True)
+
+        mq_engine = MagicMock()
+        mq_engine._errored_with = None
+        outputs_sent = []
+        mq_engine._send_outputs = lambda o: outputs_sent.append(o)
+
+        request = MagicMock(spec=RPCProcessRequest)
+        request.request_id = "chat-req-1"
+
+        MQLLMEngine._handle_process_request(mq_engine, request)
+
+        assert len(outputs_sent) == 1
+        rpc_err = outputs_sent[0]
+        assert isinstance(rpc_err, RPCError)
+        assert rpc_err.request_id == "chat-req-1"
+        assert not rpc_err.is_engine_errored
+        mq_engine.engine.add_request.assert_not_called()
+
+    def test_handle_process_request_allows_when_poc_inactive(self):
+        from vllm.engine.multiprocessing.engine import MQLLMEngine
+        from vllm.engine.multiprocessing import RPCProcessRequest
+
+        set_poc_active(False)
+
+        mq_engine = MagicMock()
+        mq_engine._errored_with = None
+        mq_engine.log_requests = False
+
+        request = MagicMock(spec=RPCProcessRequest)
+        request.request_id = "chat-req-2"
+        request.prompt = "Hello"
+        request.params = MagicMock()
+        request.lora_request = None
+        request.trace_headers = None
+        request.prompt_adapter_request = None
+        request.priority = 0
+
+        MQLLMEngine._handle_process_request(mq_engine, request)
+
+        mq_engine.engine.add_request.assert_called_once()
 
 
 class TestGenerationLoopBackoff:
-    """Tests for generation loop backoff behavior."""
-    
+    """Generation loop retries with backoff when engine returns skipped."""
+
     @pytest.mark.asyncio
-    async def test_generation_loop_backs_off_on_skip(self, mock_engine_client):
-        """Test that generation loop backs off when engine returns skipped."""
+    async def test_generation_loop_backs_off_on_skip(
+            self, mock_engine_client):
         stop_event = asyncio.Event()
         config = {
             "block_hash": "hash",
@@ -242,8 +273,9 @@ class TestGenerationLoopBackoff:
             "k_dim": 12,
         }
         stats = {"start_time": 0, "total_processed": 0}
-        
+
         call_count = 0
+
         async def mock_poc_request(action, payload, timeout_ms=None):
             nonlocal call_count
             call_count += 1
@@ -251,47 +283,44 @@ class TestGenerationLoopBackoff:
                 return {"skipped": True, "artifacts": []}
             stop_event.set()
             return {"artifacts": [], "skipped": True}
-        
+
         mock_engine_client.poc_request = mock_poc_request
-        
+
         with patch('vllm.poc.routes.POC_CHAT_BUSY_BACKOFF_SEC', 0.001):
             task = asyncio.create_task(
-                _generation_loop(mock_engine_client, stop_event, None, config, stats)
-            )
+                _generation_loop(mock_engine_client, stop_event,
+                                 None, config, stats))
             await asyncio.sleep(0.1)
             stop_event.set()
             try:
                 await asyncio.wait_for(task, timeout=1.0)
             except asyncio.CancelledError:
                 pass
-        
+
         assert call_count >= 2
 
 
 class TestUnknownAction:
-    """Tests for unknown action handling."""
-    
+    """Both engines must reject unrecognised PoC actions."""
+
     def test_mp_engine_rejects_unknown_action(self):
-        """Test MP engine rejects unknown actions."""
         from vllm.engine.multiprocessing.engine import MQLLMEngine
-        
+
         mq_engine = MagicMock()
         mq_engine._get_poc_manager = MagicMock()
-        
+
         with pytest.raises(ValueError, match="Unknown PoC action"):
-            MQLLMEngine._process_poc_action(mq_engine, "unknown_action", {})
-    
+            MQLLMEngine._process_poc_action(
+                mq_engine, "unknown_action", {})
+
     def test_mp_engine_rejects_old_actions(self):
-        """Test MP engine rejects old actions like run_batch, init, etc."""
         from vllm.engine.multiprocessing.engine import MQLLMEngine
-        
+
         mq_engine = MagicMock()
         mq_engine._get_poc_manager = MagicMock()
-        
-        for old_action in ["init", "start_generate", "stop", "status", "run_batch"]:
+
+        for old_action in ["init", "start_generate", "stop",
+                           "status", "run_batch"]:
             with pytest.raises(ValueError, match="Unknown PoC action"):
-                MQLLMEngine._process_poc_action(mq_engine, old_action, {})
-    
-    # Note: async_engine_rejects_unknown_action test is skipped because
-    # _AsyncLLMEngine is difficult to mock correctly. The behavior is
-    # covered by the MP engine test above.
+                MQLLMEngine._process_poc_action(
+                    mq_engine, old_action, {})

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import copy
-import os
 import time
 import weakref
 from functools import partial
@@ -36,10 +35,10 @@ from vllm.sequence import ExecuteModelRequest
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import Device, weak_bind
+from vllm.poc.state import is_poc_active, set_poc_active
 
 logger = init_logger(__name__)
 ENGINE_ITERATION_TIMEOUT_S = envs.VLLM_ENGINE_ITERATION_TIMEOUT_S
-POC_ENABLE_CHAT_PRIORITY = os.environ.get("POC_ENABLE_CHAT_PRIORITY", "0").lower() in ("1", "true", "yes")
 
 
 class AsyncEngineDeadError(RuntimeError):
@@ -741,6 +740,17 @@ class AsyncLLMEngine(EngineClient):
         new_requests, aborted_requests = (
             self._request_tracker.get_new_and_aborted_requests())
 
+        if is_poc_active():
+            for new_request in new_requests:
+                self._request_tracker.process_exception(
+                    new_request["request_id"],
+                    RuntimeError("PoC generation in progress, request rejected"),
+                    verbose=self.log_requests,
+                )
+            if aborted_requests:
+                await self._engine_abort(aborted_requests)
+            return False
+
         for new_request in new_requests:
             # Add the request into the vLLM engine's waiting queue.
             try:
@@ -822,6 +832,11 @@ class AsyncLLMEngine(EngineClient):
                     for ve in range(pipeline_parallel_size)
                 ]
                 has_requests_in_progress = [True] * pipeline_parallel_size
+
+            if is_poc_active():
+                # Yield while PoC is active so chat generation does not start.
+                await asyncio.sleep(0)
+                continue
 
             # Abort if iteration takes too long due to unrecoverable errors
             # (eg. NCCL timeouts).
@@ -1196,13 +1211,27 @@ class AsyncLLMEngine(EngineClient):
     async def poc_request(self, action: str, payload: dict,
                           timeout_ms: Optional[int] = None) -> dict:
         """Send a PoC (Proof of Compute) request to the engine.
-        
-        Only supports 'generate_artifacts' action. All PoC state (generation
-        loop, nonce counter, stats) is managed in the API layer.
+
+        Supported actions:
+          - ``start_session``       – mark PoC active and abort all chat requests.
+          - ``end_session``         – clear PoC active flag so chat resumes.
+          - ``generate_artifacts``  – run PoC forward pass.
         """
+        if action == "start_session":
+            set_poc_active(True)
+            aborted = self._abort_all_chat_requests()
+            if aborted > 0:
+                logger.info("PoC: aborted %d chat requests", aborted)
+            return {"ok": True}
+
+        if action == "end_session":
+            set_poc_active(False)
+            logger.info("PoC session ended")
+            return {"ok": True}
+
         if action != "generate_artifacts":
             raise ValueError(f"Unknown PoC action: {action}")
-        
+
         if not hasattr(self, '_poc_manager'):
             from vllm.poc.manager import PoCManager
             self._poc_manager = PoCManager(
@@ -1210,19 +1239,22 @@ class AsyncLLMEngine(EngineClient):
                 model_config=self.engine.model_config,
                 vllm_config=self.engine.vllm_config,
             )
-        
+
         manager = self._poc_manager
-        
-        if POC_ENABLE_CHAT_PRIORITY:
-            # Legacy behavior: chat has priority, PoC yields
-            if self.engine.has_unfinished_requests():
-                return {"artifacts": [], "skipped": True}
-        else:
-            # Default: PoC has priority, abort active chat requests
-            aborted = self._abort_all_chat_requests()
-            if aborted > 0:
-                logger.info(f"PoC: aborted {aborted} chat requests")
-        
+
+        # Always keep PoC active while generating artifacts.
+        set_poc_active(True)
+        # Always abort all chat requests to free up resources for PoC
+        aborted = self._abort_all_chat_requests()
+        if aborted > 0:
+            logger.info("PoC: aborted %d chat requests", aborted)
+        if self.engine.has_unfinished_requests():
+            return {
+                "artifacts": [],
+                "skipped": True,
+                "reason": "chat_unfinished",
+            }
+
         from vllm.poc.data import Artifact
         artifacts = await asyncio.to_thread(
             manager.generate_artifacts,

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 import pickle
 import signal
 from contextlib import contextmanager
@@ -37,11 +36,11 @@ from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.usage.usage_lib import UsageContext
 from vllm.worker.model_runner_base import InputProcessingError
+from vllm.poc.state import is_poc_active, set_poc_active
 
 logger = init_logger(__name__)
 
 POLLING_TIMEOUT_MS = 10000
-POC_ENABLE_CHAT_PRIORITY = os.environ.get("POC_ENABLE_CHAT_PRIORITY", "0").lower() in ("1", "true", "yes")
 HEALTHY_RESPONSE = (pickle.dumps(VLLM_RPC_SUCCESS_STR), )
 
 
@@ -239,6 +238,12 @@ class MQLLMEngine:
             # Handle any input from the client.
             self.handle_new_input()
 
+            # Skip inference while PoC generation is active – running
+            # engine.step() here would allocate KV-cache and compete
+            # with the PoC forward pass for GPU memory.
+            if is_poc_active():
+                continue
+
             # Engine step.
             request_outputs = self.engine_step()
 
@@ -318,6 +323,18 @@ class MQLLMEngine:
     def _handle_process_request(self, request: RPCProcessRequest):
         """Handle RPCProcessRequest by adding it to the LLMEngine."""
         request_id = request.request_id
+
+        # Reject chat/completion requests while PoC generation is active.
+        # This prevents new requests from being scheduled between
+        # consecutive PoC batches when the engine loop resumes.
+        if is_poc_active():
+            rpc_err = RPCError(
+                request_id=request_id,
+                is_engine_errored=False,
+                exception=RuntimeError(
+                    "PoC generation in progress, request rejected"))
+            self._send_outputs(rpc_err)
+            return
 
         if self._errored_with is not None:
             rpc_err = RPCError(request_id=request_id,
@@ -437,48 +454,53 @@ class MQLLMEngine:
 
     def _process_poc_action(self, action: str, payload: dict) -> dict:
         """Process a PoC action and return result.
-        
-        Only supports 'generate_artifacts' action. All PoC state (generation
-        loop, nonce counter, stats) is managed in the API layer.
+
+        Supported actions:
+          - ``start_session``       – mark PoC active and abort all chat requests.
+          - ``end_session``         – clear PoC active flag so chat resumes.
+          - ``generate_artifacts``  – run PoC forward pass.
         """
-        if action != "generate_artifacts":
-            raise ValueError(f"Unknown PoC action: {action}")
-        
-        manager = self._get_poc_manager()
-        
-        if POC_ENABLE_CHAT_PRIORITY:
-            # Legacy behavior: chat has priority, PoC yields
-            if self.input_socket.poll(timeout=0) != 0:
-                return {
-                    "artifacts": [],
-                    "skipped": True,
-                    "reason": "pending_input",
-                }
-            if self._engine_step_in_progress:
-                return {
-                    "artifacts": [],
-                    "skipped": True,
-                    "reason": "engine_step_in_progress",
-                }
-            if self.engine.has_unfinished_requests():
-                return {
-                    "artifacts": [],
-                    "skipped": True,
-                    "reason": "chat_unfinished",
-                }
-        else:
-            # Default: PoC has priority, abort active chat requests
+        if action == "start_session":
+            set_poc_active(True)
             aborted = self._abort_all_chat_requests()
             if aborted > 0:
-                logger.info(f"PoC: aborted {aborted} chat requests")
-            # Safety: never run during engine.step() (GPU conflict)
-            if self._engine_step_in_progress:
-                return {
-                    "artifacts": [],
-                    "skipped": True,
-                    "reason": "engine_step_in_progress",
-                }
-        
+                logger.info("PoC: aborted %d chat requests", aborted)
+            return {"ok": True}
+
+        if action == "end_session":
+            set_poc_active(False)
+            logger.info("PoC session ended in engine process")
+            return {"ok": True}
+
+        if action != "generate_artifacts":
+            raise ValueError(f"Unknown PoC action: {action}")
+
+        manager = self._get_poc_manager()
+
+        # Always keep PoC active while generating artifacts.
+        set_poc_active(True)
+        aborted = self._abort_all_chat_requests()
+        if aborted > 0:
+            logger.info("PoC: aborted %d chat requests", aborted)
+        if self.input_socket.poll(timeout=0) != 0:
+            return {
+                "artifacts": [],
+                "skipped": True,
+                "reason": "pending_input",
+            }
+        if self._engine_step_in_progress:
+            return {
+                "artifacts": [],
+                "skipped": True,
+                "reason": "engine_step_in_progress",
+            }
+        if self.engine.has_unfinished_requests():
+            return {
+                "artifacts": [],
+                "skipped": True,
+                "reason": "chat_unfinished",
+            }
+
         # Safe to proceed: stop remote worker loop if running (v0 TP deadlock fix)
         self._prepare_for_poc_gpu_work()
         from vllm.poc.data import Artifact

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -36,7 +36,7 @@ from typing_extensions import assert_never
 
 import vllm.envs as envs
 
-from vllm.poc.routes import is_poc_generation_active
+from vllm.poc.state import is_poc_active
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine  # type: ignore
@@ -555,7 +555,7 @@ async def show_version():
 @load_aware_call
 async def create_chat_completion(request: ChatCompletionRequest,
                                  raw_request: Request):
-    if is_poc_generation_active():
+    if is_poc_active():
         return JSONResponse(
             status_code=503,
             content={"error": {"message": "Service unavailable: POC generation in progress", "type": "service_unavailable"}}
@@ -599,7 +599,7 @@ async def create_chat_completion(request: ChatCompletionRequest,
 @with_cancellation
 @load_aware_call
 async def create_completion(request: CompletionRequest, raw_request: Request):
-    if is_poc_generation_active():
+    if is_poc_active():
         return JSONResponse(
             status_code=503,
             content={"error": {"message": "Service unavailable: POC generation in progress", "type": "service_unavailable"}}

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -14,6 +14,7 @@ from .config import PoCState
 from .data import Artifact, DEFAULT_DIST_THRESHOLD, DEFAULT_P_MISMATCH, DEFAULT_FRAUD_THRESHOLD
 from .callbacks import CallbackSender
 from .generate_queue import GenerateJob, get_queue, clear_queue, POC_MAX_QUEUED_NONCES
+from .state import is_poc_active, set_poc_active
 from .validation import run_validation
 
 logger = init_logger(__name__)
@@ -27,12 +28,8 @@ POC_RPC_TIMEOUT_MS = int(os.environ.get("POC_RPC_TIMEOUT_MS", "60000"))
 POC_BATCH_SIZE_DEFAULT = int(os.environ.get("POC_BATCH_SIZE_DEFAULT", "32"))
 
 _poc_tasks: Dict[int, Dict[str, Any]] = {}
-_poc_generation_active: bool = False
 
 
-def is_poc_generation_active() -> bool:
-    """Check if POC generation is active (for use by chat endpoint to reject requests)."""
-    return _poc_generation_active
 
 
 # =============================================================================
@@ -347,6 +344,16 @@ async def _generation_loop(
     except Exception as e:
         logger.error(f"PoC generation crashed: {e}", exc_info=True)
         raise
+    finally:
+        # Always clear the flag so chat endpoints are unblocked even
+        # if the loop crashes or is cancelled unexpectedly.
+        try:
+            await asyncio.shield(
+                engine_client.poc_request("end_session", {}, timeout_ms=5000))
+        except Exception:
+            set_poc_active(False)
+            pass
+        logger.info("PoC generation flag cleared")
 
 
 # =============================================================================
@@ -355,7 +362,6 @@ async def _generation_loop(
 
 @router.post("/init/generate")
 async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
-    global _poc_generation_active
     logger.info(f"PoC /init/generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.group_id}, {body.n_groups}, {body.batch_size}, {body.params}, {body.url}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
@@ -364,6 +370,11 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
     
     if _is_generation_active(app_id):
         raise HTTPException(status_code=409, detail="Already generating")
+    
+    # Set the flag BEFORE creating the task so that any concurrent chat
+    # request hitting the middleware / endpoint guard is rejected
+    # immediately, with no race window.
+    await engine_client.poc_request("start_session", {}, timeout_ms=5000)
     
     await _cancel_poc_tasks(app_id)
     
@@ -388,7 +399,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
     if body.url:
         callback_sender = CallbackSender(body.url, stop_event, body.params.k_dim)
         callback_task = asyncio.create_task(callback_sender.run())
-    
+
     gen_task = asyncio.create_task(
         _generation_loop(engine_client, stop_event, callback_sender, config, stats)
     )
@@ -402,7 +413,6 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         "stats": stats,
     }
     
-    _poc_generation_active = True
     return {"status": "OK", "pow_status": {"status": "GENERATING"}}
 
 
@@ -546,11 +556,10 @@ async def get_status(request: Request) -> dict:
 
 @router.post("/stop")
 async def stop_round(request: Request) -> dict:
-    global _poc_generation_active
     app_id = id(request.app)
     
     await _cancel_poc_tasks(app_id)
     await clear_queue()
     
-    _poc_generation_active = False
+    set_poc_active(False)
     return {"status": "OK", "pow_status": {"status": "STOPPED"}}

--- a/vllm/poc/state.py
+++ b/vllm/poc/state.py
@@ -1,0 +1,18 @@
+"""Centralized PoC V2 state — single source of truth for generation activity."""
+
+import threading
+
+_lock = threading.Lock()
+_poc_active: bool = False
+
+
+def is_poc_active() -> bool:
+    """Return *True* while a PoC generation round is in progress."""
+    return _poc_active
+
+
+def set_poc_active(active: bool) -> None:
+    """Set the PoC-active flag (thread-safe)."""
+    global _poc_active
+    with _lock:
+        _poc_active = active


### PR DESCRIPTION
This pull request implements a unified PoC (Proof of Compute) priority mode for both the async and multiprocessing engines, ensuring that PoC actions always take precedence over chat requests. It removes legacy chat-priority modes, introduces explicit session management for PoC, and updates test coverage to reflect the new behavior. The changes provide clear guard conditions for PoC actions and enforce rejection of chat requests while PoC is active.

Unified PoC priority mode and session management:

* Both `async_llm_engine.py` and `multiprocessing.engine` now enforce PoC priority: all chat requests are aborted when PoC is active, and PoC actions are rejected if guard conditions are not met. The legacy `POC_ENABLE_CHAT_PRIORITY` mode and related environment variable checks are removed. [[1]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643R38-L42) [[2]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643L1200-R1231) [[3]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643L1216-R1256) [[4]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25R22-R39) [[5]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L73-R261)

Explicit PoC session control:

* Added support for `start_session` and `end_session` actions in `async_llm_engine.py`, which set and clear the PoC active flag, abort chat requests, and allow chat to resume after PoC ends. [[1]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643L1200-R1231) [[2]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L73-R261)

Chat request rejection during PoC:

* Both engines now reject chat requests while PoC is active, with tests verifying that chat RPCs are rejected and not added to the engine queue. [[1]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643R743-R753) [[2]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643R836-R840) [[3]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L73-R261)

Comprehensive guard conditions and skip reasons:

* PoC actions return explicit skip reasons for pending input, unfinished chat, or engine step in progress, with test coverage for each guard condition. [[1]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L73-R261) [[2]](diffhunk://#diff-4bd825485b5162cf8021da41a2ebd3d4026929e617d1137f69bbbe4bda0ee643L1216-R1256)

Test suite refactor and coverage improvements:

* Tests in `test_coexist.py` are updated to reflect unified PoC priority, session control, and guard conditions. Legacy chat-priority tests are removed, and new tests are added for session actions, chat rejection, and skip reasons. [[1]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L2-R8) [[2]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25R22-R39) [[3]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25L73-R261) [[4]](diffhunk://#diff-b5fe57ab026624f24818bb3dafa55c9fe5f222cf915d365434698f1fd5ea5d25R278) Fe09a898L301R301)