### PR TITLE
poc: reject bad batches with os._exit(1)

### DIFF
--- a/vllm/poc/poc_model_runner.py
+++ b/vllm/poc/poc_model_runner.py
@@ -5,6 +5,7 @@ Uses actual KV cache blocks for attention to work correctly.
 Batched forward pass — processes all nonces in a single forward call.
 """
 import math
+import os
 import torch
 import torch.distributed as dist
 import numpy as np
@@ -27,6 +28,17 @@ from .layer_hooks import LayerHouseholderHook, poc_forward_context
 logger = init_logger(__name__)
 
 DEFAULT_K_DIM = 12
+_NAN_KILL_THRESHOLD = int(os.environ.get("POC_NAN_KILL_THRESHOLD", "3"))
+
+
+def _reject_bad_batch(worker, reason: str, bad_count: int, batch_size: int) -> dict:
+    worker._poc_bad_batches = getattr(worker, "_poc_bad_batches", 0) + 1
+    logger.error(f"NaN/Inf in {bad_count}/{batch_size} {reason} - batch rejected "
+                 f"[{worker._poc_bad_batches}/{_NAN_KILL_THRESHOLD} consecutive]")
+    if worker._poc_bad_batches >= _NAN_KILL_THRESHOLD:
+        logger.critical(f"Persistent GPU fault: {worker._poc_bad_batches} consecutive bad batches — exiting")
+        os._exit(1)
+    return {"nonces": [], "vectors": []}
 
 # NOTE: attention metadata must NOT be cached across PoC calls.
 # The metadata builder's internal state (workspace buffers, page-table
@@ -264,20 +276,11 @@ def execute_poc_forward(
     hidden_states = hidden_states.view(batch_size, seq_len, -1)
     last_hidden = hidden_states[:, -1, :].float()  # [batch_size, hidden_size]
 
-    # NaN detection
-    nan_mask = torch.isnan(last_hidden).any(dim=-1)  # [batch_size]
-    if nan_mask.any():
-        clean_idx = (~nan_mask).nonzero(as_tuple=True)[0]
-        nan_count = nan_mask.sum().item()
-        logger.warning("NaN in %d/%d hidden states (GPU fault?)", nan_count, batch_size)
-
-        if clean_idx.numel() == 0:
-            logger.error("All %d nonces produced NaN — batch rejected", batch_size)
-            return {"nonces": [], "vectors": np.empty((0, k_dim), dtype=np.float16)}
-
-        last_hidden = last_hidden[clean_idx]
-        nonces = [nonces[i] for i in clean_idx.tolist()]
-        batch_size = len(nonces)
+    # Reject entire batch on any NaN/Inf — matches Go validator ValidateFP16Vector
+    # which treats exponent==0x1f (NaN or Inf) as permanent failure.
+    if not torch.isfinite(last_hidden).all():
+        bad_count = (~torch.isfinite(last_hidden).all(dim=-1)).sum().item()
+        return _reject_bad_batch(worker, "hidden states", bad_count, batch_size)
 
     # Normalize to unit sphere
     last_hidden = last_hidden / (last_hidden.norm(dim=-1, keepdim=True) + 1e-8)
@@ -293,13 +296,12 @@ def execute_poc_forward(
     # Convert to FP16
     vectors_f16 = yk.half().cpu().numpy()  # [batch_size, k_dim]
 
-    # Late NaN check after FP16 conversion
-    nan_out = np.isnan(vectors_f16).any(axis=1)
-    if nan_out.any():
-        clean = ~nan_out
-        vectors_f16 = vectors_f16[clean]
-        nonces = [n for n, c in zip(nonces, clean) if c]
-        logger.warning("NaN in FP16 output — %d nonces filtered", nan_out.sum())
+    # Reject entire batch if FP16 conversion produced any NaN or Inf.
+    if not np.isfinite(vectors_f16).all():
+        bad_count = int((~np.isfinite(vectors_f16).all(axis=1)).sum())
+        return _reject_bad_batch(worker, "FP16 vectors", bad_count, batch_size)
+
+    worker._poc_bad_batches = 0
 
     return {
         "nonces": nonces,


### PR DESCRIPTION



## Purpose

Replace per-sequence NaN filtering with whole-batch rejection — sequences share one forward pass so partial corruption means the entire batch is suspect.
Add Inf detection (`isfinite` instead of `isnan`) to match Go's `ValidateFP16Vector` which rejects exponent==0x1f.

## Testing

Checked following code:
```python
import numpy as np
import torch


def test_float32_large_passes_check1_fails_check2():
    """float32 value > float16 max (65504) is finite in float32 but overflows to Inf in float16.
    check1 (torch.isfinite on float32) misses it; check2 (np.isfinite on float16) catches it."""
    x = torch.tensor([[70000.0, 1.0]])  # 70000 > 65504
    assert torch.isfinite(x).all()
    assert not np.isfinite(x.half().cpu().numpy()).all()


def test_float16_nan_0x7fff_caught_by_numpy():
    """0x7fff is the float16 bit pattern for NaN (exp=0x1f, mantissa≠0).
    np.isfinite on a float16 array correctly returns False for it."""
    f16_nan = np.frombuffer(bytes([0xff, 0x7f]), dtype=np.float16)
    assert not np.isfinite(f16_nan).all()


def test_float16_inf_0x7c00_caught_by_numpy():
    """+Inf in float16 (exp=0x1f, mantissa=0)."""
    f16_inf = np.frombuffer(bytes([0x00, 0x7c]), dtype=np.float16)
    assert not np.isfinite(f16_inf).all()


def test_after_normalization_float16_overflow_impossible():
    """Normalization to unit sphere constrains all components to [-1, 1],
    making float16 overflow structurally impossible (float16 max is 65504)."""
    x = torch.tensor([[70000.0, -500.0, 1.0]])
    x_normed = x / (x.norm(dim=-1, keepdim=True) + 1e-8)
    assert x_normed.abs().max() <= 1.0
    assert np.isfinite(x_normed.half().cpu().numpy()).all()


def test_model_nan_caught_by_check1():
    """NaN from the model forward pass is caught by torch.isfinite before any further processing."""
    x = torch.tensor([[float("nan"), 1.0, 2.0],
                      [1.0, 2.0, 3.0]])
    assert not torch.isfinite(x).all()
```
