### PR TITLE
feat(poc): stronger RNG via full SHA256 seed (concat_murmur)

### DIFF
--- a/tests/poc/test_gpu_random.py
+++ b/tests/poc/test_gpu_random.py
@@ -5,6 +5,7 @@ from scipy import stats
 
 from vllm.poc.gpu_random import (
     generate_inputs,
+    generate_inputs_concat_murmur,
     generate_target,
     generate_householder_vector,
     apply_householder,
@@ -726,3 +727,71 @@ def test_haar_rotation_different_inputs_same_rotation():
     # Should still be orthogonal
     dot = (y1 * y2).sum()
     assert abs(dot.item()) < 1e-4, f"Dot product {dot.item()} should be ~0"
+
+
+# =============================================================================
+# generate_inputs_concat_murmur() Tests
+# =============================================================================
+
+def test_concat_murmur_determinism():
+    device = torch.device("cuda:0")
+    r1 = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0, 1, 2], dim=128, seq_len=16, device=device)
+    r2 = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0, 1, 2], dim=128, seq_len=16, device=device)
+    assert torch.equal(r1, r2)
+
+
+def test_concat_murmur_different_nonces():
+    device = torch.device("cuda:0")
+    r1 = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [1], dim=128, seq_len=16, device=device)
+    r2 = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [2], dim=128, seq_len=16, device=device)
+    assert not torch.allclose(r1, r2)
+
+
+def test_concat_murmur_different_block_hash():
+    device = torch.device("cuda:0")
+    r1 = generate_inputs_concat_murmur("hash1", PUBLIC_KEY, [0], dim=128, seq_len=16, device=device)
+    r2 = generate_inputs_concat_murmur("hash2", PUBLIC_KEY, [0], dim=128, seq_len=16, device=device)
+    assert not torch.allclose(r1, r2)
+
+
+def test_concat_murmur_different_public_key():
+    device = torch.device("cuda:0")
+    r1 = generate_inputs_concat_murmur(BLOCK_HASH, "key1", [0], dim=128, seq_len=16, device=device)
+    r2 = generate_inputs_concat_murmur(BLOCK_HASH, "key2", [0], dim=128, seq_len=16, device=device)
+    assert not torch.allclose(r1, r2)
+
+
+def test_concat_murmur_shape_and_dtype():
+    device = torch.device("cuda:0")
+    result = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0, 1, 2], dim=64, seq_len=8, device=device)
+    assert result.shape == (3, 8, 64)
+    assert result.dtype == torch.float16
+
+
+def test_concat_murmur_differs_from_generate_inputs():
+    """concat_murmur uses all 256 SHA256 bits, so output differs from generate_inputs."""
+    device = torch.device("cuda:0")
+    r_standard = generate_inputs(BLOCK_HASH, PUBLIC_KEY, [0], dim=128, seq_len=16, device=device)
+    r_concat = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0], dim=128, seq_len=16, device=device)
+    assert not torch.allclose(r_standard, r_concat)
+
+
+def test_concat_murmur_gaussian_distribution():
+    """All 8 sub-seeds contribute; combined output is approximately N(0, 1)."""
+    device = torch.device("cuda:0")
+    all_samples = []
+    for batch_start in range(0, 1000, 100):
+        nonces = list(range(batch_start, batch_start + 100))
+        out = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, nonces, dim=256, seq_len=16, device=device)
+        all_samples.append(out.flatten().float())
+    combined = torch.cat(all_samples)
+    assert abs(combined.mean().item()) < 0.05
+    assert abs(combined.std().item() - 1.0) < 0.1
+
+
+def test_concat_murmur_cpu_gpu_match():
+    cpu = torch.device("cpu")
+    gpu = torch.device("cuda:0")
+    r_cpu = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0, 1], dim=64, seq_len=8, device=cpu)
+    r_gpu = generate_inputs_concat_murmur(BLOCK_HASH, PUBLIC_KEY, [0, 1], dim=64, seq_len=8, device=gpu)
+    assert torch.allclose(r_cpu, r_gpu.cpu(), rtol=1e-3, atol=1e-3)

