### PR TITLE
feat: stronger seed

### DIFF
--- a/vllm/poc/config.py
+++ b/vllm/poc/config.py
@@ -20,4 +20,5 @@ class PoCConfig:
     batch_size: int = 32
     seq_len: int = 256
     k_dim: int = 12
+    poc_stronger_rng: bool = False
     callback_url: Optional[str] = None

--- a/vllm/poc/engine_patch.py
+++ b/vllm/poc/engine_patch.py
@@ -66,6 +66,7 @@ async def poc_request(self, action: str, payload: dict, timeout_ms: int = 60000)
     public_key = payload.get("public_key", "")
     seq_len = payload.get("seq_len", 256)
     k_dim = payload.get("k_dim", 12)
+    poc_stronger_rng = payload.get("poc_stronger_rng", False)
     
     if not nonces:
         return {"artifacts": []}
@@ -112,6 +113,7 @@ async def poc_request(self, action: str, payload: dict, timeout_ms: int = 60000)
                 seq_len,
                 hidden_size,
                 k_dim,
+                poc_stronger_rng,
             ),
         )
         

--- a/vllm/poc/generate_queue.py
+++ b/vllm/poc/generate_queue.py
@@ -33,6 +33,7 @@ class GenerateJob:
     seq_len: int
     k_dim: int
     batch_size: int
+    poc_stronger_rng: bool = False
     validation_artifacts: Optional[Dict[int, str]] = None
     stat_test_dist_threshold: float = DEFAULT_DIST_THRESHOLD
     stat_test_p_mismatch: float = DEFAULT_P_MISMATCH
@@ -235,6 +236,7 @@ class GenerateQueue:
                             "public_key": job.public_key,
                             "seq_len": job.seq_len,
                             "k_dim": job.k_dim,
+                            "poc_stronger_rng": job.poc_stronger_rng,
                         }),
                         timeout=POC_GENERATE_CHUNK_TIMEOUT_SEC
                     )

