### PR TITLE
Tg/cornercases vllm15

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -696,13 +696,7 @@ class VllmConfig:
                 self.compilation_config.mode = CompilationMode.NONE
 
         if all(s not in self.compilation_config.custom_ops for s in ("all", "none")):
-            if (
-                self.compilation_config.backend == "inductor"
-                and self.compilation_config.mode != CompilationMode.NONE
-            ):
-                self.compilation_config.custom_ops.append("none")
-            else:
-                self.compilation_config.custom_ops.append("all")
+            self.compilation_config.custom_ops.append("all")
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)

--- a/vllm/entrypoints/openai/chat_completion/api_router.py
+++ b/vllm/entrypoints/openai/chat_completion/api_router.py
@@ -12,7 +12,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponse,
 )
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
 from vllm.entrypoints.openai.orca_metrics import metrics_header
 from vllm.entrypoints.openai.utils import validate_json_request
 from vllm.entrypoints.utils import (
@@ -38,12 +38,32 @@ def chat(request: Request) -> OpenAIServingChat | None:
         HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
         HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
+        HTTPStatus.SERVICE_UNAVAILABLE.value: {"model": ErrorResponse},
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
 @with_cancellation
 @load_aware_call
 async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
+    # Chat priority gating: reject inference while PoC generation is active
+    # to prevent GPU contention / NCCL deadlocks.
+    try:
+        from vllm.poc.routes import is_poc_generation_active
+        if is_poc_generation_active():
+            return JSONResponse(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+                content=ErrorResponse(
+                    error=ErrorInfo(
+                        message="PoC generation is active. Inference requests "
+                                "are temporarily unavailable.",
+                        type="service_unavailable",
+                        code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+                    ),
+                ).model_dump(),
+            )
+    except ImportError:
+        pass
+
     metrics_header_format = raw_request.headers.get(
         ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, ""
     )

--- a/vllm/poc/engine_patch.py
+++ b/vllm/poc/engine_patch.py
@@ -3,6 +3,20 @@
 This module patches the V1 AsyncLLM class to add poc_request support,
 enabling PoC (Proof of Compute) artifact generation.
 
+Chat Priority Gating:
+    PoC has priority over chat. When PoC generation is active, the chat
+    API endpoint (api_router.py) rejects new inference requests with 503.
+
+    IMPORTANT: PoC's execute_poc_forward reuses KV cache blocks starting
+    from block 0 (both as scratch for inputs_embeds and as the attention
+    slot mapping).  If any inference request still has KV blocks allocated,
+    PoC will overwrite them and permanently corrupt the model output.
+
+    Therefore poc_request MUST wait for all in-flight requests to fully
+    complete (drain) before issuing the collective_rpc.  The API-level
+    gating ensures no *new* requests arrive, so the drain is bounded by
+    the longest in-flight generation (max_tokens).
+
 Usage:
     Import this module early in the application startup to apply the patch.
 """
@@ -21,6 +35,15 @@ async def poc_request(self, action: str, payload: dict, timeout_ms: int = 60000)
     Only supports 'generate_artifacts' action. All PoC state (generation
     loop, nonce counter, stats) is managed in the API layer.
     
+    Before issuing the GPU work this method waits for every in-flight
+    inference request to complete.  This is required because
+    execute_poc_forward writes into KV-cache blocks starting from block 0;
+    if any request still holds those blocks the KV data is corrupted and
+    the model produces garbage for the rest of its lifetime.
+    
+    The API-level chat gating (api_router.py) prevents new requests from
+    arriving, so the drain is bounded by the longest in-flight generation.
+    
     Args:
         action: The PoC action to perform (only 'generate_artifacts' supported)
         payload: Dict containing nonces, block_hash, public_key, seq_len, k_dim
@@ -28,6 +51,9 @@ async def poc_request(self, action: str, payload: dict, timeout_ms: int = 60000)
         
     Returns:
         Dict with 'artifacts' list and optionally 'skipped' boolean
+        
+    Raises:
+        TimeoutError: If engine doesn't respond within timeout
     """
     if action != "generate_artifacts":
         raise ValueError(f"Unknown PoC action: {action}")
@@ -44,6 +70,29 @@ async def poc_request(self, action: str, payload: dict, timeout_ms: int = 60000)
     
     if not nonces:
         return {"artifacts": []}
+    
+    # Drain all in-flight inference before touching the GPU.
+    # execute_poc_forward reuses KV-cache blocks from block 0, so any
+    # request that still holds allocated blocks would get its KV data
+    # destroyed, permanently corrupting model output.
+    # The API-level gating (api_router.py) already blocks new requests,
+    # so we only need to wait for existing ones to finish.
+    output_processor = getattr(self, 'output_processor', None)
+    if output_processor is not None and output_processor.has_unfinished_requests():
+        n = output_processor.get_num_unfinished_requests()
+        logger.info("PoC waiting for %d in-flight inference request(s) to drain", n)
+        drain_start = asyncio.get_event_loop().time()
+        while output_processor.has_unfinished_requests():
+            await asyncio.sleep(0.1)
+            elapsed = asyncio.get_event_loop().time() - drain_start
+            if elapsed > timeout_ms / 1000.0:
+                n = output_processor.get_num_unfinished_requests()
+                logger.warning("PoC drain timed out after %.1fs with %d "
+                               "request(s) still in-flight, skipping",
+                               elapsed, n)
+                return {"artifacts": [], "skipped": True}
+        elapsed = asyncio.get_event_loop().time() - drain_start
+        logger.info("Inference drained in %.1fs, proceeding with PoC", elapsed)
     
     # Get model config for hidden_size
     # V1 engine stores config differently

--- a/vllm/poc/poc_model_runner.py
+++ b/vllm/poc/poc_model_runner.py
@@ -27,9 +27,13 @@ logger = init_logger(__name__)
 
 DEFAULT_K_DIM = 12
 
-# Cached attention metadata (reused across calls with same batch_size+seq_len)
-_cached_attn_meta = None
-_cached_attn_meta_key = None
+# NOTE: attention metadata must NOT be cached across PoC calls.
+# The metadata builder's internal state (workspace buffers, page-table
+# references) is mutated by every inference engine step.  Reusing a
+# stale metadata object causes the attention backend to write only a
+# fraction of the expected KV entries, producing all-NaN hidden states.
+# The cost of rebuilding is <1 ms per call (vs ~15 ms for the model
+# forward), so the overhead is negligible.
 
 
 def _ensure_layer_hooks(worker, block_hash, hidden_size):
@@ -128,15 +132,8 @@ def _create_v1_attn_metadata(batch_size, seq_len, block_size, device, worker):
 
 
 def _get_or_create_attn_metadata(batch_size, seq_len, block_size, device, worker):
-    """Get cached attention metadata or create new one."""
-    global _cached_attn_meta, _cached_attn_meta_key
-    key = (batch_size, seq_len, block_size, device)
-    if _cached_attn_meta_key == key and _cached_attn_meta is not None:
-        return _cached_attn_meta
-    result = _create_v1_attn_metadata(batch_size, seq_len, block_size, device, worker)
-    _cached_attn_meta = result
-    _cached_attn_meta_key = key
-    return result
+    """Create fresh attention metadata for the given parameters."""
+    return _create_v1_attn_metadata(batch_size, seq_len, block_size, device, worker)
 
 
 @torch.inference_mode()

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -389,9 +389,27 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         callback_sender = CallbackSender(body.url, stop_event, body.params.k_dim)
         callback_task = asyncio.create_task(callback_sender.run())
     
+    # Set the flag BEFORE creating the task so the chat endpoint starts
+    # rejecting immediately — the drain in poc_request relies on no new
+    # inference arriving while it waits.
+    _poc_generation_active = True
+
     gen_task = asyncio.create_task(
         _generation_loop(engine_client, stop_event, callback_sender, config, stats)
     )
+    
+    def _on_generation_done(task: asyncio.Task):
+        global _poc_generation_active
+        _poc_generation_active = False
+        if task.cancelled():
+            logger.info("PoC generation task cancelled, flag cleared")
+        elif task.exception():
+            logger.warning("PoC generation task failed, flag cleared: %s",
+                           task.exception())
+        else:
+            logger.info("PoC generation task completed, flag cleared")
+    
+    gen_task.add_done_callback(_on_generation_done)
     
     _poc_tasks[app_id] = {
         "gen_task": gen_task,
@@ -402,7 +420,6 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         "stats": stats,
     }
     
-    _poc_generation_active = True
     return {"status": "OK", "pow_status": {"status": "GENERATING"}}
 
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -268,7 +268,14 @@ class StructuredOutputManager:
                         apply_bitmask = False
                     if apply_bitmask and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
+                        if not accepted:
+                            logger.warning(
+                                "Grammar rejected token %d for request %s "
+                                "during speculative decode bitmask fill. "
+                                "Disabling bitmask for this request.",
+                                token, req_id)
+                            apply_bitmask = False
+                            continue
                         state_advancements += 1
                     cumulative_index += 1
                 if state_advancements > 0:

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -166,24 +166,34 @@ class XgrammarGrammar(StructuredOutputGrammar):
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
     _is_terminated: bool = field(default=False, repr=False, hash=False)
+    _grammar_failed: bool = field(default=False, repr=False, hash=False)
 
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
         Returns True if the FSM was advanced successfully.
         Returns False if the FSM failed to advance.
+        
+        Grammar graceful degradation: when a token is rejected (e.g.
+        enforced tokens from validation replay that conflict with the
+        grammar FSM), grammar enforcement is disabled for the rest of
+        this request instead of causing a crash.
         """
         if self._is_terminated:
             return False
+        if self._grammar_failed:
+            return True
         for token in tokens:
             if not self.matcher.accept_token(token):
-                logger.error(
-                    "Failed to advance FSM for request %s "
-                    "for tokens %s. Please file an issue.",
-                    request_id,
+                logger.warning(
+                    "Grammar rejected token %d for request %s. "
+                    "Disabling grammar enforcement for this request "
+                    "(token may be from enforced replay).",
                     token,
+                    request_id,
                 )
-                return False
+                self._grammar_failed = True
+                return True
             self.num_processed_tokens += 1
         self._is_terminated = self.matcher.is_terminated()
         return True
@@ -206,11 +216,15 @@ class XgrammarGrammar(StructuredOutputGrammar):
         return accepted_tokens
 
     def rollback(self, num_tokens: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.rollback(num_tokens)
         self.num_processed_tokens -= num_tokens
         self._is_terminated = self.matcher.is_terminated()
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.fill_next_token_bitmask(bitmask, idx)
 
     def is_terminated(self) -> bool:
@@ -218,6 +232,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def reset(self):
         self.num_processed_tokens = 0
+        self._grammar_failed = False
         self.matcher.reset()
 
 


### PR DESCRIPTION
# Corner-case fixes for vLLM 0.15 integration

## Summary

- Adds chat priority gating for PoC: when PoC generation is active, the chat completion endpoint returns 503 (`service_unavailable`) to prevent GPU contention and NCCL deadlocks. The flag is set before the generation task is created and cleared via an `add_done_callback` on the task, covering normal completion, cancellation, and failure.
- Drains in-flight inference before PoC GPU work: `poc_request` now waits for all unfinished requests to complete before issuing `collective_rpc`. This is required because `execute_poc_forward` reuses KV-cache blocks starting from block 0 — any overlap with live inference permanently corrupts model output. The drain is bounded by `timeout_ms`; on timeout, PoC is skipped with `{"skipped": True}`.
- Removes attention metadata caching in `poc_model_runner`: the metadata builder's internal state (workspace buffers, page-table references) is mutated by every inference engine step, so reusing stale metadata caused the attention backend to write only a fraction of the expected KV entries, producing all-NaN hidden states. Rebuilding costs <1 ms vs ~15 ms for the model forward.
- Adds grammar graceful degradation in xgrammar backend: when a grammar FSM rejects a token (e.g. enforced tokens from validation replay that conflict with the JSON schema), grammar enforcement is disabled for the remainder of that request instead of crashing. The `_grammar_failed` flag short-circuits `accept_tokens`, `rollback`, and `fill_bitmask`; it resets on `reset()`.
- Bakes deployment defaults into vLLM config: FlashInfer attention backend via `--attention-backend`, `processed_logprobs` as the default `--logprobs-mode`, `max_num_batched_tokens=32768` for the OpenAI API server, and a Qwen3-MoE-specific `custom_ops` compilation preset. Also forces `custom_ops=all` unconditionally instead of branching on inductor/compilation mode.