--- a/tests/poc/test_routes.py
+++ b/tests/poc/test_routes.py
@@ -97,6 +97,18 @@ class TestPoCInitGenerate:
         })
         assert response.status_code == 422
 
+    def test_init_generate_poc_stronger_rng_stored_in_config(self, client, mock_engine_client, app_with_poc):
+        """poc_stronger_rng=True must be stored in the generation config."""
+        mock_engine_client.poc_request.return_value = {"artifacts": []}
+        response = client.post("/api/v1/pow/init/generate", json={
+            "block_hash": "abc123", "block_height": 100, "public_key": "pubkey123",
+            "node_id": 0, "node_count": 1,
+            "params": {"model": "test-model", "seq_len": 256, "k_dim": 12},
+            "poc_stronger_rng": True,
+        })
+        assert response.status_code == 200
+        assert _poc_tasks[id(app_with_poc)]["config"]["poc_stronger_rng"] is True
+
 
 class TestPoCGenerate:
     def test_generate_returns_artifacts(self, client, mock_engine_client):
@@ -144,6 +156,20 @@ class TestPoCGenerate:
             "validation": {"artifacts": [{"nonce": 0, "vector_b64": "AAA="}, {"nonce": 5, "vector_b64": "BBB="}]},
         })
         assert response.status_code == 400
+
+    def test_generate_propagates_poc_stronger_rng(self, client, mock_engine_client):
+        """poc_stronger_rng=True must reach the engine_client.poc_request payload."""
+        mock_engine_client.poc_request.return_value = {
+            "artifacts": [{"nonce": 0, "vector_b64": "AAAA"}],
+        }
+        client.post("/api/v1/pow/generate", json={
+            "block_hash": "abc123", "block_height": 100, "public_key": "pubkey123",
+            "node_id": 0, "node_count": 1, "nonces": [0],
+            "params": {"model": "test-model", "seq_len": 256, "k_dim": 12},
+            "wait": True, "poc_stronger_rng": True,
+        })
+        payload = mock_engine_client.poc_request.call_args[0][1]
+        assert payload["poc_stronger_rng"] is True
 
 
 class TestPoCStatus:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -1213,6 +1213,7 @@ class AsyncLLMEngine(EngineClient):
             public_key=payload.get("public_key", ""),
             seq_len=payload.get("seq_len", 256),
             k_dim=payload.get("k_dim", 12),
+            poc_stronger_rng=payload.get("poc_stronger_rng", False),
         )
         return {
             "artifacts": [{"nonce": a.nonce, "vector_b64": a.vector_b64} for a in artifacts],

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -456,6 +456,7 @@ class MQLLMEngine:
             public_key=payload.get("public_key", ""),
             seq_len=payload.get("seq_len", 256),
             k_dim=payload.get("k_dim", 12),
+            poc_stronger_rng=payload.get("poc_stronger_rng", False),
         )
         return {
             "artifacts": [{"nonce": a.nonce, "vector_b64": a.vector_b64} for a in artifacts],

--- a/vllm/poc/config.py
+++ b/vllm/poc/config.py
@@ -20,4 +20,5 @@ class PoCConfig:
     batch_size: int = 32
     seq_len: int = 256
     k_dim: int = 12
+    poc_stronger_rng: bool = False
     callback_url: Optional[str] = None

--- a/vllm/poc/generate_queue.py
+++ b/vllm/poc/generate_queue.py
@@ -33,6 +33,7 @@ class GenerateJob:
     seq_len: int
     k_dim: int
     batch_size: int
+    poc_stronger_rng: bool = False
     validation_artifacts: Optional[Dict[int, str]] = None
     stat_test_dist_threshold: float = DEFAULT_DIST_THRESHOLD
     stat_test_p_mismatch: float = DEFAULT_P_MISMATCH
@@ -222,6 +223,7 @@ class GenerateQueue:
                     "public_key": job.public_key,
                     "seq_len": job.seq_len,
                     "k_dim": job.k_dim,
+                    "poc_stronger_rng": job.poc_stronger_rng,
                 })
                 
                 if not result.get("skipped"):

