### PR TITLE
fix(distributed): enlarge shm MessageQueue rings max_chunks -> 64

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -385,7 +385,7 @@ class GroupCoordinator:
         self.mq_broadcaster: MessageQueue | None = None
         if use_message_queue_broadcaster and self.world_size > 1:
             self.mq_broadcaster = MessageQueue.create_from_process_group(
-                self.cpu_group, 1 << 22, 6
+                self.cpu_group, 1 << 22, 64
             )
 
         # TODO(#35915): Remove is_tpu() check once tpu_inference
@@ -408,7 +408,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             writer_rank=writer_rank,
             external_writer_handle=external_writer_handle,
             blocking=blocking,
@@ -422,7 +422,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group_single_reader(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             reader_rank=self.ranks[reader_rank_in_group],
             blocking=blocking,
         )

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -151,6 +151,10 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
+                # 64 (default 10): a briefly-slow TP reader starves the writer
+                # (EngineCore) under burst load -> "No available shared memory
+                # broadcast block" engine stalls. Costs 64 x 16 MiB /dev/shm.
+                max_chunks=64,
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()


### PR DESCRIPTION
## What
`max_chunks` → 64 on two shm ring families:
- **`multiproc_executor.py` — `rpc_broadcast_mq`** (per-step SchedulerOutput ring, default 10). Its writer is the EngineCore process that tags every production stall warning — the primary starving ring. +~1 GiB /dev/shm per engine (16 MiB chunks).
- **`parallel_state.py` — GroupCoordinator object-broadcast rings** (3 call sites, was 6). 24 MiB → 256 MiB per ring.

Worker response rings stay at default: single dedicated reader in a tight loop, no starvation evidence.

## Why
Under TP load a briefly-slow reader stops draining a ring; the writer starves (`No available shared memory broadcast block found in 60s`) → engine step stalls → `EngineDeadError` past the execute-model timeout → restart, dropping in-flight requests.

## Evidence
4×B300 Kimi-K2.6 fleet (TP=4, eager), days of production data: engine-death cascades dropped from ~every 35 min to ~every 2–3 h with the parallel_state rings alone; the executor ring was extended after residual stall warnings kept carrying the EngineCore pid. Honest scope: this is a **mitigation** — rarer stall episodes have since been observed even at near-idle (Running≤3) with both rings at 64, so a deeper engine-level cause remains; a scheduler-liveness watchdog on the mlnode side stays required (companion PR in gonka-ai/gonka).

## Notes
- /dev/shm floor rises ~1.3 GiB per engine; an undersized tmpfs fails as SIGBUS under load, not at startup.
- Deeper ring → the writer-side 60 s warning fires later for a permanently wedged reader.
- The same constants exist on the 0.23 lineage; this commit cherry-picks cleanly there.