### PR TITLE
fix: poc_stronger_rng ignored when KV scratch buffer available

### DIFF
--- a/vllm/poc/gpu_random.py
+++ b/vllm/poc/gpu_random.py
@@ -7,7 +7,7 @@ OPTIMIZED: Serial Python loops replaced with batched GPU operations.
 """
 import hashlib
 import math
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -124,10 +124,16 @@ def generate_inputs(
     seq_len: int,
     device: torch.device,
     dtype: torch.dtype = torch.float16,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Generate deterministic input embeddings for PoC."""
+    """Generate deterministic input embeddings for PoC.
+
+    If ``out`` is provided it must be a pre-allocated tensor of shape
+    ``(len(nonces), seq_len, dim)``; results are written into it in-place
+    to avoid an extra GPU allocation.
+    """
     batch_size = len(nonces)
-    result = torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
+    result = out if out is not None else torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
     for i, nonce in enumerate(nonces):
         seed_str = f"{block_hash}_{public_key}_nonce{nonce}"
         seed = _seed_from_string(seed_str)
@@ -144,15 +150,19 @@ def generate_inputs_concat_murmur(
     seq_len: int,
     device: torch.device,
     dtype: torch.dtype = torch.float16,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Generate deterministic input embeddings using concat-murmur (stronger RNG).
 
     Uses all 256 bits of SHA256 by splitting into 8 × 32-bit sub-seeds.
     Each sub-seed generates one segment of length ceil(n/8) via the existing
     murmur3 pipeline; segments are concatenated.
+
+    If ``out`` is provided it must be a pre-allocated tensor of shape
+    ``(len(nonces), seq_len, dim)``; results are written into it in-place.
     """
     batch_size = len(nonces)
-    result = torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
+    result = out if out is not None else torch.empty(batch_size, seq_len, dim, device=device, dtype=dtype)
     n = seq_len * dim
     seg_len = (n + 7) // 8  # ceil(n/8); last segment may be shorter
 

--- a/vllm/poc/poc_model_runner.py
+++ b/vllm/poc/poc_model_runner.py
@@ -206,29 +206,21 @@ def execute_poc_forward(
 
     if pp_group.is_first_rank:
         kv_caches = getattr(worker.model_runner, "kv_caches", [])
-        kv_scratch = None
+        out_tensor = None
         needed_elems = batch_size * seq_len * hidden_size
         for kv in kv_caches:
             if kv.numel() >= needed_elems:
-                kv_scratch = kv.flatten()[:needed_elems].view(
+                out_tensor = kv.flatten()[:needed_elems].view(
                     batch_size, seq_len, hidden_size)
                 break
-        if kv_scratch is not None:
-            from .gpu_random import _seed_from_string, _normal
-            for i, nonce in enumerate(nonces):
-                seed = _seed_from_string(
-                    f"{block_hash}_{public_key}_nonce{nonce}")
-                vals = _normal(seed, seq_len * hidden_size, device)
-                kv_scratch[i].copy_(vals.view(seq_len, hidden_size).to(dtype))
-                del vals
-            inputs_embeds = kv_scratch
-        else:
-            _gen_fn = generate_inputs_concat_murmur if poc_stronger_rng else generate_inputs
-            inputs_embeds = _gen_fn(
-                block_hash, public_key, nonces,
-                dim=hidden_size, seq_len=seq_len,
-                device=device, dtype=dtype,
-            )
+
+        _gen_fn = generate_inputs_concat_murmur if poc_stronger_rng else generate_inputs
+        inputs_embeds = _gen_fn(
+            block_hash, public_key, nonces,
+            dim=hidden_size, seq_len=seq_len,
+            device=device, dtype=dtype,
+            out=out_tensor,
+        )
     else:
         intermediate_tensors = IntermediateTensors(
             pp_group.recv_tensor_dict(all_gather_group=get_tp_group())


### PR DESCRIPTION
## Purpose

When a KV cache slab was large enough to use as scratch, the code took a separate branch that hand-rolled the old murmur3 loop, bypassing generate_inputs_concat_murmur entirely. So poc_stronger_rng=True had no effect in that path.

Fix: add out= param to both gen functions and always route through them, passing the scratch slab when available.