--- a/vllm/poc/gpu_random.py
+++ b/vllm/poc/gpu_random.py
@@ -55,6 +55,43 @@ def _normal(seed: int, n: int, device: torch.device) -> torch.Tensor:
     return torch.cat([z0, z1])[:n]
 
 
+def generate_inputs_concat_murmur(
+    block_hash: str,
+    public_key: str,
+    nonces: List[int],
+    dim: int,
+    seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+    """Generate deterministic input embeddings using concat-murmur (stronger RNG).
+
+    Uses all 256 bits of SHA256 by splitting into 8 × 32-bit sub-seeds.
+    Each sub-seed generates one segment of length ceil(n/8) via the existing
+    murmur3 pipeline; segments are concatenated.
+    """
+    batch_size = len(nonces)
+    result = torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
+    n = seq_len * dim
+    seg_len = (n + 7) // 8  # ceil(n/8); last segment may be shorter
+
+    for i, nonce in enumerate(nonces):
+        h = hashlib.sha256(
+            f"{block_hash}_{public_key}_nonce{nonce}".encode()
+        ).digest()
+        sub_seeds = [int.from_bytes(h[j:j + 4], 'big') for j in range(0, 32, 4)]
+
+        segments = [
+            _normal(s, min(seg_len, n - k * seg_len), device)
+            for k, s in enumerate(sub_seeds)
+            if k * seg_len < n
+        ]
+        flat = torch.cat(segments)[:n]
+        result[i] = flat.view(seq_len, dim).to(dtype)
+
+    return result
+
+
 def generate_inputs(
     block_hash: str,
     public_key: str,

--- a/vllm/poc/manager.py
+++ b/vllm/poc/manager.py
@@ -33,13 +33,14 @@ class PoCManager:
         nonces: List[int],
         seq_len: int,
         k_dim: int,
+        poc_stronger_rng: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Run forward pass via collective_rpc.
-        
+
         Returns dict with 'nonces' and 'vectors' (FP16 numpy array).
         """
         from .poc_model_runner import execute_poc_forward
-        
+
         results = self.model_executor.collective_rpc(
             execute_poc_forward,
             args=(
@@ -49,6 +50,7 @@ class PoCManager:
                 seq_len,
                 self.model_config.get_hidden_size(),
                 k_dim,
+                poc_stronger_rng,
             ),
         )
         
@@ -62,6 +64,7 @@ class PoCManager:
         public_key: str,
         seq_len: int,
         k_dim: int,
+        poc_stronger_rng: bool = False,
     ) -> List[Artifact]:
         """Generate artifacts for specific nonces.
         
@@ -74,6 +77,7 @@ class PoCManager:
             nonces,
             seq_len,
             k_dim,
+            poc_stronger_rng,
         )
         
         if result is None:

--- a/vllm/poc/poc_model_runner.py
+++ b/vllm/poc/poc_model_runner.py
@@ -17,7 +17,7 @@ from vllm.sequence import IntermediateTensors
 
 from .gpu_random import (
     generate_inputs,
-    generate_target,
+    generate_inputs_concat_murmur,
     random_pick_indices,
     apply_haar_rotation,
 )
@@ -132,6 +132,7 @@ def execute_poc_forward(
     seq_len: int,
     hidden_size: int,
     k_dim: int = DEFAULT_K_DIM,
+    poc_stronger_rng: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Execute PoC forward pass on a worker.
     
@@ -165,6 +166,7 @@ def execute_poc_forward(
                 "hidden_size": hidden_size,
                 "nonces": nonces,
                 "k_dim": k_dim,
+                "poc_stronger_rng": poc_stronger_rng,
             }, src=0)
         else:
             broadcast_data = broadcast_tensor_dict(src=0)
@@ -172,6 +174,7 @@ def execute_poc_forward(
             hidden_size = int(broadcast_data["hidden_size"])
             nonces = list(broadcast_data["nonces"])
             k_dim = int(broadcast_data["k_dim"])
+            poc_stronger_rng = bool(broadcast_data["poc_stronger_rng"])
     
     batch_size = len(nonces)
     
@@ -182,7 +185,8 @@ def execute_poc_forward(
     pp_group = get_pp_group()
     
     if pp_group.is_first_rank:
-        inputs_embeds = generate_inputs(
+        _gen_fn = generate_inputs_concat_murmur if poc_stronger_rng else generate_inputs
+        inputs_embeds = _gen_fn(
             block_hash, public_key, nonces,
             dim=hidden_size, seq_len=seq_len,
             device=device, dtype=dtype,

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -38,6 +38,7 @@ class PoCParamsModel(BaseModel):
     model: str
     seq_len: int
     k_dim: int = 12
+    poc_stronger_rng: bool = False
 
 
 class PoCInitGenerateRequest(BaseModel):
@@ -223,22 +224,24 @@ async def _compute_artifacts_chunk(
     public_key: str,
     seq_len: int,
     k_dim: int,
+    poc_stronger_rng: bool = False,
     timeout_sec: float = POC_GENERATE_CHUNK_TIMEOUT_SEC,
     check_cancelled: Optional[callable] = None,
 ) -> List[Dict]:
     """Compute artifacts for a chunk with backoff on skip."""
     chunk_start_time = time.time()
-    
+
     while True:
         if check_cancelled and check_cancelled():
             raise RuntimeError("Cancelled")
-        
+
         result = await engine_client.poc_request("generate_artifacts", {
             "nonces": nonces,
             "block_hash": block_hash,
             "public_key": public_key,
             "seq_len": seq_len,
             "k_dim": k_dim,
+            "poc_stronger_rng": poc_stronger_rng,
         })
         
         if not result.get("skipped"):
@@ -293,6 +296,7 @@ async def _generation_loop(
                         "public_key": config["public_key"],
                         "seq_len": config["seq_len"],
                         "k_dim": config["k_dim"],
+                        "poc_stronger_rng": config.get("poc_stronger_rng", False),
                     },
                     timeout_ms=POC_RPC_TIMEOUT_MS
                 )
@@ -371,6 +375,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         "batch_size": body.batch_size,
         "seq_len": body.params.seq_len,
         "k_dim": body.params.k_dim,
+        "poc_stronger_rng": body.params.poc_stronger_rng,
     }
     
     stats = {"start_time": 0, "total_processed": 0}
@@ -437,6 +442,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             seq_len=body.params.seq_len,
             k_dim=body.params.k_dim,
             batch_size=body.batch_size,
+            poc_stronger_rng=body.params.poc_stronger_rng,
             validation_artifacts=validation_map,
             stat_test_dist_threshold=stat_test.dist_threshold,
             stat_test_p_mismatch=stat_test.p_mismatch,
@@ -479,6 +485,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             artifacts = await _compute_artifacts_chunk(
                 engine_client, chunk, body.block_hash, body.public_key,
                 body.params.seq_len, body.params.k_dim,
+                body.params.poc_stronger_rng,
                 POC_GENERATE_CHUNK_TIMEOUT_SEC, check_cancelled
             )
             computed_artifacts.extend(artifacts)

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -354,7 +354,7 @@ async def _generation_loop(
 
 @router.post("/init/generate")
 async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
-    logger.info(f"PoC /init/generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.group_id}, {body.n_groups}, {body.batch_size}, {body.params}, {body.url}")
+    logger.info(f"PoC /init/generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.group_id}, {body.n_groups}, {body.batch_size}, {body.params}, {body.url}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
     
@@ -406,7 +406,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
 
 @router.post("/generate")
 async def generate(request: Request, body: PoCGenerateRequest) -> dict:
-    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {body.validation}, {body.stat_test}")
+    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {body.validation}, {body.stat_test}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
     

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -38,7 +38,6 @@ class PoCParamsModel(BaseModel):
     model: str
     seq_len: int
     k_dim: int = 12
-    poc_stronger_rng: bool = False
 
 
 class PoCInitGenerateRequest(BaseModel):
@@ -52,6 +51,7 @@ class PoCInitGenerateRequest(BaseModel):
     batch_size: int = POC_BATCH_SIZE_DEFAULT
     params: PoCParamsModel
     url: Optional[str] = None
+    poc_stronger_rng: bool = False
 
 
 @dataclass
@@ -106,6 +106,7 @@ class PoCGenerateRequest(BaseModel):
     url: Optional[str] = None
     validation: Optional[ValidationModel] = None
     stat_test: Optional[StatTestModel] = None
+    poc_stronger_rng: bool = False
 
 
 # =============================================================================
@@ -296,7 +297,7 @@ async def _generation_loop(
                         "public_key": config["public_key"],
                         "seq_len": config["seq_len"],
                         "k_dim": config["k_dim"],
-                        "poc_stronger_rng": config.get("poc_stronger_rng", False),
+                        "poc_stronger_rng": config["poc_stronger_rng"],
                     },
                     timeout_ms=POC_RPC_TIMEOUT_MS
                 )
@@ -375,7 +376,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         "batch_size": body.batch_size,
         "seq_len": body.params.seq_len,
         "k_dim": body.params.k_dim,
-        "poc_stronger_rng": body.params.poc_stronger_rng,
+        "poc_stronger_rng": body.poc_stronger_rng,
     }
     
     stats = {"start_time": 0, "total_processed": 0}
@@ -442,7 +443,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             seq_len=body.params.seq_len,
             k_dim=body.params.k_dim,
             batch_size=body.batch_size,
-            poc_stronger_rng=body.params.poc_stronger_rng,
+            poc_stronger_rng=body.poc_stronger_rng,
             validation_artifacts=validation_map,
             stat_test_dist_threshold=stat_test.dist_threshold,
             stat_test_p_mismatch=stat_test.p_mismatch,
@@ -485,7 +486,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             artifacts = await _compute_artifacts_chunk(
                 engine_client, chunk, body.block_hash, body.public_key,
                 body.params.seq_len, body.params.k_dim,
-                body.params.poc_stronger_rng,
+                body.poc_stronger_rng,
                 POC_GENERATE_CHUNK_TIMEOUT_SEC, check_cancelled
             )
             computed_artifacts.extend(artifacts)


### PR DESCRIPTION
## Purpose

Fixes gonka-ai/gonka#926.

The previous `_seed_from_string` used only the first 32 bits of a SHA256 digest, leaving a small enough seed space that an attacker could forge proofs by finding collisions in ~2^32 SHA256 evaluations - allowing a single model run to be submitted as multiple nodes' outputs with different nonces.

**Changes:**

- Add `generate_inputs_concat_murmur`: splits the full 256-bit SHA256 digest into 8 × 32-bit sub-seeds, runs each through the existing murmur3 -> Box-Muller pipeline, and concatenates segments. Forging a proof now requires a full SHA256 collision (~2^128 work).
- Add `poc_stronger_rng` boolean flag (default `False`) threaded from `/init/generate` and `/generate` request bodies all the way down to input generation function selection, enabling governance-controlled activation.
- Include `poc_stronger_rng` in request log lines for auditability.

## Test Plan
```bash
# New function correctness
pytest tests/poc/test_gpu_random.py -k "concat_murmur" -v

# Flag propagation through API layer (no GPU needed)
pytest tests/poc/test_routes.py -k "poc_stronger_rng" -v
# Full routes suite
pytest tests/poc/test_routes.py -v
```
## Test Result
   
All existing `tests/poc/test_routes.py` tests pass. New tests added:
- 8 tests for `generate_inputs_concat_murmur` (determinism, sensitivity, shape/dtype, difference from old function, Gaussian distribution, CPU/GPU match)
- 2 tests verifying `poc_stronger_rng` propagation through `/init/generate` and `/generate`

Cross-GPU validation: generated artifacts on one GPU architecture and validated on another (64 nonces each direction). Model - `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`, `seq_len = 1024`, `k_dim=12`. Both directions show `fraud_detected: false` with p_value=0.999, confirming the concat_murmur pipeline is deterministic across GPU architectures:                                                                               

| Generator | Validator | n_total | n_mismatch | p_value | fraud_detected |
|-----------|-----------|---------|------------|---------|----------------|
| A100      | H200      | 64      | 1          | 0.9988  | false          |
| H200      | A100      | 64      | 1          | 0.9988  | false          |