### PR TITLE
perf: compile apply_householder with torch.compile (+10-12% PoC nonces/min)

### DIFF
--- a/vllm/poc/gpu_random.py
+++ b/vllm/poc/gpu_random.py
@@ -200,6 +200,7 @@ def generate_householder_vector(
     return v / v.norm()
 
 
+@torch.compile(dynamic=False, fullgraph=True)
 def apply_householder(
     x: torch.Tensor,
     v: torch.Tensor,


### PR DESCRIPTION
Targets `tg/scratchpad_for_mode` (head branch of #24) so the optimization lands as part of the v0.15.1 work.

## Summary

Wrap `apply_householder()` in `vllm/poc/gpu_random.py` with `@torch.compile(dynamic=False, fullgraph=True)`. One-line change.

## Why it helps

`apply_householder` is called 188× per PoC forward (94 layers × 2 tensors per layer). In eager mode each call dispatches 5 separate CUDA kernels:

```
out = (x * v).sum(dim=-1, keepdim=True)      # mul + sum
out = x - 2 * out * v                         # mul + mul + sub
```

Each kernel reads/writes the full activation tensor through HBM. With Qwen3-235B at typical PoC dims, that's ~2.3 GB of HBM I/O per call.

`torch.compile` (TorchInductor + Triton) fuses all 5 ops into a single kernel: one read of `x`, one read of `v`, one write of the result. HBM traffic drops to ~670 MB per call (~3.4× reduction). Since the op is memory-bound on B200/H100, runtime drops proportionally.

`fullgraph=True` ensures we get a single fused kernel (no graph breaks). `dynamic=False` lets Inductor specialize on the static shapes used in PoC, which gives a tighter kernel than dynamic-shape code.

## Measured impact

Same model, same hardware, same vLLM/CUDA versions, no other changes:

| GPU | Config | Baseline (n/min) | Patched (n/min) | Delta |
|---|---|---|---|---|
| 8×B200 | Qwen3-235B-FP8, TP=2 × 4 instances | 6,272 | 6,912 | **+10.2%** |
| 8×H100 | Qwen3-235B-FP8, TP=4 × 2 instances | 2,560 | 2,880 | **+12.5%** |

A/B done with pristine extraction of the unpatched file from the upstream image, so both runs use identical builds aside from this decorator.

## Correctness

`@torch.compile` is semantics-preserving for this function — pure tensor math, no Python-side state, no in-place mutation, no control flow. Output of compiled vs eager is bitwise-identical for the dtypes used in PoC (verified on FP16 and FP32 inputs).

## Things considered, not done

Other functions in `gpu_random.py` (`_batched_murmur3_32`, `_batched_normal`, etc.) are also compileable but the per-PoC-batch call count is small (1-N vs 188×) so realistic upper bound is <1% additional, not worth the surface area increase.

`mode="reduce-overhead"` (CUDA Graphs) was tested and rejected — caused output-tensor aliasing errors in the multi-instance setup. Default mode (no CUDA Graphs) gives the gain cleanly.

## Test plan

- [x] Output bitwise-equivalence vs eager
- [x] B200 throughput measurement (8 GPUs, 2-min steady-state, 3 trials)
- [x] H100 throughput measurement (8 GPUs, 2-min steady-state, 3 trials)
- [ ] CI green