--- a/vllm/poc/gpu_random.py
+++ b/vllm/poc/gpu_random.py
@@ -136,6 +136,43 @@ def generate_inputs(
     return result
 
 
+def generate_inputs_concat_murmur(
+    block_hash: str,
+    public_key: str,
+    nonces: List[int],
+    dim: int,
+    seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+    """Generate deterministic input embeddings using concat-murmur (stronger RNG).
+
+    Uses all 256 bits of SHA256 by splitting into 8 × 32-bit sub-seeds.
+    Each sub-seed generates one segment of length ceil(n/8) via the existing
+    murmur3 pipeline; segments are concatenated.
+    """
+    batch_size = len(nonces)
+    result = torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
+    n = seq_len * dim
+    seg_len = (n + 7) // 8  # ceil(n/8); last segment may be shorter
+
+    for i, nonce in enumerate(nonces):
+        h = hashlib.sha256(
+            f"{block_hash}_{public_key}_nonce{nonce}".encode()
+        ).digest()
+        sub_seeds = [int.from_bytes(h[j:j + 4], 'big') for j in range(0, 32, 4)]
+
+        segments = [
+            _normal(s, min(seg_len, n - k * seg_len), device)
+            for k, s in enumerate(sub_seeds)
+            if k * seg_len < n
+        ]
+        flat = torch.cat(segments)[:n]
+        result[i] = flat.view(seq_len, dim).to(dtype)
+
+    return result
+
+
 def generate_target(
     block_hash: str,
     public_key: str,

--- a/vllm/poc/manager.py
+++ b/vllm/poc/manager.py
@@ -38,6 +38,7 @@ class PoCManager:
         nonces: List[int],
         seq_len: int,
         k_dim: int,
+        poc_stronger_rng: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Run forward pass via collective_rpc.
         
@@ -54,6 +55,7 @@ class PoCManager:
                 seq_len,
                 self.model_config.get_hidden_size(),
                 k_dim,
+                poc_stronger_rng,
             ),
         )
         
@@ -67,6 +69,7 @@ class PoCManager:
         public_key: str,
         seq_len: int,
         k_dim: int,
+        poc_stronger_rng: bool = False,
     ) -> List[Artifact]:
         """Generate artifacts for specific nonces.
         
@@ -79,6 +82,7 @@ class PoCManager:
             nonces,
             seq_len,
             k_dim,
+            poc_stronger_rng,
         )
         
         if result is None:

--- a/vllm/poc/poc_model_runner.py
+++ b/vllm/poc/poc_model_runner.py
@@ -18,6 +18,7 @@ from vllm.logger import init_logger
 
 from .gpu_random import (
     generate_inputs,
+    generate_inputs_concat_murmur,
     random_pick_indices,
     apply_haar_rotation,
 )
@@ -145,6 +146,7 @@ def execute_poc_forward(
     seq_len: int,
     hidden_size: int,
     k_dim: int = DEFAULT_K_DIM,
+    poc_stronger_rng: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Execute batched PoC forward pass on a V1 worker.
 
@@ -169,6 +171,7 @@ def execute_poc_forward(
                 "hidden_size": hidden_size,
                 "nonces": nonces,
                 "k_dim": k_dim,
+                "poc_stronger_rng": poc_stronger_rng,
             }, src=0)
         else:
             broadcast_data = broadcast_tensor_dict(src=0)
@@ -177,6 +180,7 @@ def execute_poc_forward(
             nonces = list(broadcast_data["nonces"])
             k_dim = int(broadcast_data["k_dim"])
             batch_size = len(nonces)
+            poc_stronger_rng = bool(broadcast_data["poc_stronger_rng"])
 
     pp_group = get_pp_group()
 
@@ -219,7 +223,8 @@ def execute_poc_forward(
                 del vals
             inputs_embeds = kv_scratch
         else:
-            inputs_embeds = generate_inputs(
+            _gen_fn = generate_inputs_concat_murmur if poc_stronger_rng else generate_inputs
+            inputs_embeds = _gen_fn(
                 block_hash, public_key, nonces,
                 dim=hidden_size, seq_len=seq_len,
                 device=device, dtype=dtype,

--- a/vllm/poc/routes.py
+++ b/vllm/poc/routes.py
@@ -57,6 +57,7 @@ class PoCInitGenerateRequest(BaseModel):
     batch_size: int = POC_BATCH_SIZE_DEFAULT
     params: PoCParamsModel
     url: Optional[str] = None
+    poc_stronger_rng: bool = False
 
 
 @dataclass
@@ -111,6 +112,7 @@ class PoCGenerateRequest(BaseModel):
     url: Optional[str] = None
     validation: Optional[ValidationModel] = None
     stat_test: Optional[StatTestModel] = None
+    poc_stronger_rng: bool = False
 
 
 # =============================================================================
@@ -229,6 +231,7 @@ async def _compute_artifacts_chunk(
     public_key: str,
     seq_len: int,
     k_dim: int,
+    poc_stronger_rng: bool = False,
     timeout_sec: float = POC_GENERATE_CHUNK_TIMEOUT_SEC,
     check_cancelled: Optional[callable] = None,
 ) -> List[Dict]:
@@ -245,6 +248,7 @@ async def _compute_artifacts_chunk(
             "public_key": public_key,
             "seq_len": seq_len,
             "k_dim": k_dim,
+            "poc_stronger_rng": poc_stronger_rng,
         })
         
         if not result.get("skipped"):
@@ -299,6 +303,7 @@ async def _generation_loop(
                         "public_key": config["public_key"],
                         "seq_len": config["seq_len"],
                         "k_dim": config["k_dim"],
+                        "poc_stronger_rng": config["poc_stronger_rng"],
                     },
                     timeout_ms=POC_RPC_TIMEOUT_MS
                 )
@@ -356,7 +361,7 @@ async def _generation_loop(
 @router.post("/init/generate")
 async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
     global _poc_generation_active
-    logger.info(f"PoC /init/generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.group_id}, {body.n_groups}, {body.batch_size}, {body.params}, {body.url}")
+    logger.info(f"PoC /init/generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.group_id}, {body.n_groups}, {body.batch_size}, {body.params}, {body.url}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
 
@@ -378,6 +383,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
         "batch_size": body.batch_size,
         "seq_len": body.params.seq_len,
         "k_dim": body.params.k_dim,
+        "poc_stronger_rng": body.poc_stronger_rng,
     }
     
     stats = {"start_time": 0, "total_processed": 0}
@@ -425,7 +431,7 @@ async def init_generate(request: Request, body: PoCInitGenerateRequest) -> dict:
 
 @router.post("/generate")
 async def generate(request: Request, body: PoCGenerateRequest) -> dict:
-    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {body.validation}, {body.stat_test}")
+    logger.info(f"PoC /generate: {body.block_hash}, {body.block_height}, {body.public_key}, {body.node_id}, {body.node_count}, {body.nonces}, {body.params}, {body.batch_size}, {body.wait}, {body.url}, {body.validation}, {body.stat_test}, {body.poc_stronger_rng}")
     check_params_match(request, body.params)
     engine_client = await get_engine_client(request)
     
@@ -462,6 +468,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
             seq_len=body.params.seq_len,
             k_dim=body.params.k_dim,
             batch_size=body.batch_size,
+            poc_stronger_rng=body.poc_stronger_rng,
             validation_artifacts=validation_map,
             stat_test_dist_threshold=stat_test.dist_threshold,
             stat_test_p_mismatch=stat_test.p_mismatch,
@@ -503,7 +510,7 @@ async def generate(request: Request, body: PoCGenerateRequest) -> dict:
         try:
             artifacts = await _compute_artifacts_chunk(
                 engine_client, chunk, body.block_hash, body.public_key,
-                body.params.seq_len, body.params.k_dim,
+                body.params.seq_len, body.params.k_dim, body.poc_stronger_rng,
                 POC_GENERATE_CHUNK_TIMEOUT_SEC, check_cancelled
             )
             computed_artifacts.extend(artifacts)


### PR DESCRIPTION
## Purpose

Fixes gonka-ai/gonka#926.

The previous `_seed_from_string` used only the first 32 bits of a SHA256 digest, leaving a small enough seed space that an attacker could forge proofs by finding collisions in ~2^32 SHA256 evaluations - allowing a single model run to be submitted as multiple nodes' outputs with different nonces.

**Changes:**

- Add `generate_inputs_concat_murmur`: splits the full 256-bit SHA256 digest into 8 × 32-bit sub-seeds, runs each through the existing murmur3 -> Box-Muller pipeline, and concatenates segments. Forging a proof now requires a full SHA256 collision (~2^128 work).
- Add `poc_stronger_rng` boolean flag (default `False`) threaded from `/init/generate` and `/generate` request bodies all the way down to input generation function selection, enabling governance-controlled activation.
- Include `poc_stronger_rng` in request log lines for auditability.

## Test Plan
```bash
# New function correctness
pytest tests/poc/test_gpu_random.py -k "concat_murmur" -v

# Flag propagation through API layer (no GPU needed)
pytest tests/poc/test_routes.py -k "poc_stronger_rng" -v
# Full routes suite
pytest tests/poc/test_routes.py -v
```
Cross-GPU validation: generated artifacts on one GPU architecture and validated on another (64 nonces each direction). Model - `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`, `seq_len = 1024`, `k_dim=12`. Both directions show `fraud_detected: false` with p_value=0.999, confirming the concat_murmur pipeline is deterministic across GPU architectures:                                                                               

| Generator | Validator | n_total | n_mismatch | p_value | fraud_detected |
|-----------|-----------|---------|------------|---------|----------------|
| A100      | H200      | 64      | 1          | 0.9988  | false          |
| H200      | A100      | 64      | 1          | 0.9988  | false          |