### PR TITLE
feat(sampling): reproducible deterministic sampling + validator replay (Stage-1), non-enforcing shadow path

### DIFF
--- a/scripts/gen_conformance_vectors.py
+++ b/scripts/gen_conformance_vectors.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Generate the cross-language conformance vectors for deterministic sampling.
+
+These vectors are the executable form of the deterministic-sampling contract
+(gonka-ai/gonka#1199). The vLLM Python pipeline and the gonka Go validator must
+both reproduce them bit-for-bit. Run:
+
+    python scripts/gen_conformance_vectors.py
+
+Writes tests/v1/validation/conformance_vectors.json (deterministic output;
+diff-review it like any other checked-in artifact). Pure CPU, no torch/GPU:
+the module is loaded by file path so a built vLLM env is not required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import struct
+import sys
+from typing import Dict, Optional
+
+CONTRACT_VERSION = "1.0.0"
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DU_PATH = os.path.join(_REPO_ROOT, "vllm", "v1", "sample", "deterministic_utils.py")
+_OUT_PATH = os.path.join(
+    _REPO_ROOT, "tests", "v1", "validation", "conformance_vectors.json"
+)
+
+
+def _load_du():
+    """Load deterministic_utils by path (avoids importing the vllm package)."""
+    spec = importlib.util.spec_from_file_location("deterministic_utils", _DU_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve cls.__module__.
+    sys.modules["deterministic_utils"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+du = _load_du()
+
+
+def _canonical(f: float) -> str:
+    """The one float->string conversion (contract §1)."""
+    return repr(f)
+
+
+def _f32_widened(f: float) -> float:
+    """float32 value widened to float64 (what the model actually emits)."""
+    return struct.unpack("f", struct.pack("f", f))[0]
+
+
+# Each case: fixed inputs -> the reference pipeline computes the outputs.
+# logprobs are already canonical strings (contract §1).
+_CASES = [
+    {
+        "name": "single_token",
+        "logprobs": {"791": "-0.05"},
+        "temperature": "1.0",
+    },
+    {
+        "name": "three_token_plain",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1"},
+        "temperature": "1.0",
+    },
+    {
+        "name": "two_token_near_tie",
+        # ln(0.5) for both -> equal probabilities; RNG breaks the tie.
+        "logprobs": {"5": "-0.6931471805599453", "7": "-0.6931471805599453"},
+        "temperature": "1.0",
+    },
+    {
+        "name": "top_k_truncation",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1", "9": "-1.0"},
+        "temperature": "1.0",
+        "top_k": 2,
+    },
+    {
+        "name": "top_p_nucleus",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1", "9": "-1.0"},
+        "temperature": "1.0",
+        "top_p": "0.9",
+    },
+    {
+        "name": "min_p_filter",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1", "9": "-1.0"},
+        "temperature": "1.0",
+        "min_p": "0.05",
+    },
+    {
+        "name": "temperature_small",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1"},
+        "temperature": "0.1",
+    },
+    {
+        "name": "temperature_large",
+        "logprobs": {"791": "-0.05", "1": "-3.2", "5": "-2.1"},
+        "temperature": "2.0",
+    },
+    {
+        "name": "float32_widened_logprob",
+        # The producer would emit repr(f32->f64); pin that exact string here.
+        "logprobs": {"791": _canonical(_f32_widened(-0.05)), "1": "-3.0"},
+        "temperature": "0.7",
+    },
+    {
+        "name": "ten_tokens",
+        "logprobs": {
+            str(t): _canonical(-0.1 * (i + 1))
+            for i, t in enumerate([3, 10, 42, 100, 256, 512, 777, 1024, 2048, 4096])
+        },
+        "temperature": "0.8",
+        "top_p": "0.95",
+    },
+]
+
+# Every case is replayed under this fixed seed string (seed composition is S1,
+# out of scope for this contract; here it is an opaque input).
+_SEED_STR = "42|[1,2,3]"
+
+
+def _run_case(case: Dict) -> Dict:
+    logprobs: Dict[str, str] = case["logprobs"]
+    temperature: str = case["temperature"]
+    top_p: Optional[str] = case.get("top_p")
+    top_k: Optional[int] = case.get("top_k")
+    min_p: Optional[str] = case.get("min_p")
+
+    weights = du.logprobs_to_weights(
+        logprobs, temperature, top_p=top_p, top_k=top_k, min_p=min_p
+    )
+    rng = du.Sha256CounterRNG.from_seed_string(_SEED_STR)
+    token = du.decimal_sample_from_logprobs(
+        logprobs, rng, temperature, top_p=top_p, top_k=top_k, min_p=min_p
+    )
+    out = {
+        "name": case["name"],
+        "logprobs": logprobs,
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "min_p": min_p,
+        "seed_str": _SEED_STR,
+        "expected_weights": {tid: int(w) for tid, w in sorted(weights.items())},
+        "expected_weight_sum": int(sum(weights.values())),
+        "expected_token": token,
+    }
+    return out
+
+
+def _iter_uint64_below(seed: str, n: int, count: int) -> list:
+    """A sequence of unbiased [0, n) draws from a fresh RNG (contract §6)."""
+    rng = du.Sha256CounterRNG.from_seed_string(seed)
+    return [du.uint64_below(rng, n) for _ in range(count)]
+
+
+def build() -> Dict:
+    rng_ref_seed = "reference_seed_v1"
+    doc = {
+        "contract_version": CONTRACT_VERSION,
+        "decimal": {"prec": 10, "rounding": "ROUND_HALF_EVEN"},
+        "weight_scale": du.WEIGHT_SCALE,
+        "rng_reference": {
+            "seed": rng_ref_seed,
+            "first_u64": du.iter_u64(rng_ref_seed, 5),
+        },
+        "float_to_string": [
+            {
+                "description": "plain -0.05 as float64",
+                "repr": _canonical(-0.05),
+            },
+            {
+                "description": "-0.05 as float32 widened to float64",
+                "repr": _canonical(_f32_widened(-0.05)),
+            },
+            {
+                "description": "0.1 as float32 widened to float64",
+                "repr": _canonical(_f32_widened(0.1)),
+            },
+        ],
+        "cases": [_run_case(c) for c in _CASES],
+        # Unbiased categorical draw (contract §6). The pipeline always produces
+        # weights summing to 2^16 (a power of 2), so uint64_below never rejects
+        # there; these non-power-of-2 moduli exercise the limit + modulo path and
+        # pin it cross-language.
+        "uint64_below": {
+            "seed": rng_ref_seed,
+            "count": 8,
+            "cases": [
+                {"n": n, "draws": _iter_uint64_below(rng_ref_seed, n, 8)}
+                for n in [3, 10, 1000, 65537, 999983]
+            ],
+        },
+        # Chain-bound seed derivation (gonka-ai/vllm#56). Independently versioned
+        # via its own domain tag; the Go validator must reproduce these digests
+        # and reject the same invalid inference ids.
+        "seed_derivation": {
+            # Pinned contract value (must match deterministic_utils._SEED_DOMAIN_TAG;
+            # the accept digests below are derived through it, so drift is caught).
+            "domain_tag": "gonka-deterministic-sampling-v1",
+            "accept": [
+                {"user_seed": us, "inference_id": iid,
+                 "expected_seed": du.derive_chain_bound_seed(us, iid)}
+                for us, iid in [
+                    (7, "chain-abc"),               # pinned golden vector
+                    (7, "chain-xyz"),               # domain separation vs above
+                    (42, "devshard-escrow1-100"),   # devshard-style id
+                    (-1, "chain-abc"),              # negative seed
+                    (2**63 - 1, "x"),               # int64 max boundary
+                ]
+            ],
+            # Must fail closed on both sides (Go seed is int64, so only the
+            # inference-id rules are cross-language-relevant here).
+            "reject_inference_id": [
+                {"inference_id": "", "reason": "empty"},
+                {"inference_id": " chain-abc ", "reason": "whitespace (space is 0x20, below 0x21)"},
+                {"inference_id": "chain\tabc", "reason": "control char (tab)"},
+                {"inference_id": "chain-é", "reason": "non-ASCII"},
+                {"inference_id": "x" * 257, "reason": "too long (>256)"},
+            ],
+        },
+    }
+    return doc
+
+
+def main() -> None:
+    doc = build()
+    os.makedirs(os.path.dirname(_OUT_PATH), exist_ok=True)
+    with open(_OUT_PATH, "w") as fh:
+        json.dump(doc, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    print(f"wrote {_OUT_PATH}")
+    print(f"  contract_version={doc['contract_version']} cases={len(doc['cases'])}")
+    for c in doc["cases"]:
+        assert c["expected_weight_sum"] == du.WEIGHT_SCALE, c["name"]
+        print(f"  {c['name']:24} -> token={c['expected_token']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_conformance_vectors.py
+++ b/scripts/gen_conformance_vectors.py
@@ -45,6 +45,37 @@ def _load_du():
 du = _load_du()
 
 
+def _load_validation_sampling():
+    """Load validation_sampling by path so the generator can compute the
+    reference *sequence* verdicts and distances (stubs the vllm package tree so
+    its ``from vllm.v1.sample.deterministic_utils import ...`` resolves to du)."""
+    import types
+    for pkg in ("vllm", "vllm.v1", "vllm.v1.sample"):
+        sys.modules.setdefault(pkg, types.ModuleType(pkg))
+    sys.modules["vllm.v1.sample.deterministic_utils"] = du
+    sys.modules["vllm.v1.sample"].deterministic_utils = du
+    path = os.path.join(_REPO_ROOT, "vllm", "validation_sampling.py")
+    spec = importlib.util.spec_from_file_location("validation_sampling", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["validation_sampling"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vs = _load_validation_sampling()
+SEED_DOMAIN = "gonka-deterministic-sampling-v1"
+
+
+class _Tok:
+    """Duck-typed EnforcedToken stand-in (verify_sequence reads .token/.logprobs)."""
+
+    __slots__ = ("token", "logprobs")
+
+    def __init__(self, token, logprobs):
+        self.token = token
+        self.logprobs = logprobs
+
+
 def _canonical(f: float) -> str:
     """The one float->string conversion (contract §1)."""
     return repr(f)
@@ -159,6 +190,123 @@ def _iter_uint64_below(seed: str, n: int, count: int) -> list:
     return [du.uint64_below(rng, n) for _ in range(count)]
 
 
+# ---------------------------------------------------------------------------- #
+# Sequence-level cases: pin the per-position seed composition (``base|pos``),
+# the three-valued aggregation, and the unbounded/greedy/version gates. The
+# reference (validation_sampling.verify_sequence) computes the expected verdict.
+# ---------------------------------------------------------------------------- #
+
+_SEQ_LOGPROBS = [
+    {"5": "-0.5", "10": "-1.2", "2": "-2.5", "100": "-3.9", "7": "-4.1"},
+    {"3": "-0.3", "42": "-1.1", "9": "-2.2", "11": "-3.0", "1": "-4.5"},
+    {"8": "-0.7", "6": "-1.5", "4": "-2.0", "20": "-2.9", "15": "-3.3"},
+]
+_SEQ_BASE_SEED = "42|[1,2,3]"
+
+_SEQ_CASES = [
+    {"name": "honest_top_k", "top_k": 20},
+    {"name": "honest_min_p", "min_p": "0.02"},
+    {"name": "fraud_at_pos_1", "top_k": 20, "tamper": {"pos": 1, "token": "999999"}},
+    {"name": "honest_with_missing_position", "top_k": 20, "drop": [1]},
+    {"name": "inconclusive_unbounded_top_p", "top_p": "0.9"},  # no top_k/min_p
+    {"name": "inconclusive_greedy", "top_k": 20, "greedy": True, "temperature": "0"},
+    {"name": "inconclusive_bad_version", "top_k": 20, "contract_version": "9.9.9"},
+]
+
+
+def _honest_token(logprobs, pos, temperature, top_p, top_k, min_p):
+    rng = du.Sha256CounterRNG.from_seed_string(f"{_SEQ_BASE_SEED}|{pos}")
+    return du.decimal_sample_from_logprobs(
+        logprobs, rng, temperature, top_p=top_p, top_k=top_k, min_p=min_p)
+
+
+def _run_seq_case(case: Dict) -> Dict:
+    temperature = case.get("temperature", "1.0")
+    top_p = case.get("top_p")
+    top_k = case.get("top_k")
+    min_p = case.get("min_p")
+    greedy = case.get("greedy", False)
+    version = case.get("contract_version", CONTRACT_VERSION)
+    drop = set(case.get("drop", []))
+    tamper = case.get("tamper")
+
+    # Only cases that actually replay (bounded, non-greedy, supported version)
+    # need honest tokens; the gated cases short-circuit before touching them.
+    replays = (not greedy and version == CONTRACT_VERSION
+               and vs._support_is_bounded(top_k, min_p))
+
+    # The vector stores logprobs as canonical strings (contract §1) for the Go
+    # side. verify_sequence takes floats (production EnforcedToken.logprobs) and
+    # re-canonicalizes via repr; since repr(float(canonical)) == canonical, both
+    # sides see the identical strings.
+    positions_out = []
+    toks = []
+    for i, lp_str in enumerate(_SEQ_LOGPROBS):
+        if i in drop:
+            positions_out.append({"logprobs": None, "reported_token": ""})
+            toks.append(_Tok("", None))
+            continue
+        lp_float = {tid: float(s) for tid, s in lp_str.items()}
+        if replays:
+            tok = _honest_token(lp_str, i, temperature, top_p, top_k, min_p)
+        else:
+            tok = next(iter(lp_str))  # placeholder; never replayed
+        if tamper and tamper["pos"] == i:
+            tok = tamper["token"]
+        positions_out.append({"logprobs": lp_str, "reported_token": tok})
+        toks.append(_Tok(tok, lp_float))
+
+    result = vs.verify_sequence(
+        toks, _SEQ_BASE_SEED, temperature,
+        top_p=top_p, top_k=top_k, min_p=min_p,
+        contract_version=version, greedy=greedy)
+
+    return {
+        "name": case["name"],
+        "base_seed": _SEQ_BASE_SEED,
+        "contract_version": version,
+        "seed_domain": SEED_DOMAIN,
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "min_p": min_p,
+        "greedy": greedy,
+        "positions": positions_out,
+        "expected": {
+            "verdict": result.verdict.value,
+            "fraud_position": result.fraud_position,
+            "n_honest": result.n_honest,
+            "n_inconclusive": result.n_inconclusive,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------- #
+# Distance cases: pin the Stage-2 MAE-over-support metric.
+# ---------------------------------------------------------------------------- #
+
+_DIST_P0 = {"5": -0.5, "10": -1.2, "2": -2.5, "100": -3.9, "7": -4.1}
+_DIST_P1 = {"3": -0.3, "42": -1.1, "9": -2.2, "11": -3.0, "1": -4.5}
+_DIST_P0_SHIFTED = {t: v - 0.5 for t, v in _DIST_P0.items()}
+_DIST_P0_PARTIAL = {t: v for t, v in list(_DIST_P0.items())[:-1]}  # drop one token
+
+_DIST_CASES = [
+    {"name": "identical", "executor": [_DIST_P0], "validator": [_DIST_P0]},
+    {"name": "uniform_shift", "executor": [_DIST_P0], "validator": [_DIST_P0_SHIFTED]},
+    {"name": "length_mismatch", "executor": [_DIST_P0, _DIST_P1], "validator": [_DIST_P0]},
+    {"name": "missing_token", "executor": [_DIST_P0], "validator": [_DIST_P0_PARTIAL]},
+]
+
+
+def _run_dist_case(case: Dict) -> Dict:
+    return {
+        "name": case["name"],
+        "executor": case["executor"],
+        "validator": case["validator"],
+        "expected_mae": vs.mae_distance(case["executor"], case["validator"]),
+    }
+
+
 def build() -> Dict:
     rng_ref_seed = "reference_seed_v1"
     doc = {
@@ -224,6 +372,13 @@ def build() -> Dict:
                 {"inference_id": "x" * 257, "reason": "too long (>256)"},
             ],
         },
+        # Sequence-level replay: per-position seed composition + three-valued
+        # aggregation + unbounded/greedy/version gates (validation_sampling.
+        # verify_sequence / detsample.VerifySequence).
+        "sequence_cases": [_run_seq_case(c) for c in _SEQ_CASES],
+        # Stage-2 MAE-over-support distance (validation_sampling.mae_distance /
+        # detsample.MAEDistance).
+        "distance_cases": [_run_dist_case(c) for c in _DIST_CASES],
     }
     return doc
 
@@ -235,10 +390,18 @@ def main() -> None:
         json.dump(doc, fh, indent=2, ensure_ascii=False)
         fh.write("\n")
     print(f"wrote {_OUT_PATH}")
-    print(f"  contract_version={doc['contract_version']} cases={len(doc['cases'])}")
+    print(f"  contract_version={doc['contract_version']} cases={len(doc['cases'])} "
+          f"sequence_cases={len(doc['sequence_cases'])} "
+          f"distance_cases={len(doc['distance_cases'])}")
     for c in doc["cases"]:
         assert c["expected_weight_sum"] == du.WEIGHT_SCALE, c["name"]
         print(f"  {c['name']:24} -> token={c['expected_token']}")
+    for c in doc["sequence_cases"]:
+        e = c["expected"]
+        print(f"  seq {c['name']:32} -> {e['verdict']} "
+              f"(fraud_pos={e['fraud_position']}, honest={e['n_honest']})")
+    for c in doc["distance_cases"]:
+        print(f"  dist {c['name']:24} -> mae={c['expected_mae']}")
 
 
 if __name__ == "__main__":

--- a/tests/v1/logits_processors/test_enforced.py
+++ b/tests/v1/logits_processors/test_enforced.py
@@ -1,0 +1,378 @@
+import random
+
+import pytest
+import torch
+
+from tests.utils import create_new_process_for_each_test
+from tests.v1.sample.utils import (
+    create_fake_logits,
+    create_penalty_tensor,
+    create_prompt_tokens_tensor,
+)
+from vllm.config import VllmConfig
+from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
+from vllm.utils.platform_utils import is_pin_memory_available
+from vllm.v1.sample.logits_processor import build_logitsprocs
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import Sampler
+
+PIN_MEMORY_AVAILABLE = is_pin_memory_available()
+VOCAB_SIZE = 1024
+NUM_OUTPUT_TOKENS = 10
+CUDA_DEVICES = [
+    f"{current_platform.device_type}:{i}"
+    for i in range(1 if current_platform.device_count() == 1 else 2)
+]
+
+
+def _create_enforced_sampling_metadata(
+    batch_size: int,
+    vocab_size: int,
+    device: torch.device,
+    enforced_req_ids: list[int],
+    enforced_token_ids: dict[int, list[int]],
+    enforced_tokens: dict[int, list[dict[int, list[int]]]] | None = None,
+) -> SamplingMetadata:
+    """Create sampling metadata with enforced tokens."""
+    output_token_ids: list[list[int]] = []
+    prompt_token_ids: list[list[int]] = []
+    
+    for i in range(batch_size):
+        # For enforced requests, use shorter output to test step-based enforcement
+        if i in enforced_req_ids:
+            output_token_ids.append([random.randint(0, vocab_size - 1) for _ in range(random.randint(0, 5))])
+        else:
+            output_token_ids.append([random.randint(0, vocab_size - 1) for _ in range(NUM_OUTPUT_TOKENS)])
+        prompt_token_ids.append([random.randint(0, vocab_size - 1) for _ in range(10)])
+    
+    logitsprocs = build_logitsprocs(
+        vllm_config=VllmConfig(),
+        device=device,
+        is_pin_memory=PIN_MEMORY_AVAILABLE,
+        is_pooling_model=False,
+    )
+
+    all_enforced = len(enforced_req_ids) == batch_size
+    mixed_enforced = len(enforced_req_ids) > 0 and len(enforced_req_ids) < batch_size
+    all_greedy = not all_enforced and not mixed_enforced
+    all_random = False
+    
+    sampling_metadata = SamplingMetadata(
+        temperature=torch.full((batch_size,), 0.0 if all_greedy else 1.0, device=device),
+        all_greedy=all_greedy,
+        all_random=all_random,
+        all_enforced=all_enforced,
+        mixed_enforced=mixed_enforced,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=3 if enforced_tokens else 0,
+        prompt_token_ids=create_prompt_tokens_tensor(prompt_token_ids, vocab_size, device),
+        output_token_ids=output_token_ids,
+        frequency_penalties=create_penalty_tensor(batch_size, 0.0, device),
+        presence_penalties=create_penalty_tensor(batch_size, 0.0, device),
+        repetition_penalties=create_penalty_tensor(batch_size, 1.0, device),
+        no_penalties=True,
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=logitsprocs,
+        enforced_req_ids=enforced_req_ids,
+        enforced_token_ids=enforced_token_ids,
+        enforced_tokens=enforced_tokens or {},
+    )
+    return sampling_metadata
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+def test_all_enforced_sampling(device: str, batch_size: int):
+    """Test sampling when all requests have enforced tokens."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+
+    enforced_req_ids = list(range(batch_size))
+    enforced_token_ids = {
+        i: [random.randint(0, VOCAB_SIZE - 1) for _ in range(5)]
+        for i in range(batch_size)
+    }
+    
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    sampling_metadata = _create_enforced_sampling_metadata(
+        batch_size, VOCAB_SIZE, device_obj, enforced_req_ids, enforced_token_ids
+    )
+
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+
+    assert sampled.shape == (batch_size,)
+    for i in range(batch_size):
+        step = len(sampling_metadata.output_token_ids[i])
+        expected_token = enforced_token_ids[i][min(step, len(enforced_token_ids[i]) - 1)]
+        assert sampled[i].item() == expected_token, (
+            f"Request {i}: expected token {expected_token} at step {step}, "
+            f"got {sampled[i].item()}"
+        )
+
+ 
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("batch_size,num_enforced", [(8, 2), (16, 5), (32, 10)])
+def test_mixed_enforced_sampling(device: str, batch_size: int, num_enforced: int):
+    """Test sampling when only some requests have enforced tokens."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+
+    enforced_req_ids = random.sample(range(batch_size), num_enforced)
+    enforced_token_ids = {
+        i: [random.randint(0, VOCAB_SIZE - 1) for _ in range(5)]
+        for i in enforced_req_ids
+    }
+    
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    for i in range(batch_size):
+        if i not in enforced_req_ids:
+            logits[i, i % VOCAB_SIZE] = 100.0  # Clear winner
+
+    sampling_metadata = _create_enforced_sampling_metadata(
+        batch_size, VOCAB_SIZE, device_obj, enforced_req_ids, enforced_token_ids
+    )
+    
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+
+    assert sampled.shape == (batch_size,)
+    for i in enforced_req_ids:
+        step = len(sampling_metadata.output_token_ids[i])
+        expected_token = enforced_token_ids[i][min(step, len(enforced_token_ids[i]) - 1)]
+        assert sampled[i].item() == expected_token, (
+            f"Enforced request {i}: expected token {expected_token} at step {step}, "
+            f"got {sampled[i].item()}"
+        )
+
+    for i in range(batch_size):
+        if i not in enforced_req_ids:
+            # Should pick the dominant token we set
+            expected_token = i % VOCAB_SIZE
+            assert sampled[i].item() == expected_token, (
+                f"Non-enforced request {i}: expected greedy token {expected_token}, "
+                f"got {sampled[i].item()}"
+            )
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_enforced_tokens_with_logprobs(device: str):
+    """Test that enforced tokens work correctly with logprobs gathering."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+    batch_size = 4
+    
+    enforced_req_ids = [0, 2]
+    enforced_token_ids = {
+        0: [10, 20, 30],
+        2: [40, 50, 60],
+    }
+    enforced_tokens = {
+        0: [
+            {10: [10, 11, 12]},  # step 0: token 10, top tokens [10, 11, 12]
+            {20: [20, 21, 22]},  # step 1: token 20, top tokens [20, 21, 22]
+            {30: [30, 31, 32]},  # step 2: token 30, top tokens [30, 31, 32]
+        ],
+        2: [
+            {40: [40, 41, 42]},
+            {50: [50, 51, 52]},
+            {60: [60, 61, 62]},
+        ],
+    }
+
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    sampling_metadata = _create_enforced_sampling_metadata(
+        batch_size, VOCAB_SIZE, device_obj, enforced_req_ids, 
+        enforced_token_ids, enforced_tokens
+    )
+    
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+
+    for i in enforced_req_ids:
+        step = len(sampling_metadata.output_token_ids[i])
+        expected_token = enforced_token_ids[i][min(step, len(enforced_token_ids[i]) - 1)]
+        assert sampled[i].item() == expected_token
+    
+    logprobs = sampler.compute_logprobs(logits)
+    logprobs_tensors = sampler.gather_logprobs(
+        logprobs, 3, sampled.long(), sampling_metadata
+    )
+
+    assert logprobs_tensors.logprob_token_ids.shape == (batch_size, 4)  # sampled + top 3
+    assert logprobs_tensors.logprobs.shape == (batch_size, 4)
+    assert logprobs_tensors.selected_token_ranks.shape == (batch_size,)
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("step", [0, 2, 5, 10])
+def test_enforced_tokens_at_different_steps(device: str, step: int):
+    """Test that enforced tokens work correctly at different generation steps."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+    batch_size = 4
+    
+    enforced_req_ids = [1]
+    enforced_sequence = [100, 200, 300, 400, 500]
+    enforced_token_ids = {1: enforced_sequence}
+    
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    output_token_ids = [[] for _ in range(batch_size)]
+    output_token_ids[1] = [0] * step  # Simulate 'step' tokens already generated
+    
+    prompt_token_ids = [[random.randint(0, VOCAB_SIZE - 1) for _ in range(10)] for _ in range(batch_size)]
+    
+    logitsprocs = build_logitsprocs(
+        vllm_config=VllmConfig(),
+        device=device_obj,
+        is_pin_memory=PIN_MEMORY_AVAILABLE,
+        is_pooling_model=False,
+    )
+    
+    sampling_metadata = SamplingMetadata(
+        temperature=torch.full((batch_size,), 1.0, device=device_obj),
+        all_greedy=False,
+        all_random=False,
+        all_enforced=False,
+        mixed_enforced=True,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=0,
+        prompt_token_ids=create_prompt_tokens_tensor(prompt_token_ids, VOCAB_SIZE, device_obj),
+        output_token_ids=output_token_ids,
+        frequency_penalties=create_penalty_tensor(batch_size, 0.0, device_obj),
+        presence_penalties=create_penalty_tensor(batch_size, 0.0, device_obj),
+        repetition_penalties=create_penalty_tensor(batch_size, 1.0, device_obj),
+        no_penalties=True,
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=logitsprocs,
+        enforced_req_ids=enforced_req_ids,
+        enforced_token_ids=enforced_token_ids,
+        enforced_tokens={},
+    )
+    
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+    expected_token = enforced_sequence[min(step, len(enforced_sequence) - 1)]
+    assert sampled[1].item() == expected_token, (
+        f"At step {step}: expected token {expected_token}, got {sampled[1].item()}"
+    )
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_enforced_tokens_last_token_repeats(device: str):
+    """Test that when step exceeds sequence length, last token is repeated."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+    batch_size = 2
+    
+    enforced_req_ids = [0]
+    enforced_sequence = [100, 200, 300]
+    enforced_token_ids = {0: enforced_sequence}
+    
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    output_token_ids = [[0] * 5, []]
+    prompt_token_ids = [[random.randint(0, VOCAB_SIZE - 1) for _ in range(10)] for _ in range(batch_size)]
+    
+    logitsprocs = build_logitsprocs(
+        vllm_config=VllmConfig(),
+        device=device_obj,
+        is_pin_memory=PIN_MEMORY_AVAILABLE,
+        is_pooling_model=False,
+    )
+    
+    sampling_metadata = SamplingMetadata(
+        temperature=torch.full((batch_size,), 1.0, device=device_obj),
+        all_greedy=False,
+        all_random=False,
+        all_enforced=False,
+        mixed_enforced=True,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=0,
+        prompt_token_ids=create_prompt_tokens_tensor(prompt_token_ids, VOCAB_SIZE, device_obj),
+        output_token_ids=output_token_ids,
+        frequency_penalties=create_penalty_tensor(batch_size, 0.0, device_obj),
+        presence_penalties=create_penalty_tensor(batch_size, 0.0, device_obj),
+        repetition_penalties=create_penalty_tensor(batch_size, 1.0, device_obj),
+        no_penalties=True,
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=logitsprocs,
+        enforced_req_ids=enforced_req_ids,
+        enforced_token_ids=enforced_token_ids,
+        enforced_tokens={},
+    )
+
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+
+    assert sampled[0].item() == 300, (
+        f"Expected last token (300) to repeat, got {sampled[0].item()}"
+    )
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_enforced_tokens_empty_batch(device: str):
+    """Test that empty enforced_req_ids doesn't break sampling."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+    batch_size = 4
+
+    enforced_req_ids = []
+    enforced_token_ids = {}
+
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+
+    sampling_metadata = _create_enforced_sampling_metadata(
+        batch_size, VOCAB_SIZE, device_obj, enforced_req_ids, enforced_token_ids
+    )
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+
+    assert sampled.shape == (batch_size,)
+
+
+@create_new_process_for_each_test()
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_enforced_tokens_ordering_after_condense(device: str):
+    """Test that enforced tokens work correctly even when req_ids are out of order."""
+    torch.set_default_device(device)
+    device_obj = torch.device(device)
+    batch_size = 4
+    
+    # Enforced req_ids out of order (simulating post-condense state)
+    enforced_req_ids = [2, 0, 3]
+    enforced_token_ids = {
+        0: [100, 101, 102],
+        2: [200, 201, 202],
+        3: [300, 301, 302],
+    }
+
+    logits = create_fake_logits(batch_size, VOCAB_SIZE).to(device_obj)
+    sampling_metadata = _create_enforced_sampling_metadata(
+        batch_size, VOCAB_SIZE, device_obj, enforced_req_ids, enforced_token_ids
+    )
+
+    sampler = Sampler()
+    sampled, _ = sampler.sample(logits, sampling_metadata)
+    
+    for req_id in enforced_req_ids:
+        step = len(sampling_metadata.output_token_ids[req_id])
+        expected_token = enforced_token_ids[req_id][min(step, len(enforced_token_ids[req_id]) - 1)]
+        assert sampled[req_id].item() == expected_token, (
+            f"Request {req_id}: expected token {expected_token}, got {sampled[req_id].item()}"
+        )

--- a/tests/v1/sample/test_chain_bound_seed_domain.py
+++ b/tests/v1/sample/test_chain_bound_seed_domain.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Invariant tests for chain-bound deterministic sampling seed derivation.
+
+Guards the security boundary required by the inference-validation proposal:
+
+    run_seed = SHA256(user_seed || inference_id_from_chain)
+
+Stage-1 sampling replay is only sound if the RNG domain is bound to the
+chain inference instance and cannot be steered by request-controlled material.
+These tests pin that contract; they need no GPU, torch, or running server.
+"""
+import pytest
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    derive_chain_bound_seed,
+)
+
+
+def _stream(seed_str: str, n: int = 8):
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    return [rng.next_u64() for _ in range(n)]
+
+
+def test_domain_separation_different_inference_id():
+    # Same user_seed + (implicitly) same prompt, different chain inference id
+    # MUST produce a different seed and therefore a different RNG stream.
+    seed_a = derive_chain_bound_seed(42, "chain-inference-0001")
+    seed_b = derive_chain_bound_seed(42, "chain-inference-0002")
+    assert seed_a != seed_b
+    assert _stream(seed_a) != _stream(seed_b)
+
+
+def test_determinism_same_inputs():
+    # Same (user_seed, inference_id) MUST be bit-identical across calls.
+    seed_1 = derive_chain_bound_seed(42, "chain-inference-0001")
+    seed_2 = derive_chain_bound_seed(42, "chain-inference-0001")
+    assert seed_1 == seed_2
+    assert _stream(seed_1) == _stream(seed_2)
+
+
+def test_fail_closed_on_missing_inference_id():
+    # No silent fallback to request-controlled material.
+    for bad in (None, "", "   "):
+        with pytest.raises(ValueError):
+            derive_chain_bound_seed(42, bad)  # type: ignore[arg-type]
+
+
+def test_no_concatenation_collision():
+    # Length-prefixed framing must prevent ambiguous concatenation, e.g.
+    # naive f"{user_seed}{inference_id}" collides for (4,"2x") and (42,"x").
+    assert (
+        derive_chain_bound_seed(4, "2x")
+        != derive_chain_bound_seed(42, "x")
+    )
+
+
+def test_output_is_stable_hex_digest():
+    seed = derive_chain_bound_seed(7, "chain-abc")
+    assert isinstance(seed, str)
+    assert len(seed) == 64
+    assert seed == seed.lower()
+    int(seed, 16)  # must be valid hex
+
+
+def test_chain_bound_seed_golden_vector():
+    # Pins the exact digest so a future framing/encoding change is caught even
+    # when the property-level tests still pass.
+    assert derive_chain_bound_seed(7, "chain-abc") == (
+        "910b688db5b2061e66385acf0ee665682d5e01bab5d1d8d2cdde9a2612a6e6c2"
+    )
+
+
+def test_non_string_chain_id_rejected():
+    # Provenance material must be chain-provided text, never a stringified
+    # object/bytes/int.
+    for bad in (123, b"chain-abc", object()):
+        with pytest.raises(TypeError):
+            derive_chain_bound_seed(7, bad)  # type: ignore[arg-type]
+
+
+def test_whitespace_in_chain_id_rejected_language_invariant():
+    # The accept/reject boundary must be identical across Python/Go/Rust/JS.
+    # A "whitespace-only" / strip() predicate rejects a DIFFERENT set of code
+    # points per runtime (U+001C-1F, U+0085, U+00A0, U+2028, ...), which would
+    # split consensus on validity. Printable-ASCII-only rejects them all.
+    for ws in (" ", "\t", "\n", "\x1c", "\x85", "\xa0", " "):
+        with pytest.raises(ValueError):
+            derive_chain_bound_seed(7, "chain" + ws + "abc")
+
+
+def test_control_and_nul_chars_rejected():
+    # NUL / control bytes must never enter the hashed provenance material.
+    for bad in ("chain\x00abc", "chain\x07", "\x1fchain"):
+        with pytest.raises(ValueError):
+            derive_chain_bound_seed(7, bad)
+
+
+def test_non_ascii_chain_id_rejected():
+    # Non-ASCII is byte-fragile across honest re-encoders (JSON/DB NFC); the
+    # canonical id charset is printable ASCII only.
+    for bad in ("chain-β", "chain-é", "chain-\U0001F600"):
+        with pytest.raises(ValueError):
+            derive_chain_bound_seed(7, bad)
+
+
+def test_inference_id_length_bounded():
+    # Unbounded id is a hash-DoS surface; the contract caps it.
+    with pytest.raises(ValueError):
+        derive_chain_bound_seed(7, "a" * 257)
+    # At the bound it is still accepted.
+    assert len(derive_chain_bound_seed(7, "a" * 256)) == 64
+
+
+def test_user_seed_int64_range_enforced():
+    # A Python big int hashes fine but an int64 validator overflows; pin range.
+    for bad in (2**63, -(2**63) - 1, 2**100):
+        with pytest.raises(ValueError):
+            derive_chain_bound_seed(bad, "chain-abc")
+    # int64 extremes accepted.
+    assert len(derive_chain_bound_seed(2**63 - 1, "chain-abc")) == 64
+    assert len(derive_chain_bound_seed(-(2**63), "chain-abc")) == 64
+
+
+def test_int_subclass_seed_rejected():
+    # type(x) is int rejects subclasses whose __str__ is overridden, which
+    # would hash the repr instead of the value while passing an isinstance
+    # check. Exact-int only.
+    class _Sneaky(int):
+        def __str__(self) -> str:  # pragma: no cover - trivial
+            return "999"
+
+    with pytest.raises(TypeError):
+        derive_chain_bound_seed(_Sneaky(7), "chain-abc")
+
+
+def test_user_seed_type_rejected():
+    # vLLM's seed is int-only; a str "7" would collide with int 7, so only int
+    # is accepted. bool is a subclass of int and is rejected explicitly.
+    for bad in (None, True, False, 1.5, "7", b"7", object()):
+        with pytest.raises(TypeError):
+            derive_chain_bound_seed(bad, "chain-abc")  # type: ignore[arg-type]

--- a/tests/v1/sample/test_e1_shadow.py
+++ b/tests/v1/sample/test_e1_shadow.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-CPU tests for the E1 shadow helper ``decimal_token_from_probs``
+(gonka-ai/gonka#1199). It computes the token the decimal validator pipeline
+would sample from a post-filter distribution, for comparison against the float
+executor path. No torch needed."""
+
+import math
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    decimal_sample_from_logprobs,
+    decimal_token_from_probs,
+)
+
+_PROBS = {5: 0.6, 10: 0.3, 2: 0.08, 100: 0.02}
+
+
+def test_matches_decimal_pipeline_on_equivalent_logprobs():
+    """The shadow token equals what the decimal pipeline draws from the
+    equivalent logprobs (temperature 1, no filter) under the same RNG."""
+    ids = list(_PROBS)
+    vals = [_PROBS[t] for t in ids]
+    seed = "e1shadow|0"
+
+    shadow_tok = decimal_token_from_probs(
+        ids, vals, Sha256CounterRNG.from_seed_string(seed))
+
+    logprobs = {str(t): repr(math.log(p)) for t, p in _PROBS.items()}
+    pipeline_tok = decimal_sample_from_logprobs(
+        logprobs, Sha256CounterRNG.from_seed_string(seed), "1.0")
+
+    assert shadow_tok == pipeline_tok
+
+
+def test_deterministic():
+    ids = list(_PROBS)
+    vals = [_PROBS[t] for t in ids]
+    a = decimal_token_from_probs(ids, vals, Sha256CounterRNG.from_seed_string("s"))
+    b = decimal_token_from_probs(ids, vals, Sha256CounterRNG.from_seed_string("s"))
+    assert a == b
+
+
+def test_peaked_distribution_returns_peak():
+    probs = {7: 0.999, 1: 0.001}
+    tok = decimal_token_from_probs(
+        list(probs), list(probs.values()),
+        Sha256CounterRNG.from_seed_string("x"))
+    assert tok == "7"
+
+
+def test_zero_probability_support_is_dropped():
+    # tokens with prob 0 (masked by top_k/top_p) must not be sampled.
+    ids = [5, 10, 2, 0]
+    vals = [0.6, 0.4, 0.0, 0.0]
+    tok = decimal_token_from_probs(
+        ids, vals, Sha256CounterRNG.from_seed_string("z"))
+    assert tok in ("5", "10")

--- a/tests/v1/sample/test_enforced_sampling.py
+++ b/tests/v1/sample/test_enforced_sampling.py
@@ -1,0 +1,117 @@
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams, SamplingType
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+from vllm.utils.platform_utils import is_pin_memory_available
+
+@pytest.fixture
+def device():
+    """Get available device."""
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@pytest.fixture
+def input_batch(device):
+    batch = InputBatch(
+        max_num_reqs=8,
+        max_model_len=128,
+        max_num_batched_tokens=1024,
+        device=device,
+        vocab_size=32000,
+        pin_memory=is_pin_memory_available(),
+        block_sizes=[1],
+        kernel_block_sizes=[1],
+    )
+    return batch
+
+
+@pytest.mark.parametrize(
+    "i1,i2,enforced_positions,enforced_tokens_data,expected_req_ids,expected_token_ids", [
+    # Test 1: Only one position has enforced, swap must move it
+    (0, 2, [0], {0: [100, 200, 300]}, [2], {2: [100, 200, 300]}),
+    # Test 2: Both positions have enforced, both stay in list (values swap)
+    (0, 2, [0, 2], {0: [100], 2: [200]}, {0, 2}, {0: [200], 2: [100]}),
+    # Test 3: Neither position has enforced, no change
+    (0, 2, [1, 3], {1: [100], 3: [200]}, [1, 3], {1: [100], 3: [200]}),
+    ]
+)
+def test_swap_enforced_states(input_batch, i1, i2, enforced_positions, enforced_tokens_data, 
+                               expected_req_ids, expected_token_ids):
+    max_index = max(i1, i2, max(enforced_positions) if enforced_positions else 0)
+    for req_idx in range(max_index + 1):
+        req = CachedRequestState(
+            req_id=f"req_{req_idx}",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(temperature=0.0),
+            pooling_params=None,
+            mm_features=[],
+            block_ids=([],),
+            generator=None,
+            num_computed_tokens=0,
+            output_token_ids=[],
+        )
+        input_batch.add_request(req)
+
+    input_batch.enforced_req_ids = enforced_positions.copy()
+    input_batch.enforced_token_ids = enforced_tokens_data.copy()
+    input_batch.enforced_tokens = {}
+    
+    input_batch.swap_states(i1, i2)
+
+    if isinstance(expected_req_ids, set):
+        assert set(input_batch.enforced_req_ids) == expected_req_ids
+    else:
+        assert input_batch.enforced_req_ids == expected_req_ids
+
+    assert input_batch.enforced_token_ids == expected_token_ids
+
+
+@pytest.mark.parametrize(
+    "greedy_reqs,random_reqs,enforced_reqs,expected", [
+    (set(), set(), set(), False),  # empty batch
+    (set(), set(), {"req_1", "req_2"}, True),  # only enforced
+    ({"req_1"}, set(), {"req_2"}, False),  # mixed batch (enforced + greedy)
+    ({"req_1"}, set(), set(), False),  # only greedy
+    ]
+)
+def test_all_enforced_property(input_batch, greedy_reqs, random_reqs, enforced_reqs, expected):
+    """Test all_enforced property with different request combinations."""
+    input_batch.greedy_reqs = greedy_reqs
+    input_batch.random_reqs = random_reqs
+    input_batch.enforced_reqs = enforced_reqs
+
+    assert input_batch.all_enforced == expected
+
+
+@pytest.mark.parametrize(
+    "greedy_reqs,random_reqs,enforced_reqs,expected", [
+    ({"req_1"}, set(), {"req_2"}, True),  # enforced mixed with greedy
+    (set(), set(), {"req_1", "req_2"}, False),  # all enforced (not mixed)
+    ({"req_1"}, {"req_2"}, set(), False),  # no enforced (not mixed)
+    ]
+)
+def test_mixed_enforced_property(input_batch, greedy_reqs, random_reqs, enforced_reqs, expected):
+    """Test mixed_enforced property with different request combinations."""
+    input_batch.greedy_reqs = greedy_reqs
+    input_batch.random_reqs = random_reqs
+    input_batch.enforced_reqs = enforced_reqs
+
+    assert input_batch.mixed_enforced == expected
+
+
+@pytest.mark.parametrize(
+    "temperature,enforced_token_ids,enforced_tokens,expected_type", [
+    (0.0, [100, 200, 300], None, SamplingType.ENFORCED),  # enforced_token_ids
+    (0.0, None, [{100: [100, 200]}, {200: [200, 300]}], SamplingType.ENFORCED),  # enforced_tokens
+    (0.0, None, None, SamplingType.GREEDY),  # no enforced, temp=0
+    (1.0, None, None, SamplingType.RANDOM),  # no enforced, temp>0
+    ]
+)
+def test_sampling_type_detection(temperature, enforced_token_ids, enforced_tokens, expected_type):
+    params = SamplingParams(
+        temperature=temperature,
+        enforced_token_ids=enforced_token_ids,
+        enforced_tokens=enforced_tokens,
+    )
+    assert params.sampling_type == expected_type

--- a/tests/v1/sample/test_enforced_sampling_e2e.py
+++ b/tests/v1/sample/test_enforced_sampling_e2e.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import asyncio
+import aiohttp
+import random
+from ...utils import RemoteOpenAIServer
+import requests
+import json
+
+from vllm import LLM, SamplingParams
+
+MODEL = "hmellor/tiny-random-LlamaForCausalLM"
+SERVER_ARGS = [
+    "--enforce_eager",
+    "--no_enable_prefix_caching",
+    "--gpu-memory-utilization=0.7",
+]
+PROMPT = "Hello my name is Robert and I"
+
+VOCAB = [str(i) for i in range(1000, 1050)]
+
+def generate_random_enforced(max_tokens):
+    n = max_tokens
+    tokens = []
+    used = set()
+    for _ in range(n):
+        tok = random.choice(VOCAB)
+        while tok in used:
+            tok = random.choice(VOCAB)
+        used.add(tok)
+
+        others = set(VOCAB) - {tok}
+        top_two = random.choices(list(others), k=2)
+        top = [tok] + top_two
+
+        tokens.append({
+            "token": tok,
+            "top_tokens": top
+        })
+    return tokens
+
+
+def validate_enforced_tokens(response_content, enforced_tokens):
+    content = response_content
+    enforced = enforced_tokens
+
+    if len(content) < len(enforced):
+        enforced = enforced[:len(content)]
+
+    for i, enforced_item in enumerate(enforced):
+        exp_tok = enforced_item["token"]
+        exp_top = set(enforced_item["top_tokens"])
+
+        model_tok = content[i]["token"]
+
+        top_logits = content[i]["top_logprobs"]
+        if isinstance(top_logits, dict):
+            model_top = set(top_logits.keys())
+        else:
+            model_top = {t["token"] for t in top_logits}
+
+        assert model_tok == exp_tok, f"token mismatch at position {i}: {model_tok} != {exp_tok}"
+        assert model_top.issubset(exp_top), f"top-logprobs mismatch at position {i}: {model_top} not subset of {exp_top}"
+        
+
+def test_enforced_tokens():
+    max_tokens = 10
+    enforced = generate_random_enforced(max_tokens)
+
+    headers = {"Content-Type": "application/json"}
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 0.99,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "enforced_tokens": {"tokens": enforced},
+    }
+    with RemoteOpenAIServer(MODEL, SERVER_ARGS) as remote_server:
+        url = f"{remote_server.url_for('v1')}/chat/completions"
+        response = requests.post(url, headers=headers, data=json.dumps(payload))
+        assert response.status_code == 200, response.text
+        resp_json = response.json()
+
+    content = resp_json["choices"][0]["logprobs"]["content"]
+    validate_enforced_tokens(content, enforced)
+
+
+@pytest.mark.parametrize("max_tokens", [5, 50, 100])
+def test_enforced_tokens_different_lengths(max_tokens):
+    enforced = generate_random_enforced(max_tokens)
+
+    headers = {"Content-Type": "application/json"}
+    payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 0.99,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "enforced_tokens": {"tokens": enforced},
+    }
+    with RemoteOpenAIServer(MODEL, SERVER_ARGS) as remote_server:
+        url = f"{remote_server.url_for('v1')}/chat/completions"
+        response = requests.post(url, headers=headers, data=json.dumps(payload))
+        assert response.status_code == 200, response.text
+        resp_json = response.json()
+
+    content = resp_json["choices"][0]["logprobs"]["content"]
+    validate_enforced_tokens(content, enforced)
+
+
+def test_enforced_tokens_batch_with_random_and_greedy():
+    max_tokens = 10
+    enforced = generate_random_enforced(max_tokens)
+
+    headers = {"Content-Type": "application/json"}
+
+    enforced_payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 0.99,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "enforced_tokens": {"tokens": enforced},
+    }
+    
+    random_payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 0.99,
+        "logprobs": True,
+        "top_logprobs": 3,
+    }
+    
+    greedy_payload = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "logprobs": True,
+        "top_logprobs": 3,
+    }
+
+    with RemoteOpenAIServer(MODEL, SERVER_ARGS) as remote_server:
+        url = f"{remote_server.url_for('v1')}/chat/completions"
+
+        async def send_requests():
+            async with aiohttp.ClientSession() as session:
+                tasks = [
+                    session.post(url, headers=headers, json=enforced_payload),
+                    session.post(url, headers=headers, json=random_payload),
+                    session.post(url, headers=headers, json=greedy_payload),
+                ]
+                responses = await asyncio.gather(*tasks)
+                return responses
+        
+        responses = asyncio.run(send_requests())
+
+        assert all(r.status == 200 for r in responses), "Some requests failed"
+
+        enforced_resp = asyncio.run(responses[0].json())
+        random_resp = asyncio.run(responses[1].json())
+        greedy_resp = asyncio.run(responses[2].json())
+
+    enforced_content = enforced_resp["choices"][0]["logprobs"]["content"]
+    validate_enforced_tokens(enforced_content, enforced)
+
+    random_content = random_resp["choices"][0]["logprobs"]["content"]
+    greedy_content = greedy_resp["choices"][0]["logprobs"]["content"]
+
+    enforced_tokens = [item["token"] for item in enforced_content]
+    random_tokens = [item["token"] for item in random_content]
+    greedy_tokens = [item["token"] for item in greedy_content]
+
+    assert len(random_tokens) > 0, "Random sampling produced no tokens"
+    assert len(greedy_tokens) > 0, "Greedy sampling produced no tokens"
+    assert len(enforced_tokens) > 0, "Enforced sampling produced no tokens"

--- a/tests/v1/validation/__init__.py
+++ b/tests/v1/validation/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Validation tests for decentralized inference verification.
+
+This package contains tests for:
+- Distance calculation (Go parity verification)
+- Sampling verification (deterministic RNG)
+- Weight quantization and consistency
+- Integration tests with mocked models
+- E2E tests with real vLLM server
+"""

--- a/tests/v1/validation/conformance_vectors.json
+++ b/tests/v1/validation/conformance_vectors.json
@@ -361,5 +361,440 @@
         "reason": "too long (>256)"
       }
     ]
-  }
+  },
+  "sequence_cases": [
+    {
+      "name": "honest_top_k",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": 20,
+      "min_p": null,
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "1"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "6"
+        }
+      ],
+      "expected": {
+        "verdict": "honest",
+        "fraud_position": -1,
+        "n_honest": 3,
+        "n_inconclusive": 0
+      }
+    },
+    {
+      "name": "honest_min_p",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": "0.02",
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "11"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "6"
+        }
+      ],
+      "expected": {
+        "verdict": "honest",
+        "fraud_position": -1,
+        "n_honest": 3,
+        "n_inconclusive": 0
+      }
+    },
+    {
+      "name": "fraud_at_pos_1",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": 20,
+      "min_p": null,
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "999999"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "6"
+        }
+      ],
+      "expected": {
+        "verdict": "fraud",
+        "fraud_position": 1,
+        "n_honest": 1,
+        "n_inconclusive": 0
+      }
+    },
+    {
+      "name": "honest_with_missing_position",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": 20,
+      "min_p": null,
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": null,
+          "reported_token": ""
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "6"
+        }
+      ],
+      "expected": {
+        "verdict": "honest",
+        "fraud_position": -1,
+        "n_honest": 2,
+        "n_inconclusive": 1
+      }
+    },
+    {
+      "name": "inconclusive_unbounded_top_p",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": "0.9",
+      "top_k": null,
+      "min_p": null,
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "3"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "8"
+        }
+      ],
+      "expected": {
+        "verdict": "inconclusive",
+        "fraud_position": -1,
+        "n_honest": 0,
+        "n_inconclusive": 0
+      }
+    },
+    {
+      "name": "inconclusive_greedy",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "1.0.0",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "0",
+      "top_p": null,
+      "top_k": 20,
+      "min_p": null,
+      "greedy": true,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "3"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "8"
+        }
+      ],
+      "expected": {
+        "verdict": "inconclusive",
+        "fraud_position": -1,
+        "n_honest": 0,
+        "n_inconclusive": 0
+      }
+    },
+    {
+      "name": "inconclusive_bad_version",
+      "base_seed": "42|[1,2,3]",
+      "contract_version": "9.9.9",
+      "seed_domain": "gonka-deterministic-sampling-v1",
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": 20,
+      "min_p": null,
+      "greedy": false,
+      "positions": [
+        {
+          "logprobs": {
+            "5": "-0.5",
+            "10": "-1.2",
+            "2": "-2.5",
+            "100": "-3.9",
+            "7": "-4.1"
+          },
+          "reported_token": "5"
+        },
+        {
+          "logprobs": {
+            "3": "-0.3",
+            "42": "-1.1",
+            "9": "-2.2",
+            "11": "-3.0",
+            "1": "-4.5"
+          },
+          "reported_token": "3"
+        },
+        {
+          "logprobs": {
+            "8": "-0.7",
+            "6": "-1.5",
+            "4": "-2.0",
+            "20": "-2.9",
+            "15": "-3.3"
+          },
+          "reported_token": "8"
+        }
+      ],
+      "expected": {
+        "verdict": "inconclusive",
+        "fraud_position": -1,
+        "n_honest": 0,
+        "n_inconclusive": 0
+      }
+    }
+  ],
+  "distance_cases": [
+    {
+      "name": "identical",
+      "executor": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        }
+      ],
+      "validator": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        }
+      ],
+      "expected_mae": 0.0
+    },
+    {
+      "name": "uniform_shift",
+      "executor": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        }
+      ],
+      "validator": [
+        {
+          "5": -1.0,
+          "10": -1.7,
+          "2": -3.0,
+          "100": -4.4,
+          "7": -4.6
+        }
+      ],
+      "expected_mae": 0.5000000000000001
+    },
+    {
+      "name": "length_mismatch",
+      "executor": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        },
+        {
+          "3": -0.3,
+          "42": -1.1,
+          "9": -2.2,
+          "11": -3.0,
+          "1": -4.5
+        }
+      ],
+      "validator": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        }
+      ],
+      "expected_mae": 10.0
+    },
+    {
+      "name": "missing_token",
+      "executor": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9,
+          "7": -4.1
+        }
+      ],
+      "validator": [
+        {
+          "5": -0.5,
+          "10": -1.2,
+          "2": -2.5,
+          "100": -3.9
+        }
+      ],
+      "expected_mae": 2.0
+    }
+  ]
 }

--- a/tests/v1/validation/conformance_vectors.json
+++ b/tests/v1/validation/conformance_vectors.json
@@ -1,0 +1,365 @@
+{
+  "contract_version": "1.0.0",
+  "decimal": {
+    "prec": 10,
+    "rounding": "ROUND_HALF_EVEN"
+  },
+  "weight_scale": 65536,
+  "rng_reference": {
+    "seed": "reference_seed_v1",
+    "first_u64": [
+      4286832458236889005,
+      12281003819428572724,
+      12352776571910749143,
+      12178488218135958089,
+      6205195570139478562
+    ]
+  },
+  "float_to_string": [
+    {
+      "description": "plain -0.05 as float64",
+      "repr": "-0.05"
+    },
+    {
+      "description": "-0.05 as float32 widened to float64",
+      "repr": "-0.05000000074505806"
+    },
+    {
+      "description": "0.1 as float32 widened to float64",
+      "repr": "0.10000000149011612"
+    }
+  ],
+  "cases": [
+    {
+      "name": "single_token",
+      "logprobs": {
+        "791": "-0.05"
+      },
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "791": 65536
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "three_token_plain",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1"
+      },
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "1": 2397,
+        "5": 7201,
+        "791": 55938
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "two_token_near_tie",
+      "logprobs": {
+        "5": "-0.6931471805599453",
+        "7": "-0.6931471805599453"
+      },
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "5": 32768,
+        "7": 32768
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "7"
+    },
+    {
+      "name": "top_k_truncation",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1",
+        "9": "-1.0"
+      },
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": 2,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "791": 47259,
+        "9": 18277
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "top_p_nucleus",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1",
+        "9": "-1.0"
+      },
+      "temperature": "1.0",
+      "top_p": "0.9",
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "5": 5567,
+        "791": 43245,
+        "9": 16724
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "min_p_filter",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1",
+        "9": "-1.0"
+      },
+      "temperature": "1.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": "0.05",
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "5": 5567,
+        "791": 43245,
+        "9": 16724
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "temperature_small",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1"
+      },
+      "temperature": "0.1",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "1": 0,
+        "5": 0,
+        "791": 65536
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "temperature_large",
+      "logprobs": {
+        "791": "-0.05",
+        "1": "-3.2",
+        "5": "-2.1"
+      },
+      "temperature": "2.0",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "1": 8664,
+        "5": 15017,
+        "791": 41855
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "float32_widened_logprob",
+      "logprobs": {
+        "791": "-0.05000000074505806",
+        "1": "-3.0"
+      },
+      "temperature": "0.7",
+      "top_p": null,
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "1": 955,
+        "791": 64581
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "791"
+    },
+    {
+      "name": "ten_tokens",
+      "logprobs": {
+        "3": "-0.1",
+        "10": "-0.2",
+        "42": "-0.30000000000000004",
+        "100": "-0.4",
+        "256": "-0.5",
+        "512": "-0.6000000000000001",
+        "777": "-0.7000000000000001",
+        "1024": "-0.8",
+        "2048": "-0.9",
+        "4096": "-1.0"
+      },
+      "temperature": "0.8",
+      "top_p": "0.95",
+      "top_k": null,
+      "min_p": null,
+      "seed_str": "42|[1,2,3]",
+      "expected_weights": {
+        "10": 9525,
+        "100": 7418,
+        "1024": 4499,
+        "2048": 3970,
+        "256": 6546,
+        "3": 10793,
+        "4096": 3504,
+        "42": 8406,
+        "512": 5777,
+        "777": 5098
+      },
+      "expected_weight_sum": 65536,
+      "expected_token": "3"
+    }
+  ],
+  "uint64_below": {
+    "seed": "reference_seed_v1",
+    "count": 8,
+    "cases": [
+      {
+        "n": 3,
+        "draws": [
+          1,
+          1,
+          0,
+          2,
+          1,
+          0,
+          0,
+          2
+        ]
+      },
+      {
+        "n": 10,
+        "draws": [
+          5,
+          4,
+          3,
+          9,
+          2,
+          9,
+          1,
+          0
+        ]
+      },
+      {
+        "n": 1000,
+        "draws": [
+          5,
+          724,
+          143,
+          89,
+          562,
+          449,
+          921,
+          110
+        ]
+      },
+      {
+        "n": 65537,
+        "draws": [
+          12997,
+          43373,
+          2752,
+          34948,
+          5254,
+          28917,
+          42537,
+          24722
+        ]
+      },
+      {
+        "n": 999983,
+        "draws": [
+          594664,
+          773438,
+          484737,
+          309324,
+          502931,
+          719637,
+          764984,
+          890163
+        ]
+      }
+    ]
+  },
+  "seed_derivation": {
+    "domain_tag": "gonka-deterministic-sampling-v1",
+    "accept": [
+      {
+        "user_seed": 7,
+        "inference_id": "chain-abc",
+        "expected_seed": "910b688db5b2061e66385acf0ee665682d5e01bab5d1d8d2cdde9a2612a6e6c2"
+      },
+      {
+        "user_seed": 7,
+        "inference_id": "chain-xyz",
+        "expected_seed": "10668913c3b68c1da4d32a882523ee44cd37af73d4d4361dd0dd8d71f1fbee4b"
+      },
+      {
+        "user_seed": 42,
+        "inference_id": "devshard-escrow1-100",
+        "expected_seed": "c12c2cbf4165c5b1a4240bc69c4c527ada1b8c65c51b35de017d15be22c7b3d9"
+      },
+      {
+        "user_seed": -1,
+        "inference_id": "chain-abc",
+        "expected_seed": "3d06091b4635031cf457f333dd2d3c64de7eaf56dfa4ae4e6bcc37d81c90c515"
+      },
+      {
+        "user_seed": 9223372036854775807,
+        "inference_id": "x",
+        "expected_seed": "934d232ad3fca38d5cde7e9c8dd8132155ab91e8674977973ea64e431abd72c6"
+      }
+    ],
+    "reject_inference_id": [
+      {
+        "inference_id": "",
+        "reason": "empty"
+      },
+      {
+        "inference_id": " chain-abc ",
+        "reason": "whitespace (space is 0x20, below 0x21)"
+      },
+      {
+        "inference_id": "chain\tabc",
+        "reason": "control char (tab)"
+      },
+      {
+        "inference_id": "chain-é",
+        "reason": "non-ASCII"
+      },
+      {
+        "inference_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "reason": "too long (>256)"
+      }
+    ]
+  }
+}

--- a/tests/v1/validation/conftest.py
+++ b/tests/v1/validation/conftest.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Pytest configuration for validation tests.
+"""
+
+import os
+import pytest
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "e2e: mark test as end-to-end (requires running vLLM server)"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip E2E tests unless explicitly enabled."""
+    if not os.environ.get("RUN_E2E_TESTS") and not os.environ.get("VLLM_TEST_SERVER_URL"):
+        skip_e2e = pytest.mark.skip(
+            reason="E2E tests disabled. Set RUN_E2E_TESTS=1 or VLLM_TEST_SERVER_URL"
+        )
+        for item in items:
+            if "e2e" in item.keywords:
+                item.add_marker(skip_e2e)
+
+
+@pytest.fixture(scope="session")
+def validation_test_seed():
+    """Common seed for validation tests."""
+    return 42
+
+
+@pytest.fixture(scope="session")
+def validation_test_prompt():
+    """Common prompt for validation tests."""
+    return "What is 2+2?"
+
+
+@pytest.fixture(scope="session")
+def validation_test_temperature():
+    """Common temperature for validation tests."""
+    return 0.99

--- a/tests/v1/validation/data/__init__.py
+++ b/tests/v1/validation/data/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Golden test data for validation tests.
+
+This package contains reference data for testing:
+- Reference RNG values for cross-implementation verification
+- Example artifacts (honest, prefill attack, tampered)
+- Expected distance values
+"""

--- a/tests/v1/validation/data/golden_data.py
+++ b/tests/v1/validation/data/golden_data.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Golden test data for validation tests.
+
+These values are reference data for cross-implementation verification.
+Any correct implementation of the deterministic sampling should produce
+identical values.
+"""
+
+# Reference seed used for generating golden values
+REFERENCE_SEED = "reference_seed_v1"
+
+# Expected u64 values from Sha256CounterRNG.next_u64()
+# These should match exactly in any correct implementation
+REFERENCE_U64_VALUES = [
+    4286832458236889005,
+    12281003819428572724,
+    12352776571910749143,
+    12178488218135958089,
+    6205195570139478562,
+    16961475390381133449,
+    4266954777775371921,
+    13066482787726221110,
+    16734088885020042614,
+    3747751605064727020,
+]
+
+# Reference uniform01 values (top 53 bits / 2^53)
+REFERENCE_UNIFORM01_VALUES = [
+    0.9068004449621377,
+    0.4617930339411858,
+    0.6654016091697149,
+    0.5163785527847619,
+    0.6518953972990012,
+    0.5252103851316428,
+    0.3389057015892847,
+    0.6336096627037583,
+    0.4395949424780534,
+    0.4820731330936308,
+]
+
+# Reference sampling results
+# Seed: "reference_sampling_v1"
+# Weights: [60000, 5000, 500]
+REFERENCE_SAMPLING_SEED = "reference_sampling_v1"
+REFERENCE_SAMPLING_WEIGHTS = [60000, 5000, 500]
+REFERENCE_SAMPLING_RESULTS = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  # Expected indices
+
+# Example honest artifact data
+# This is what an honest executor would produce
+EXAMPLE_HONEST_ARTIFACT = {
+    "seed": 42,
+    "prompt": "What is 2+2?",
+    "temperature": 0.99,
+    "tokens": [
+        {
+            "token": "100",
+            "top_tokens": ["100", "101", "102", "103", "104"],
+            "logprobs": {
+                "100": -0.5,
+                "101": -2.0,
+                "102": -3.5,
+                "103": -5.0,
+                "104": -6.5,
+            },
+            "sampling_weights": {
+                "100": 56923,
+                "101": 7025,
+                "102": 867,
+                "103": 107,
+                "104": 14,
+            },
+        },
+    ],
+}
+
+# Example pre-fill attack artifact
+# The token doesn't match what would be sampled from the weights
+EXAMPLE_PREFILL_ATTACK_ARTIFACT = {
+    "seed": 42,
+    "prompt": "What is 2+2?",
+    "temperature": 0.99,
+    "tokens": [
+        {
+            "token": "104",  # WRONG: Would actually sample "100"
+            "top_tokens": ["100", "101", "102", "103", "104"],
+            "logprobs": {
+                "100": -0.5,
+                "101": -2.0,
+                "102": -3.5,
+                "103": -5.0,
+                "104": -6.5,
+            },
+            "sampling_weights": {
+                "100": 56923,
+                "101": 7025,
+                "102": 867,
+                "103": 107,
+                "104": 14,
+            },
+        },
+    ],
+}
+
+# Example tampered weights artifact
+# The weights don't match what would be computed from logprobs
+EXAMPLE_TAMPERED_WEIGHTS_ARTIFACT = {
+    "seed": 42,
+    "prompt": "What is 2+2?",
+    "temperature": 0.99,
+    "tokens": [
+        {
+            "token": "104",
+            "top_tokens": ["100", "101", "102", "103", "104"],
+            "logprobs": {
+                "100": -0.5,
+                "101": -2.0,
+                "102": -3.5,
+                "103": -5.0,
+                "104": -6.5,
+            },
+            "sampling_weights": {
+                "100": 0,  # TAMPERED: Should be ~56923
+                "101": 0,
+                "102": 0,
+                "103": 0,
+                "104": 65536,  # Put all weight on last token
+            },
+        },
+    ],
+}
+
+# Expected distance values for Go parity verification
+# Format: (inf_logprobs, val_logprobs, expected_distance)
+DISTANCE_TEST_CASES = [
+    # Identical logprobs -> baseline distance
+    (
+        [{"100": -0.5, "200": -1.2}],
+        [{"100": -0.5, "200": -1.2}],
+        0.004975124378109453,  # (0 + 1) / (100 * 2 + 1)
+    ),
+    # Small difference
+    (
+        [{"100": -0.5, "200": -1.2}] * 100,
+        [{"100": -0.55, "200": -1.25}] * 100,
+        None,  # Will be computed, just check it's small
+    ),
+]
+
+# Fraud detection test cases
+# Format: (description, should_detect_fraud, artifact_type)
+FRAUD_DETECTION_CASES = [
+    ("honest_same_gpu", False, "honest"),
+    ("prefill_attack", True, "prefill"),
+    ("tampered_weights", True, "tampered"),
+    ("wrong_model", True, "wrong_model"),
+]

--- a/tests/v1/validation/fixtures.py
+++ b/tests/v1/validation/fixtures.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test fixtures and data generators for validation tests.
+
+These fixtures provide synthetic data for testing the validation logic
+without requiring a running vLLM server.
+"""
+
+import random
+import math
+from typing import List, Dict, Optional, Tuple
+
+from vllm.validation import EnforcedToken, EnforcedTokens
+from vllm.validation_logic import (
+    recompute_weights_from_logprobs,
+    quantize_to_weights,
+    WEIGHT_SCALE,
+)
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical_weights,
+)
+
+
+def generate_random_logprobs(
+    vocab_size: int = 32000,
+    top_k: int = 5,
+    seed: Optional[int] = None,
+) -> Dict[str, float]:
+    """
+    Generate random logprobs simulating model output.
+    
+    Args:
+        vocab_size: Total vocabulary size for token ID generation
+        top_k: Number of top tokens to include
+        seed: Random seed for reproducibility
+        
+    Returns:
+        Dict mapping token ID (str) to logprob
+    """
+    if seed is not None:
+        random.seed(seed)
+    
+    # Select random token IDs
+    token_ids = random.sample(range(vocab_size), top_k)
+    
+    # Generate logprobs (dominant token has highest prob)
+    logprobs = {}
+    
+    # Dominant token: logprob between -0.1 and -2.0
+    logprobs[str(token_ids[0])] = -random.uniform(0.1, 2.0)
+    
+    # Other tokens: progressively lower logprobs
+    for i, tid in enumerate(token_ids[1:], 1):
+        base = logprobs[str(token_ids[0])]
+        logprobs[str(tid)] = base - random.uniform(1.0 * i, 3.0 * i)
+    
+    return logprobs
+
+
+def generate_logprobs_sequence(
+    n_positions: int,
+    top_k: int = 5,
+    seed: Optional[int] = None,
+) -> List[Dict[str, float]]:
+    """Generate a sequence of logprobs for multiple positions."""
+    if seed is not None:
+        random.seed(seed)
+    
+    return [
+        generate_random_logprobs(top_k=top_k, seed=None)
+        for _ in range(n_positions)
+    ]
+
+
+def build_artifact_from_logprobs(
+    logprobs_sequence: List[Dict[str, float]],
+    seed_str: str,
+    temperature: float = 0.99,
+) -> Tuple[EnforcedTokens, List[int]]:
+    """
+    Build an artifact from logprobs using deterministic sampling.
+    
+    Returns:
+        Tuple of (EnforcedTokens artifact, list of sampled token IDs)
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    
+    tokens = []
+    sampled_ids = []
+    
+    for logprobs in logprobs_sequence:
+        # Compute weights
+        weights = recompute_weights_from_logprobs(logprobs, temperature)
+        
+        # Sort by token ID for deterministic ordering
+        sorted_items = sorted(weights.items(), key=lambda x: int(x[0]))
+        weight_list = [w for _, w in sorted_items]
+        token_list = [t for t, _ in sorted_items]
+        
+        # Sample
+        idx = sample_categorical_weights(weight_list, rng)
+        sampled_token = token_list[idx]
+        sampled_ids.append(int(sampled_token))
+        
+        tokens.append(EnforcedToken(
+            token=sampled_token,
+            top_tokens=list(logprobs.keys()),
+            logprobs=logprobs,
+            sampling_weights=weights,
+        ))
+    
+    return EnforcedTokens(tokens=tokens), sampled_ids
+
+
+def build_honest_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+    logprobs_seed: Optional[int] = None,
+) -> EnforcedTokens:
+    """
+    Build an honest artifact with correct sampling.
+    
+    This simulates what an honest executor would produce.
+    
+    Args:
+        prompt: The prompt string
+        seed: The user-provided seed
+        n_tokens: Number of tokens to generate
+        temperature: Sampling temperature
+        top_k: Number of top logprobs per position
+        logprobs_seed: Seed for generating synthetic logprobs
+        
+    Returns:
+        EnforcedTokens artifact
+    """
+    seed_str = f"{seed}|{prompt}"
+    logprobs_seq = generate_logprobs_sequence(n_tokens, top_k, logprobs_seed)
+    artifact, _ = build_artifact_from_logprobs(logprobs_seq, seed_str, temperature)
+    return artifact
+
+
+def build_prefill_attack_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+    logprobs_seed: Optional[int] = None,
+) -> EnforcedTokens:
+    """
+    Build an artifact simulating a pre-fill attack.
+    
+    The tokens don't match what would be sampled from the logprobs/weights.
+    
+    Args:
+        prompt: The prompt string
+        seed: The user-provided seed
+        n_tokens: Number of tokens to generate
+        temperature: Sampling temperature
+        top_k: Number of top logprobs per position
+        logprobs_seed: Seed for generating synthetic logprobs
+        
+    Returns:
+        EnforcedTokens artifact with wrong tokens
+    """
+    seed_str = f"{seed}|{prompt}"
+    logprobs_seq = generate_logprobs_sequence(n_tokens, top_k, logprobs_seed)
+    
+    tokens = []
+    for logprobs in logprobs_seq:
+        weights = recompute_weights_from_logprobs(logprobs, temperature)
+        
+        # ATTACK: Pick the LEAST likely token (wrong choice)
+        sorted_items = sorted(weights.items(), key=lambda x: x[1])
+        wrong_token = sorted_items[0][0]  # Lowest weight token
+        
+        tokens.append(EnforcedToken(
+            token=wrong_token,
+            top_tokens=list(logprobs.keys()),
+            logprobs=logprobs,
+            sampling_weights=weights,
+        ))
+    
+    return EnforcedTokens(tokens=tokens)
+
+
+def build_tampered_weights_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+    logprobs_seed: Optional[int] = None,
+) -> EnforcedTokens:
+    """
+    Build an artifact with tampered weights.
+    
+    The sampling_weights are modified to be inconsistent with logprobs.
+    
+    Args:
+        prompt: The prompt string
+        seed: The user-provided seed
+        n_tokens: Number of tokens to generate
+        temperature: Sampling temperature
+        top_k: Number of top logprobs per position
+        logprobs_seed: Seed for generating synthetic logprobs
+        
+    Returns:
+        EnforcedTokens artifact with tampered weights
+    """
+    seed_str = f"{seed}|{prompt}"
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    logprobs_seq = generate_logprobs_sequence(n_tokens, top_k, logprobs_seed)
+    
+    tokens = []
+    for logprobs in logprobs_seq:
+        # Create fake weights (all weight on arbitrary token)
+        token_ids = list(logprobs.keys())
+        fake_weights = {tid: 0 for tid in token_ids}
+        fake_weights[token_ids[-1]] = WEIGHT_SCALE  # All weight on last
+        
+        # Sample from fake weights
+        sorted_items = sorted(fake_weights.items(), key=lambda x: int(x[0]))
+        weight_list = [w for _, w in sorted_items]
+        token_list = [t for t, _ in sorted_items]
+        
+        idx = sample_categorical_weights(weight_list, rng)
+        sampled_token = token_list[idx]
+        
+        tokens.append(EnforcedToken(
+            token=sampled_token,
+            top_tokens=token_ids,
+            logprobs=logprobs,
+            sampling_weights=fake_weights,  # TAMPERED
+        ))
+    
+    return EnforcedTokens(tokens=tokens)
+
+
+def build_wrong_model_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 100,
+    temperature: float = 0.99,
+    top_k: int = 5,
+    logprob_shift: float = 2.0,
+) -> Tuple[EnforcedTokens, List[Dict[str, float]]]:
+    """
+    Build artifact simulating wrong model (for Stage 2 testing).
+    
+    Returns:
+        Tuple of:
+        - EnforcedTokens from "executor" (honest sampling from executor's logprobs)
+        - Validator's logprobs (shifted to simulate different model)
+    """
+    # Generate executor's honest artifact
+    honest_artifact = build_honest_artifact(
+        prompt, seed, n_tokens, temperature, top_k
+    )
+    
+    # Validator's logprobs are shifted (different model)
+    validator_logprobs = []
+    for token in honest_artifact.tokens:
+        if token.logprobs:
+            shifted = {k: v + logprob_shift for k, v in token.logprobs.items()}
+            validator_logprobs.append(shifted)
+    
+    return honest_artifact, validator_logprobs
+
+
+def perturb_logprobs(
+    logprobs: Dict[str, float],
+    noise_scale: float = 0.001,
+) -> Dict[str, float]:
+    """
+    Add small perturbation to logprobs (simulating numerical precision).
+    
+    Args:
+        logprobs: Original logprobs
+        noise_scale: Scale of noise to add
+        
+    Returns:
+        Perturbed logprobs
+    """
+    return {
+        k: v + random.gauss(0, noise_scale)
+        for k, v in logprobs.items()
+    }
+
+
+def simulate_cross_gpu_logprobs(
+    logprobs_seq: List[Dict[str, float]],
+    noise_scale: float = 0.0001,
+) -> List[Dict[str, float]]:
+    """
+    Simulate logprobs from a different GPU (small numerical differences).
+    
+    Args:
+        logprobs_seq: Original logprobs sequence
+        noise_scale: Scale of noise to add
+        
+    Returns:
+        Perturbed logprobs sequence (simulating different GPU)
+    """
+    return [perturb_logprobs(lp, noise_scale) for lp in logprobs_seq]
+
+
+# Pytest fixtures
+
+import pytest
+
+
+@pytest.fixture
+def honest_artifact():
+    """Fixture providing an honest artifact."""
+    return build_honest_artifact(
+        prompt="Test prompt",
+        seed=42,
+        n_tokens=10,
+        temperature=0.99,
+        logprobs_seed=123,
+    )
+
+
+@pytest.fixture
+def prefill_attack_artifact():
+    """Fixture providing a pre-fill attack artifact."""
+    return build_prefill_attack_artifact(
+        prompt="Test prompt",
+        seed=42,
+        n_tokens=10,
+        temperature=0.99,
+        logprobs_seed=123,
+    )
+
+
+@pytest.fixture
+def tampered_weights_artifact():
+    """Fixture providing a tampered weights artifact."""
+    return build_tampered_weights_artifact(
+        prompt="Test prompt",
+        seed=42,
+        n_tokens=10,
+        temperature=0.99,
+        logprobs_seed=123,
+    )
+
+
+@pytest.fixture
+def sample_logprobs_sequence():
+    """Fixture providing a sample logprobs sequence."""
+    return generate_logprobs_sequence(n_positions=20, top_k=5, seed=42)

--- a/tests/v1/validation/test_conformance_vectors.py
+++ b/tests/v1/validation/test_conformance_vectors.py
@@ -38,10 +38,40 @@ def _load_du():
 
 du = _load_du()
 
+
+def _load_vs(du_mod):
+    """Load validation_sampling by path (torch-free), stubbing the vllm package
+    tree so its ``from vllm.v1.sample.deterministic_utils import ...`` resolves."""
+    import types
+    for pkg in ("vllm", "vllm.v1", "vllm.v1.sample"):
+        sys.modules.setdefault(pkg, types.ModuleType(pkg))
+    sys.modules["vllm.v1.sample.deterministic_utils"] = du_mod
+    sys.modules["vllm.v1.sample"].deterministic_utils = du_mod
+    path = os.path.join(_REPO_ROOT, "vllm", "validation_sampling.py")
+    spec = importlib.util.spec_from_file_location("validation_sampling", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["validation_sampling"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vs = _load_vs(du)
+
+
+class _Tok:
+    """Duck-typed EnforcedToken stand-in (verify_sequence reads .token/.logprobs)."""
+
+    def __init__(self, token, logprobs):
+        self.token = token
+        self.logprobs = logprobs
+
+
 with open(_VECTORS) as fh:
     VECTORS = json.load(fh)
 
 CASES = VECTORS["cases"]
+SEQUENCE_CASES = VECTORS["sequence_cases"]
+DISTANCE_CASES = VECTORS["distance_cases"]
 
 
 def test_weight_scale_matches_contract():
@@ -116,3 +146,35 @@ def test_reproducible_across_runs():
         c["logprobs"], du.Sha256CounterRNG.from_seed_string(c["seed_str"]),
         c["temperature"], **kw)
     assert a == b
+
+
+@pytest.mark.parametrize("case", SEQUENCE_CASES, ids=lambda c: c["name"])
+def test_sequence_case_reproduces(case):
+    """verify_sequence reproduces the committed per-position-seed aggregation.
+    Logprobs are stored as canonical strings; parsed to float here because
+    repr(float(canonical)) == canonical, so the pipeline sees the same strings
+    the Go validator does."""
+    toks = []
+    for pos in case["positions"]:
+        lp = pos["logprobs"]
+        lp_float = ({tid: float(s) for tid, s in lp.items()}
+                    if lp is not None else None)
+        toks.append(_Tok(pos["reported_token"], lp_float))
+
+    result = vs.verify_sequence(
+        toks, case["base_seed"], case["temperature"],
+        top_p=case["top_p"], top_k=case["top_k"], min_p=case["min_p"],
+        contract_version=case["contract_version"], greedy=case["greedy"])
+
+    exp = case["expected"]
+    assert result.verdict.value == exp["verdict"]
+    assert result.fraud_position == exp["fraud_position"]
+    assert result.n_honest == exp["n_honest"]
+    assert result.n_inconclusive == exp["n_inconclusive"]
+
+
+@pytest.mark.parametrize("case", DISTANCE_CASES, ids=lambda c: c["name"])
+def test_distance_case_reproduces(case):
+    """mae_distance reproduces the committed Stage-2 distance bit-for-bit."""
+    got = vs.mae_distance(case["executor"], case["validator"])
+    assert got == case["expected_mae"]

--- a/tests/v1/validation/test_conformance_vectors.py
+++ b/tests/v1/validation/test_conformance_vectors.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Drift guard for the deterministic-sampling cross-language contract.
+
+Re-runs the reference Python pipeline over the committed conformance vectors and
+asserts the outputs still match. If this fails, either the pipeline changed
+(bump contract_version and regenerate) or a regression slipped in. The gonka Go
+validator consumes the same JSON and must produce identical results.
+
+Pure CPU, no torch/GPU — deterministic_utils is loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+_DU_PATH = os.path.join(_REPO_ROOT, "vllm", "v1", "sample", "deterministic_utils.py")
+_VECTORS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "conformance_vectors.json")
+
+
+def _load_du():
+    spec = importlib.util.spec_from_file_location("deterministic_utils", _DU_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["deterministic_utils"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+du = _load_du()
+
+with open(_VECTORS) as fh:
+    VECTORS = json.load(fh)
+
+CASES = VECTORS["cases"]
+
+
+def test_weight_scale_matches_contract():
+    assert VECTORS["weight_scale"] == du.WEIGHT_SCALE == 65536
+
+
+def test_uint64_below_vectors():
+    ub = VECTORS["uint64_below"]
+    for case in ub["cases"]:
+        rng = du.Sha256CounterRNG.from_seed_string(ub["seed"])
+        got = [du.uint64_below(rng, case["n"]) for _ in case["draws"]]
+        assert got == case["draws"], case["n"]
+
+
+def test_rng_reference_vector():
+    ref = VECTORS["rng_reference"]
+    assert du.iter_u64(ref["seed"], len(ref["first_u64"])) == ref["first_u64"]
+    # The pinned reference value from the contract (§5).
+    assert ref["first_u64"][0] == 4286832458236889005
+
+
+def test_float_to_string_canonicalization():
+    import struct
+    f32_neg005 = struct.unpack("f", struct.pack("f", -0.05))[0]
+    assert repr(-0.05) == "-0.05"
+    assert repr(f32_neg005) == "-0.05000000074505806"
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_case_reproduces(case):
+    logprobs = case["logprobs"]
+    kw = dict(top_p=case["top_p"], top_k=case["top_k"], min_p=case["min_p"])
+
+    weights = du.logprobs_to_weights(logprobs, case["temperature"], **kw)
+    weights = {tid: int(w) for tid, w in weights.items()}
+    assert weights == case["expected_weights"], case["name"]
+    assert sum(weights.values()) == case["expected_weight_sum"] == 65536
+
+    rng = du.Sha256CounterRNG.from_seed_string(case["seed_str"])
+    token = du.decimal_sample_from_logprobs(logprobs, rng, case["temperature"], **kw)
+    assert token == case["expected_token"], case["name"]
+
+
+def test_seed_derivation_accept_vectors():
+    # The committed accept digests must still reproduce through
+    # derive_chain_bound_seed, and the domain tag must match the impl. The Go
+    # validator consumes the same block and must derive identical seeds.
+    sd = VECTORS["seed_derivation"]
+    assert sd["domain_tag"] == du._SEED_DOMAIN_TAG
+    for case in sd["accept"]:
+        got = du.derive_chain_bound_seed(case["user_seed"], case["inference_id"])
+        assert got == case["expected_seed"], case["inference_id"]
+
+
+def test_seed_derivation_reject_vectors():
+    # Every inference_id the contract marks invalid must fail closed (never
+    # silently derive a seed) on the Python side too.
+    sd = VECTORS["seed_derivation"]
+    for case in sd["reject_inference_id"]:
+        with pytest.raises(ValueError):
+            du.derive_chain_bound_seed(7, case["inference_id"])
+
+
+def test_reproducible_across_runs():
+    # Same seed twice -> identical token (determinism, not just fixture match).
+    c = CASES[0]
+    kw = dict(top_p=c["top_p"], top_k=c["top_k"], min_p=c["min_p"])
+    a = du.decimal_sample_from_logprobs(
+        c["logprobs"], du.Sha256CounterRNG.from_seed_string(c["seed_str"]),
+        c["temperature"], **kw)
+    b = du.decimal_sample_from_logprobs(
+        c["logprobs"], du.Sha256CounterRNG.from_seed_string(c["seed_str"]),
+        c["temperature"], **kw)
+    assert a == b

--- a/tests/v1/validation/test_conformance_vectors.py
+++ b/tests/v1/validation/test_conformance_vectors.py
@@ -164,7 +164,8 @@ def test_sequence_case_reproduces(case):
     result = vs.verify_sequence(
         toks, case["base_seed"], case["temperature"],
         top_p=case["top_p"], top_k=case["top_k"], min_p=case["min_p"],
-        contract_version=case["contract_version"], greedy=case["greedy"])
+        contract_version=case["contract_version"],
+        seed_domain=case["seed_domain"], greedy=case["greedy"])
 
     exp = case["expected"]
     assert result.verdict.value == exp["verdict"]

--- a/tests/v1/validation/test_distance_calculation.py
+++ b/tests/v1/validation/test_distance_calculation.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for distance calculation.
+
+These tests verify that the Python implementation matches the Go implementation
+in gonka/decentralized-api/internal/validation/inference_validation.go.
+
+The distance metric uses: |a - b| / (eps + |a| + |b|) / 2
+Aggregated across all positions and normalized.
+"""
+
+import pytest
+import math
+
+from vllm.validation_logic import (
+    position_distance,
+    compute_distance,
+    DEFAULT_FRAUD_DISTANCE_THRESHOLD,
+)
+
+
+class TestPositionDistance:
+    """Test single position distance calculation."""
+
+    def test_identical_logprobs_zero_distance(self):
+        """Identical logprobs should have zero distance."""
+        logprobs = {"100": -0.5, "200": -1.2, "300": -2.1}
+        dist = position_distance(logprobs, logprobs)
+        assert dist == 0.0
+
+    def test_different_logprobs_nonzero_distance(self):
+        """Different logprobs should have non-zero distance."""
+        inf_lp = {"100": -0.5, "200": -1.2}
+        val_lp = {"100": -0.8, "200": -1.5}
+        
+        dist = position_distance(inf_lp, val_lp)
+        assert 0.0 < dist < 1.0
+        
+    def test_symmetric_distance(self):
+        """Distance should be symmetric: d(a,b) == d(b,a)."""
+        inf_lp = {"100": -0.5, "200": -1.2, "300": -2.5}
+        val_lp = {"100": -0.7, "200": -1.0, "300": -2.8}
+        
+        dist1 = position_distance(inf_lp, val_lp)
+        dist2 = position_distance(val_lp, inf_lp)
+        
+        # Should be equal (symmetric)
+        assert abs(dist1 - dist2) < 1e-10
+
+    def test_missing_token_estimation(self):
+        """Test distance when validator is missing a token."""
+        inf_lp = {"100": -0.5, "200": -1.2, "300": -2.1}
+        val_lp = {"100": -0.5, "200": -1.2}  # Missing 300
+        
+        dist = position_distance(inf_lp, val_lp)
+        
+        # Should have non-zero distance due to estimated missing token
+        assert dist > 0.0
+
+    def test_empty_logprobs(self):
+        """Empty logprobs should return zero distance."""
+        assert position_distance({}, {}) == 0.0
+        assert position_distance({"100": -0.5}, {}) == 0.0
+        assert position_distance({}, {"100": -0.5}) == 0.0
+
+    def test_single_token(self):
+        """Test with single token."""
+        inf_lp = {"100": -0.5}
+        val_lp = {"100": -0.5}
+        assert position_distance(inf_lp, val_lp) == 0.0
+        
+        val_lp = {"100": -1.0}
+        assert position_distance(inf_lp, val_lp) > 0.0
+
+    def test_distance_formula_correctness(self):
+        """Verify the distance formula matches Go implementation."""
+        # Test case with known values
+        inf_lp = {"100": -1.0, "200": -2.0}
+        val_lp = {"100": -1.5, "200": -2.5}
+        
+        dist = position_distance(inf_lp, val_lp)
+        
+        # Manual calculation:
+        # Token 100: |(-1.0) - (-1.5)| / (1e-10 + |-1.0| + |-1.5|) / 2
+        #          = 0.5 / (1e-10 + 1.0 + 1.5) / 2
+        #          = 0.5 / 2.5 / 2 = 0.1
+        # Token 200: |(-2.0) - (-2.5)| / (1e-10 + |-2.0| + |-2.5|) / 2
+        #          = 0.5 / (1e-10 + 2.0 + 2.5) / 2
+        #          = 0.5 / 4.5 / 2 ≈ 0.0556
+        # Total ≈ 0.1 + 0.0556 ≈ 0.1556
+        
+        expected = 0.5 / 2.5 / 2 + 0.5 / 4.5 / 2
+        assert abs(dist - expected) < 1e-6
+
+
+class TestComputeDistance:
+    """Test full sequence distance calculation."""
+
+    def test_identical_sequences_zero_distance(self):
+        """Identical sequences should have low distance."""
+        logprobs = [
+            {"100": -0.5, "200": -1.2},
+            {"300": -0.8, "400": -2.1},
+            {"500": -0.3, "600": -1.5},
+        ]
+        
+        dist = compute_distance(logprobs, logprobs)
+        
+        # Distance should be close to normalization baseline
+        # (total_dist=0 + 1.0) / (max(100, 3) * 2 + 1.0)
+        expected_baseline = 1.0 / (100 * 2 + 1.0)
+        assert abs(dist - expected_baseline) < 1e-6
+
+    def test_different_sequences_nonzero_distance(self):
+        """Different sequences should have higher distance."""
+        inf_logprobs = [
+            {"100": -0.5, "200": -1.2},
+            {"300": -0.8, "400": -2.1},
+        ]
+        val_logprobs = [
+            {"100": -0.8, "200": -1.5},
+            {"300": -1.2, "400": -2.5},
+        ]
+        
+        dist = compute_distance(inf_logprobs, val_logprobs)
+        
+        # Should be higher than baseline
+        baseline = 1.0 / (100 * 2 + 1.0)
+        assert dist > baseline
+
+    def test_length_mismatch_max_distance(self):
+        """Mismatched sequence lengths should return max fraud distance."""
+        inf_logprobs = [{"100": -0.5}, {"200": -1.0}]
+        val_logprobs = [{"100": -0.5}]
+        
+        dist = compute_distance(inf_logprobs, val_logprobs)
+        assert dist == 10.0
+
+    def test_empty_sequences(self):
+        """Empty sequences should return zero distance."""
+        assert compute_distance([], []) == 0.0
+
+    def test_normalization(self):
+        """Test normalization matches Go implementation."""
+        # With 150 positions and top-5 logprobs
+        n_positions = 150
+        n_tokens = 5
+        
+        # Create identical sequences
+        logprobs = [
+            {str(i): -float(i) for i in range(100, 100 + n_tokens)}
+            for _ in range(n_positions)
+        ]
+        
+        dist = compute_distance(logprobs, logprobs)
+        
+        # Normalization: (0 + 1.0) / (max(100, 150) * 5 + 1.0)
+        expected = 1.0 / (150 * 5 + 1.0)
+        assert abs(dist - expected) < 1e-6
+
+    def test_fraud_threshold(self):
+        """Test that significant differences exceed fraud threshold."""
+        # Simulate very different distributions (wrong model)
+        inf_logprobs = [
+            {"100": -0.1, "200": -5.0, "300": -10.0}  # Token 100 dominates
+            for _ in range(100)
+        ]
+        val_logprobs = [
+            {"100": -5.0, "200": -0.1, "300": -10.0}  # Token 200 dominates
+            for _ in range(100)
+        ]
+        
+        dist = compute_distance(inf_logprobs, val_logprobs)
+        
+        # Should exceed fraud threshold
+        assert dist > DEFAULT_FRAUD_DISTANCE_THRESHOLD
+
+
+class TestGoParity:
+    """
+    Tests to verify parity with Go implementation.
+    
+    These use specific test cases with known expected values from
+    the Go implementation in inference_validation.go.
+    """
+
+    def test_position_distance_go_example_1(self):
+        """Test case from Go implementation."""
+        # Example logprobs
+        inf_lp = {
+            "16": -0.0008104139124043286,
+            "15": -7.125810623168945,
+            "785": -13.875810623168945,
+        }
+        val_lp = {
+            "16": -0.0008104139124043286,
+            "15": -7.125810623168945,
+            "785": -13.875810623168945,
+        }
+        
+        dist = position_distance(inf_lp, val_lp)
+        assert dist == 0.0
+
+    def test_honest_execution_passes_threshold(self):
+        """Honest execution (same model) should pass threshold."""
+        # Simulated honest logprobs with small FP variations
+        inf_logprobs = []
+        val_logprobs = []
+        
+        for i in range(100):
+            # Small variations due to numerical precision
+            inf = {
+                "100": -0.5 + i * 0.001,
+                "200": -1.2 - i * 0.0005,
+                "300": -2.1 + i * 0.0008,
+            }
+            val = {
+                "100": -0.5 + i * 0.001 + 0.0001,  # Tiny variation
+                "200": -1.2 - i * 0.0005 - 0.0002,
+                "300": -2.1 + i * 0.0008 + 0.0001,
+            }
+            inf_logprobs.append(inf)
+            val_logprobs.append(val)
+        
+        dist = compute_distance(inf_logprobs, val_logprobs)
+        
+        # Should be below fraud threshold
+        assert dist < DEFAULT_FRAUD_DISTANCE_THRESHOLD, \
+            f"Honest execution distance {dist} exceeds threshold"
+
+
+class TestEdgeCases:
+    """Test edge cases and corner cases."""
+
+    def test_very_negative_logprobs(self):
+        """Test with very negative logprobs (rare tokens)."""
+        inf_lp = {"100": -0.1, "999": -50.0}
+        val_lp = {"100": -0.1, "999": -50.0}
+        
+        dist = position_distance(inf_lp, val_lp)
+        assert dist == 0.0
+
+    def test_near_zero_logprobs(self):
+        """Test with logprobs near zero (dominant token)."""
+        inf_lp = {"100": -0.0001, "200": -10.0}
+        val_lp = {"100": -0.0002, "200": -10.0}
+        
+        dist = position_distance(inf_lp, val_lp)
+        assert dist > 0.0  # Should be small but non-zero
+
+    def test_large_vocabulary(self):
+        """Test with large number of top-k tokens."""
+        n_tokens = 50
+        
+        inf_lp = {str(i): -float(i) / 10 for i in range(100, 100 + n_tokens)}
+        val_lp = {str(i): -float(i) / 10 for i in range(100, 100 + n_tokens)}
+        
+        dist = position_distance(inf_lp, val_lp)
+        assert dist == 0.0

--- a/tests/v1/validation/test_replay_smoke.py
+++ b/tests/v1/validation/test_replay_smoke.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-CPU smoke test for Check 2 sampling replay (no torch).
+
+Asserts that ``verify_sampling_from_logprobs`` correctly accepts a self-
+consistent position and rejects a tampered one.
+
+Scope:
+- This proves the *replay logic* is correct, NOT that the executor is honest
+  (that needs Check 1 / GPU), and NOT that it accepts a real v011 executor
+  artifact (the production weight path is not yet reproducible). The artifact
+  here is self-consistent: the "reported" token is computed by the same decimal
+  pipeline the validator replays.
+"""
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    decimal_sample_from_logprobs,
+)
+from vllm.validation_sampling import verify_sampling_from_logprobs
+
+# A position's logprobs as JSON floats (as they live on EnforcedToken.logprobs).
+_LOGPROBS = {
+    "791": -0.05000000074505806,
+    "1": -3.0,
+    "2": -3.5,
+    "10": -4.0,
+}
+_SEED = "42|[1,2,3]"
+_TEMPERATURE = "1.0"
+
+
+def _self_consistent_token() -> str:
+    """The token the validator's own pipeline draws for this position -- i.e.
+    what an honest executor sharing the decimal path would report."""
+    logprob_strings = {tid: repr(f) for tid, f in _LOGPROBS.items()}
+    return decimal_sample_from_logprobs(
+        logprob_strings,
+        Sha256CounterRNG.from_seed_string(_SEED),
+        _TEMPERATURE,
+    )
+
+
+def test_replay_accepts_self_consistent_token():
+    honest_token = _self_consistent_token()
+    assert verify_sampling_from_logprobs(
+        _LOGPROBS, _SEED, _TEMPERATURE,
+        top_p=None, top_k=None, min_p=None,
+        reported_token=honest_token,
+    ) is True
+
+
+def test_replay_rejects_tampered_token():
+    honest_token = _self_consistent_token()
+    tampered = next(t for t in _LOGPROBS if t != honest_token)
+    assert verify_sampling_from_logprobs(
+        _LOGPROBS, _SEED, _TEMPERATURE,
+        top_p=None, top_k=None, min_p=None,
+        reported_token=tampered,
+    ) is False

--- a/tests/v1/validation/test_sampling_verification.py
+++ b/tests/v1/validation/test_sampling_verification.py
@@ -1,0 +1,423 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for sampling verification and weight consistency.
+
+These tests verify:
+1. Deterministic sampling verification (Stage 1b)
+2. Weight consistency verification (Stage 1a)
+3. Weight quantization
+"""
+
+import pytest
+import math
+from typing import List, Dict
+
+from vllm.validation_logic import (
+    verify_sampling_sequence,
+    verify_weights_consistency,
+    recompute_weights_from_logprobs,
+    quantize_to_weights,
+    WEIGHT_SCALE,
+)
+from vllm.validation import EnforcedToken
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical_weights,
+)
+
+
+class TestQuantizeToWeights:
+    """Test probability to weight quantization."""
+
+    def test_basic_quantization(self):
+        """Test basic probability quantization."""
+        probs = {"100": 0.6, "200": 0.3, "300": 0.1}
+        weights = quantize_to_weights(probs)
+        
+        assert weights["100"] == round(0.6 * WEIGHT_SCALE)
+        assert weights["200"] == round(0.3 * WEIGHT_SCALE)
+        assert weights["300"] == round(0.1 * WEIGHT_SCALE)
+
+    def test_weights_sum_approximately_correct(self):
+        """Weights should sum to approximately WEIGHT_SCALE."""
+        probs = {str(i): 1/100 for i in range(100)}  # Uniform
+        weights = quantize_to_weights(probs)
+        
+        total = sum(weights.values())
+        # Allow small rounding error
+        assert abs(total - WEIGHT_SCALE) < 100
+
+    def test_dominant_token(self):
+        """Test with one dominant token."""
+        probs = {"100": 0.9999, "200": 0.0001}
+        weights = quantize_to_weights(probs)
+        
+        assert weights["100"] > WEIGHT_SCALE * 0.99
+        assert weights["200"] < 10
+
+    def test_empty_probs(self):
+        """Empty probs should return empty weights."""
+        assert quantize_to_weights({}) == {}
+
+    def test_zero_probs(self):
+        """Zero probabilities should quantize to zero."""
+        probs = {"100": 0.5, "200": 0.5, "300": 0.0}
+        weights = quantize_to_weights(probs)
+        
+        assert weights["300"] == 0
+
+
+class TestRecomputeWeightsFromLogprobs:
+    """Test weight recomputation from logprobs."""
+
+    def test_basic_recomputation(self):
+        """Test basic weight recomputation."""
+        # Logprobs that give roughly [0.6, 0.3, 0.1] after softmax
+        logprobs = {"100": -0.5, "200": -1.2, "300": -2.3}
+        
+        weights = recompute_weights_from_logprobs(logprobs, temperature=1.0)
+        
+        # Should have three weights
+        assert len(weights) == 3
+        # First should be largest
+        assert weights["100"] > weights["200"] > weights["300"]
+
+    def test_temperature_effect(self):
+        """Test that temperature affects weight distribution."""
+        logprobs = {"100": -0.5, "200": -1.0, "300": -2.0}
+        
+        weights_high_temp = recompute_weights_from_logprobs(logprobs, temperature=2.0)
+        weights_low_temp = recompute_weights_from_logprobs(logprobs, temperature=0.5)
+        
+        # Higher temperature -> more uniform distribution
+        # Lower temperature -> more peaked distribution
+        ratio_high = weights_high_temp["100"] / max(1, weights_high_temp["300"])
+        ratio_low = weights_low_temp["100"] / max(1, weights_low_temp["300"])
+        
+        assert ratio_low > ratio_high  # Low temp is more peaked
+
+    def test_empty_logprobs(self):
+        """Empty logprobs should return empty weights."""
+        assert recompute_weights_from_logprobs({}, temperature=1.0) == {}
+
+    def test_single_token(self):
+        """Single token should get all weight."""
+        logprobs = {"100": -0.5}
+        weights = recompute_weights_from_logprobs(logprobs, temperature=1.0)
+        
+        assert weights["100"] == WEIGHT_SCALE
+
+
+class TestVerifySamplingSequence:
+    """Test sampling sequence verification (Stage 1b)."""
+
+    def test_correct_sampling_passes(self):
+        """Correctly sampled sequence should pass verification."""
+        seed_str = "verification_test_seed"
+        
+        # Generate a sequence with known correct sampling
+        weights1 = [60000, 5000, 500]
+        weights2 = [30000, 30000, 5536]
+        token_ids = ["100", "200", "300"]
+        
+        # Sample using same RNG to get expected tokens
+        rng = Sha256CounterRNG.from_seed_string(seed_str)
+        idx1 = sample_categorical_weights(weights1, rng)
+        idx2 = sample_categorical_weights(weights2, rng)
+        
+        expected_token1 = token_ids[idx1]
+        expected_token2 = token_ids[idx2]
+        
+        # Build artifact with correct tokens
+        tokens = [
+            EnforcedToken(
+                token=expected_token1,
+                top_tokens=token_ids,
+                sampling_weights={tid: w for tid, w in zip(token_ids, weights1)},
+            ),
+            EnforcedToken(
+                token=expected_token2,
+                top_tokens=token_ids,
+                sampling_weights={tid: w for tid, w in zip(token_ids, weights2)},
+            ),
+        ]
+        
+        success, failed_pos = verify_sampling_sequence(tokens, seed_str)
+        
+        assert success, f"Verification failed at position {failed_pos}"
+        assert failed_pos == -1
+
+    def test_wrong_token_fails(self):
+        """Wrong token should fail verification."""
+        seed_str = "wrong_token_test"
+        weights = [60000, 5000, 500]
+        token_ids = ["100", "200", "300"]
+        
+        # Get expected token
+        rng = Sha256CounterRNG.from_seed_string(seed_str)
+        expected_idx = sample_categorical_weights(weights, rng)
+        
+        # Use wrong token
+        wrong_idx = (expected_idx + 1) % 3
+        wrong_token = token_ids[wrong_idx]
+        
+        tokens = [
+            EnforcedToken(
+                token=wrong_token,
+                top_tokens=token_ids,
+                sampling_weights={tid: w for tid, w in zip(token_ids, weights)},
+            ),
+        ]
+        
+        success, failed_pos = verify_sampling_sequence(tokens, seed_str)
+        
+        assert not success
+        assert failed_pos == 0
+
+    def test_wrong_seed_fails(self):
+        """Wrong seed should fail verification."""
+        correct_seed = "correct_seed"
+        wrong_seed = "wrong_seed"
+        
+        weights = [60000, 5000, 500]
+        token_ids = ["100", "200", "300"]
+        
+        # Sample with correct seed
+        rng = Sha256CounterRNG.from_seed_string(correct_seed)
+        idx = sample_categorical_weights(weights, rng)
+        token = token_ids[idx]
+        
+        tokens = [
+            EnforcedToken(
+                token=token,
+                top_tokens=token_ids,
+                sampling_weights={tid: w for tid, w in zip(token_ids, weights)},
+            ),
+        ]
+        
+        # Verify with wrong seed
+        success, failed_pos = verify_sampling_sequence(tokens, wrong_seed)
+        
+        # May or may not fail depending on whether wrong seed happens to
+        # produce same sample (unlikely but possible)
+        # In most cases it should fail
+        # This test documents the behavior
+
+    def test_no_weights_skipped(self):
+        """Tokens without sampling_weights should be skipped."""
+        seed_str = "no_weights_test"
+        
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                sampling_weights=None,  # No weights
+            ),
+        ]
+        
+        success, failed_pos = verify_sampling_sequence(tokens, seed_str)
+        
+        # Should pass (nothing to verify)
+        assert success
+        assert failed_pos == -1
+
+    def test_long_sequence(self):
+        """Test with longer sequence."""
+        seed_str = "long_sequence_test"
+        n_positions = 50
+        
+        weights_template = [60000, 5000, 500, 35, 1]
+        token_ids = ["100", "200", "300", "400", "500"]
+        
+        # Generate expected sequence
+        rng = Sha256CounterRNG.from_seed_string(seed_str)
+        expected_tokens = []
+        for _ in range(n_positions):
+            idx = sample_categorical_weights(weights_template, rng)
+            expected_tokens.append(token_ids[idx])
+        
+        # Build artifact
+        tokens = [
+            EnforcedToken(
+                token=expected_tokens[i],
+                top_tokens=token_ids,
+                sampling_weights={tid: w for tid, w in zip(token_ids, weights_template)},
+            )
+            for i in range(n_positions)
+        ]
+        
+        success, failed_pos = verify_sampling_sequence(tokens, seed_str)
+        
+        assert success, f"Failed at position {failed_pos}"
+        assert failed_pos == -1
+
+
+class TestVerifyWeightsConsistency:
+    """Test weight consistency verification (Stage 1a)."""
+
+    def test_consistent_weights_pass(self):
+        """Consistent weights should pass verification."""
+        # Create logprobs and compute weights
+        logprobs = {"100": -0.5, "200": -1.2, "300": -2.3}
+        weights = recompute_weights_from_logprobs(logprobs, temperature=0.99)
+        
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200", "300"],
+                logprobs=logprobs,
+                sampling_weights=weights,
+            ),
+        ]
+        
+        success, failed_pos = verify_weights_consistency(tokens, temperature=0.99)
+        
+        assert success
+        assert failed_pos == -1
+
+    def test_tampered_weights_fail(self):
+        """Tampered weights should fail verification."""
+        logprobs = {"100": -0.5, "200": -1.2, "300": -2.3}
+        correct_weights = recompute_weights_from_logprobs(logprobs, temperature=0.99)
+        
+        # Tamper with weights
+        tampered_weights = dict(correct_weights)
+        tampered_weights["100"] = 99999  # Very different
+        
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200", "300"],
+                logprobs=logprobs,
+                sampling_weights=tampered_weights,
+            ),
+        ]
+        
+        success, failed_pos = verify_weights_consistency(tokens, temperature=0.99)
+        
+        assert not success
+        assert failed_pos == 0
+
+    def test_no_logprobs_skipped(self):
+        """Tokens without logprobs should be skipped."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                logprobs=None,
+                sampling_weights={"100": 60000, "200": 5536},
+            ),
+        ]
+        
+        success, failed_pos = verify_weights_consistency(tokens, temperature=0.99)
+        
+        # Should pass (nothing to verify)
+        assert success
+        assert failed_pos == -1
+
+    def test_no_weights_skipped(self):
+        """Tokens without weights should be skipped."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                logprobs={"100": -0.5, "200": -1.2},
+                sampling_weights=None,
+            ),
+        ]
+        
+        success, failed_pos = verify_weights_consistency(tokens, temperature=0.99)
+        
+        assert success
+        assert failed_pos == -1
+
+    def test_tolerance_allows_small_differences(self):
+        """Small differences within tolerance should pass."""
+        logprobs = {"100": -0.5, "200": -1.2}
+        correct_weights = recompute_weights_from_logprobs(logprobs, temperature=0.99)
+        
+        # Add small perturbation (within 5% tolerance)
+        slightly_off_weights = {
+            k: int(v * 1.03)  # 3% increase
+            for k, v in correct_weights.items()
+        }
+        
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                logprobs=logprobs,
+                sampling_weights=slightly_off_weights,
+            ),
+        ]
+        
+        success, failed_pos = verify_weights_consistency(
+            tokens, temperature=0.99, tolerance=0.05
+        )
+        
+        assert success
+
+
+class TestDeterministicRNGProperties:
+    """Test properties of the deterministic RNG."""
+
+    def test_rng_reproducibility(self):
+        """Same seed should produce identical sequence."""
+        seed = "reproducibility_test"
+        
+        rng1 = Sha256CounterRNG.from_seed_string(seed)
+        rng2 = Sha256CounterRNG.from_seed_string(seed)
+        
+        for _ in range(100):
+            assert rng1.next_u64() == rng2.next_u64()
+
+    def test_different_seeds_differ(self):
+        """Different seeds should produce different sequences."""
+        rng1 = Sha256CounterRNG.from_seed_string("seed_a")
+        rng2 = Sha256CounterRNG.from_seed_string("seed_b")
+        
+        seq1 = [rng1.next_u64() for _ in range(10)]
+        seq2 = [rng2.next_u64() for _ in range(10)]
+        
+        assert seq1 != seq2
+
+    def test_sample_categorical_weights_distribution(self):
+        """Sampling should follow weight distribution."""
+        weights = [60000, 4000, 1536, 500]  # Sum = 66036
+        seed = "distribution_test"
+        
+        rng = Sha256CounterRNG.from_seed_string(seed)
+        n_samples = 10000
+        
+        counts = [0] * len(weights)
+        for _ in range(n_samples):
+            idx = sample_categorical_weights(weights, rng)
+            counts[idx] += 1
+        
+        # Check approximate proportions (with some tolerance)
+        total_weight = sum(weights)
+        for i, (count, weight) in enumerate(zip(counts, weights)):
+            expected_prop = weight / total_weight
+            actual_prop = count / n_samples
+            # Allow 10% relative error
+            if expected_prop > 0.01:  # Only check non-negligible probs
+                assert abs(actual_prop - expected_prop) / expected_prop < 0.2, \
+                    f"Index {i}: expected {expected_prop:.3f}, got {actual_prop:.3f}"
+
+    def test_reference_values(self):
+        """Verify reference values for cross-implementation testing."""
+        rng = Sha256CounterRNG.from_seed_string("reference_seed_v1")
+        
+        # These values are from the current Sha256CounterRNG implementation
+        expected = [
+            4286832458236889005,
+            12281003819428572724,
+            12352776571910749143,
+            12178488218135958089,
+            6205195570139478562,
+        ]
+        
+        for exp in expected:
+            actual = rng.next_u64()
+            assert actual == exp, f"Reference value mismatch: {actual} != {exp}"

--- a/tests/v1/validation/test_sequence_replay.py
+++ b/tests/v1/validation/test_sequence_replay.py
@@ -114,6 +114,23 @@ def test_missing_logprobs_position_is_inconclusive_not_fraud():
     assert r.n_honest == len(_POS) - 1
 
 
+def test_unsupported_seed_domain_is_inconclusive():
+    # mirrors the Go validator's seed-domain gate (detsample.VerifyPosition).
+    r = verify_sequence(_honest_artifact(), _BASE_SEED, _TEMP,
+                        top_p=None, top_k=_TOP_K, min_p=None,
+                        seed_domain="some-other-domain")
+    assert r.verdict is Verdict.INCONCLUSIVE
+    assert "seed domain" in r.reason
+
+
+def test_zero_weights_raises_not_silent_fallback():
+    # §6.9: a degenerate all-zero weight vector must raise, not silently return
+    # the last index (matches the Go validator, which errors).
+    import pytest
+    with pytest.raises(ValueError):
+        sample_categorical_weights([0, 0, 0], Sha256CounterRNG.from_seed_string("z"))
+
+
 def test_support_boundedness_rule():
     assert _support_is_bounded(_TOP_K, None) is True
     assert _support_is_bounded(None, "0.02") is True

--- a/tests/v1/validation/test_sequence_replay.py
+++ b/tests/v1/validation/test_sequence_replay.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-CPU tests for the sequence-level Stage-1 replay orchestrator
+(``verify_sequence``) and the Stage-2 ``mae_distance`` metric — the contract-
+faithful path that replaces the legacy ``validation_logic.validate_full``
+(gonka-ai/gonka#1199 follow-up).
+
+Scope: replay/aggregation logic only. The "reported" tokens are computed by the
+same decimal pipeline the validator replays (self-consistent artifacts), so an
+HONEST verdict proves the orchestration is correct, not that a real executor is
+honest. No torch: ``verify_sequence`` reads only ``.token`` / ``.logprobs``, so a
+minimal stand-in stands in for ``EnforcedToken``.
+"""
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    logprobs_to_weights,
+    sample_categorical_weights,
+)
+from vllm.validation_sampling import (
+    STAGE2_MAE_FRAUD_THRESHOLD,
+    Verdict,
+    _support_is_bounded,
+    mae_distance,
+    verify_sequence,
+)
+
+_BASE_SEED = "42|[1,2,3]"
+_TEMP = "1.0"
+_TOP_K = 20  # bounded support (> the 5 tokens per position, so clamps to all)
+
+# Four positions of self-consistent per-position logprobs.
+_POS = [
+    {"5": -0.5, "10": -1.2, "2": -2.5, "100": -3.9, "7": -4.1},
+    {"3": -0.3, "42": -1.1, "9": -2.2, "11": -3.0, "1": -4.5},
+    {"8": -0.7, "6": -1.5, "4": -2.0, "20": -2.9, "15": -3.3},
+    {"12": -0.9, "13": -1.8, "14": -2.4, "16": -3.1, "17": -3.7},
+]
+
+
+class _Tok:
+    """Duck-typed stand-in for EnforcedToken (verify_sequence only reads
+    ``.token`` and ``.logprobs``)."""
+
+    def __init__(self, token, logprobs):
+        self.token = token
+        self.logprobs = logprobs
+
+
+def _honest_token(logprobs, pos, *, top_p=None, top_k=_TOP_K, min_p=None):
+    """The token an honest executor sharing the decimal path would report at
+    ``pos`` — the same pipeline + per-position seed verify_sequence replays."""
+    lp = {tid: repr(f) for tid, f in logprobs.items()}
+    weights = logprobs_to_weights(lp, _TEMP, top_p=top_p, top_k=top_k, min_p=min_p)
+    tids = sorted(weights)
+    weight_list = [weights[t] for t in tids]
+    rng = Sha256CounterRNG.from_seed_string(f"{_BASE_SEED}|{pos}")
+    return tids[sample_categorical_weights(weight_list, rng)]
+
+
+def _honest_artifact():
+    return [_Tok(_honest_token(p, i), p) for i, p in enumerate(_POS)]
+
+
+# --------------------------------------------------------------------------- #
+# Stage-1: verify_sequence
+# --------------------------------------------------------------------------- #
+
+def test_sequence_accepts_honest():
+    r = verify_sequence(_honest_artifact(), _BASE_SEED, _TEMP,
+                        top_p=None, top_k=_TOP_K, min_p=None)
+    assert r.verdict is Verdict.HONEST
+    assert r.n_honest == len(_POS)
+    assert r.fraud_position == -1
+
+
+def test_sequence_flags_first_tampered_position():
+    toks = _honest_artifact()
+    toks[2] = _Tok("999999", _POS[2])  # a token the RNG would not have drawn
+    r = verify_sequence(toks, _BASE_SEED, _TEMP,
+                        top_p=None, top_k=_TOP_K, min_p=None)
+    assert r.verdict is Verdict.FRAUD
+    assert r.fraud_position == 2
+
+
+def test_unbounded_support_is_inconclusive():
+    # top_p only, no top_k / min_p -> support may exceed the signed top-K.
+    r = verify_sequence(_honest_artifact(), _BASE_SEED, _TEMP,
+                        top_p="0.9", top_k=None, min_p=None)
+    assert r.verdict is Verdict.INCONCLUSIVE
+    assert "unbounded" in r.reason
+
+
+def test_greedy_is_inconclusive():
+    r = verify_sequence(_honest_artifact(), _BASE_SEED, "0",
+                        top_p=None, top_k=_TOP_K, min_p=None, greedy=True)
+    assert r.verdict is Verdict.INCONCLUSIVE
+
+
+def test_unsupported_version_is_inconclusive():
+    r = verify_sequence(_honest_artifact(), _BASE_SEED, _TEMP,
+                        top_p=None, top_k=_TOP_K, min_p=None,
+                        contract_version="9.9.9")
+    assert r.verdict is Verdict.INCONCLUSIVE
+
+
+def test_missing_logprobs_position_is_inconclusive_not_fraud():
+    toks = _honest_artifact()
+    toks[1] = _Tok(toks[1].token, None)  # no replay data at this position
+    r = verify_sequence(toks, _BASE_SEED, _TEMP,
+                        top_p=None, top_k=_TOP_K, min_p=None)
+    assert r.verdict is Verdict.HONEST  # >=1 honest; missing != fraud
+    assert r.n_inconclusive == 1
+    assert r.n_honest == len(_POS) - 1
+
+
+def test_support_boundedness_rule():
+    assert _support_is_bounded(_TOP_K, None) is True
+    assert _support_is_bounded(None, "0.02") is True
+    assert _support_is_bounded(None, None) is False   # pure temperature
+    assert _support_is_bounded(0, "0") is False       # disabled sentinels
+
+
+# --------------------------------------------------------------------------- #
+# Stage-2: mae_distance
+# --------------------------------------------------------------------------- #
+
+def test_mae_distance_identical_is_zero():
+    assert mae_distance([_POS[0]], [_POS[0]]) == 0.0
+
+
+def test_mae_distance_uniform_shift():
+    shifted = {tid: v - 0.5 for tid, v in _POS[0].items()}
+    assert abs(mae_distance([_POS[0]], [shifted]) - 0.5) < 1e-9
+
+
+def test_mae_distance_length_mismatch_is_max():
+    assert mae_distance([_POS[0], _POS[1]], [_POS[0]]) == 10.0
+
+
+def test_mae_distance_missing_token_penalized():
+    partial = dict(list(_POS[0].items())[:-1])  # validator missing one token
+    assert mae_distance([_POS[0]], [partial]) > STAGE2_MAE_FRAUD_THRESHOLD

--- a/tests/v1/validation/test_token_order_convergence.py
+++ b/tests/v1/validation/test_token_order_convergence.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression test for U12 — token iteration order (contract §3).
+
+Two Python validators must agree on the same artifact:
+- ``validation_sampling.py`` sorts the weight list by token-ID **string**
+  (lexicographic, contract §3 — the correct one).
+- ``validation_logic.py::verify_sampling_sequence`` historically sorted by
+  **numeric** token id, so ``"10" < "2"`` lexicographically but ``2 < 10``
+  numerically. The two orderings map the same RNG draw to different tokens and
+  false-reject an honest executor.
+
+Contract §3 pins lexicographic string order; the numeric-sort path must match.
+
+Pure CPU, no torch/GPU — modules are loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _load_by_path(mod_name: str, rel_path: str):
+    """Load a stdlib-only module by file path, bypassing ``import vllm``
+    (which pulls torch). Registers in sys.modules first so dataclasses in the
+    module resolve their own module namespace."""
+    path = os.path.join(_REPO_ROOT, rel_path)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# deterministic_utils must be importable as its bare name because
+# validation_logic imports it as `from vllm.v1.sample.deterministic_utils`.
+# We shim that import path by pre-registering the by-path module under the
+# fully-qualified name the function uses.
+_du = _load_by_path("deterministic_utils",
+                    "vllm/v1/sample/deterministic_utils.py")
+sys.modules["vllm.v1.sample.deterministic_utils"] = _du
+
+_vl = _load_by_path("validation_logic", "vllm/validation_logic.py")
+
+
+class _StubToken:
+    """Minimal stand-in for EnforcedToken: only the two attributes
+    verify_sampling_sequence touches."""
+
+    def __init__(self, token: str, sampling_weights):
+        self.token = token
+        self.sampling_weights = sampling_weights
+
+
+# Chosen so lexicographic and numeric order diverge:
+#   lexicographic ("10" < "2") -> RNG draws token "2"
+#   numeric       (2 < 10)     -> RNG draws token "10"
+_SEED = "42|1,2,3"
+_WEIGHTS = {"2": 30000, "10": 35536}  # sums to 65536
+_HONEST_TOKEN = "2"  # what the contract's lexicographic order actually samples
+
+
+def test_verify_sampling_sequence_accepts_lexicographically_honest_artifact():
+    """An artifact whose token was sampled under contract §3 (lexicographic
+    string order) must verify as honest. Under the legacy numeric sort it
+    false-rejects."""
+    tokens = [_StubToken(_HONEST_TOKEN, _WEIGHTS)]
+
+    success, failed_pos = _vl.verify_sampling_sequence(tokens, _SEED)
+
+    assert success is True, (
+        f"honest lexicographic artifact false-rejected at pos {failed_pos}; "
+        "verify_sampling_sequence is not using contract §3 string order")
+    assert failed_pos == -1
+
+
+def test_verify_sampling_sequence_still_rejects_tampered_token():
+    """The order fix must not weaken detection: a token that was NOT the one
+    sampled under contract §3 order must still be flagged as fraud."""
+    # Under lexicographic order the honest token is "2"; claiming "10" is a
+    # tampered artifact.
+    tokens = [_StubToken("10", _WEIGHTS)]
+
+    success, failed_pos = _vl.verify_sampling_sequence(tokens, _SEED)
+
+    assert success is False
+    assert failed_pos == 0

--- a/tests/v1/validation/test_validation_e2e.py
+++ b/tests/v1/validation/test_validation_e2e.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+End-to-end tests for validation with real vLLM server.
+
+These tests require:
+1. A running vLLM server with VLLM_DETERMINISTIC_SAMPLING=1
+2. Network access to the server
+
+Run with:
+    RUN_E2E_TESTS=1 pytest tests/v1/validation/test_validation_e2e.py -v
+
+Or start server manually and run:
+    VLLM_TEST_SERVER_URL=http://localhost:8000 pytest tests/v1/validation/test_validation_e2e.py -v
+"""
+
+import os
+import json
+import pytest
+from typing import Dict, List, Any, Optional
+
+
+# Skip all tests if E2E testing is not enabled
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RUN_E2E_TESTS") and not os.environ.get("VLLM_TEST_SERVER_URL"),
+    reason="E2E tests disabled. Set RUN_E2E_TESTS=1 or VLLM_TEST_SERVER_URL"
+)
+
+
+def get_server_url() -> str:
+    """Get the vLLM server URL."""
+    return os.environ.get("VLLM_TEST_SERVER_URL", "http://localhost:8000")
+
+
+def get_model_name() -> str:
+    """Get the model name to use for testing."""
+    return os.environ.get("VLLM_TEST_MODEL", "Qwen/Qwen2.5-1.5B-Instruct")
+
+
+@pytest.fixture(scope="module")
+def http_client():
+    """Create HTTP client for API calls."""
+    import requests
+    
+    class SimpleClient:
+        def __init__(self, base_url: str, model: str):
+            self.base_url = base_url
+            self.model = model
+        
+        def chat_completion(
+            self,
+            messages: List[Dict[str, str]],
+            **kwargs
+        ) -> Dict[str, Any]:
+            """Send chat completion request."""
+            response = requests.post(
+                f"{self.base_url}/v1/chat/completions",
+                json={
+                    "model": self.model,
+                    "messages": messages,
+                    **kwargs
+                },
+                timeout=120,
+            )
+            response.raise_for_status()
+            return response.json()
+    
+    return SimpleClient(get_server_url(), get_model_name())
+
+
+def build_enforced_tokens_from_response(response: Dict) -> Dict:
+    """Build enforced_tokens dict from executor response."""
+    content = response["choices"][0]["logprobs"]["content"]
+    
+    tokens = []
+    for pos in content:
+        token_data = {
+            "token": str(pos["token"]),
+            "top_tokens": [str(t["token"]) for t in pos["top_logprobs"]],
+        }
+        
+        # Include logprobs if available
+        if pos.get("top_logprobs"):
+            token_data["logprobs"] = {
+                str(t["token"]): t["logprob"]
+                for t in pos["top_logprobs"]
+            }
+        
+        # Include sampling_weights if available
+        if pos.get("sampling_weights"):
+            token_data["sampling_weights"] = pos["sampling_weights"]
+        
+        tokens.append(token_data)
+    
+    return {"tokens": tokens}
+
+
+@pytest.mark.e2e
+class TestDeterministicSampling:
+    """Test deterministic sampling features."""
+    
+    def test_sampling_weights_in_response(self, http_client):
+        """Test that sampling_weights are included when logprobs requested."""
+        response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "Say hello"}],
+            temperature=0.99,
+            seed=42,
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=5,
+        )
+        
+        content = response["choices"][0]["logprobs"]["content"]
+        assert len(content) > 0, "No logprobs content returned"
+        
+        first_token = content[0]
+        assert "sampling_weights" in first_token, "sampling_weights missing"
+        assert first_token["sampling_weights"] is not None, "sampling_weights is None"
+        assert isinstance(first_token["sampling_weights"], dict), "sampling_weights not dict"
+        
+        # Verify weights are integers
+        for tid, weight in first_token["sampling_weights"].items():
+            assert isinstance(weight, int), f"Weight {weight} is not int"
+    
+    def test_reproducibility(self, http_client):
+        """Test that same seed produces identical outputs."""
+        params = {
+            "messages": [{"role": "user", "content": "Count from 1 to 5"}],
+            "temperature": 0.99,
+            "seed": 12345,
+            "max_tokens": 20,
+        }
+        
+        results = []
+        for _ in range(3):
+            response = http_client.chat_completion(**params)
+            text = response["choices"][0]["message"]["content"]
+            results.append(text)
+        
+        assert len(set(results)) == 1, f"Outputs differ: {results}"
+    
+    def test_different_seeds_differ(self, http_client):
+        """Test that different seeds produce different outputs."""
+        base_params = {
+            "messages": [{"role": "user", "content": "Write a random sentence"}],
+            "temperature": 0.99,
+            "max_tokens": 20,
+        }
+        
+        results = []
+        for seed in [100, 200, 300]:
+            response = http_client.chat_completion(**base_params, seed=seed)
+            text = response["choices"][0]["message"]["content"]
+            results.append(text)
+        
+        # At least 2 different outputs (unlikely but possible to get same)
+        assert len(set(results)) >= 2, "All seeds produced same output"
+    
+    def test_greedy_no_weights(self, http_client):
+        """Test that greedy sampling doesn't include weights."""
+        response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "Hello"}],
+            temperature=0,  # Greedy
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=5,
+        )
+        
+        content = response["choices"][0]["logprobs"]["content"]
+        first_token = content[0]
+        
+        # Greedy should have None weights
+        weights = first_token.get("sampling_weights")
+        assert weights is None, f"Expected None for greedy, got {weights}"
+
+
+@pytest.mark.e2e
+class TestValidationFlow:
+    """Test the full validation flow."""
+    
+    def test_honest_executor_passes_validation(self, http_client):
+        """Test that honest executor's artifact passes validation."""
+        # Step 1: Executor generates
+        exec_response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            temperature=0.99,
+            seed=42,
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=10,
+        )
+        
+        # Step 2: Build enforced_tokens
+        enforced_tokens = build_enforced_tokens_from_response(exec_response)
+        
+        # Verify we have the necessary data
+        assert len(enforced_tokens["tokens"]) > 0
+        first_token = enforced_tokens["tokens"][0]
+        assert "logprobs" in first_token or "sampling_weights" in first_token
+        
+        # Step 3: Validator verifies (same prompt, seed, params)
+        # Note: The actual validation result depends on server implementation
+        # This test just verifies the flow works
+        try:
+            val_response = http_client.chat_completion(
+                messages=[{"role": "user", "content": "What is 2+2?"}],
+                temperature=0.99,
+                seed=42,
+                logprobs=True,
+                top_logprobs=5,
+                max_tokens=10,
+                extra_body={"enforced_tokens": enforced_tokens},
+            )
+            
+            # Check for validation result if present
+            if "validation" in val_response:
+                validation = val_response["validation"]
+                assert not validation.get("fraud"), "Honest execution flagged as fraud!"
+        except Exception as e:
+            # Some servers may not support extra_body
+            pytest.skip(f"Server doesn't support enforced_tokens: {e}")
+    
+    def test_executor_validator_output_match(self, http_client):
+        """Test that executor and validator produce matching logprobs."""
+        # Generate with executor
+        exec_response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "The capital of France is"}],
+            temperature=0.99,
+            seed=999,
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=5,
+        )
+        
+        exec_content = exec_response["choices"][0]["logprobs"]["content"]
+        exec_text = exec_response["choices"][0]["message"]["content"]
+        
+        # Generate again with same params (simulating validator)
+        val_response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "The capital of France is"}],
+            temperature=0.99,
+            seed=999,
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=5,
+        )
+        
+        val_content = val_response["choices"][0]["logprobs"]["content"]
+        val_text = val_response["choices"][0]["message"]["content"]
+        
+        # Outputs should be identical (deterministic)
+        assert exec_text == val_text, f"Texts differ: {exec_text} != {val_text}"
+        
+        # Logprobs should be very close
+        for i, (exec_pos, val_pos) in enumerate(zip(exec_content, val_content)):
+            assert exec_pos["token"] == val_pos["token"], \
+                f"Tokens differ at position {i}"
+            
+            # Compare top logprob values
+            exec_top = {t["token"]: t["logprob"] for t in exec_pos["top_logprobs"]}
+            val_top = {t["token"]: t["logprob"] for t in val_pos["top_logprobs"]}
+            
+            for token in exec_top:
+                if token in val_top:
+                    diff = abs(exec_top[token] - val_top[token])
+                    assert diff < 0.01, \
+                        f"Logprob diff too large at pos {i}: {diff}"
+
+
+@pytest.mark.e2e
+class TestWeightIntegrity:
+    """Test sampling weight integrity."""
+    
+    def test_weights_sum_approximately_correct(self, http_client):
+        """Test that sampling weights sum to approximately 2^16."""
+        response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "Hello world"}],
+            temperature=0.99,
+            seed=42,
+            logprobs=True,
+            top_logprobs=10,
+            max_tokens=5,
+        )
+        
+        WEIGHT_SCALE = 2**16
+        
+        content = response["choices"][0]["logprobs"]["content"]
+        for i, pos in enumerate(content):
+            weights = pos.get("sampling_weights")
+            if weights:
+                total = sum(weights.values())
+                # Allow some tolerance for rounding
+                assert abs(total - WEIGHT_SCALE) < WEIGHT_SCALE * 0.1, \
+                    f"Weight sum {total} too far from {WEIGHT_SCALE} at position {i}"
+    
+    def test_weights_match_logprob_ordering(self, http_client):
+        """Test that weight ordering matches logprob ordering."""
+        response = http_client.chat_completion(
+            messages=[{"role": "user", "content": "Test"}],
+            temperature=0.99,
+            seed=42,
+            logprobs=True,
+            top_logprobs=5,
+            max_tokens=3,
+        )
+        
+        content = response["choices"][0]["logprobs"]["content"]
+        for pos in content:
+            weights = pos.get("sampling_weights")
+            if not weights:
+                continue
+            
+            top_logprobs = pos["top_logprobs"]
+            
+            # Get tokens sorted by logprob (descending = higher prob first)
+            sorted_by_logprob = sorted(
+                top_logprobs,
+                key=lambda x: x["logprob"],
+                reverse=True
+            )
+            
+            # Get tokens sorted by weight (descending)
+            sorted_by_weight = sorted(
+                [(t["token"], weights.get(str(t["token"]), 0)) for t in top_logprobs],
+                key=lambda x: x[1],
+                reverse=True
+            )
+            
+            # Orderings should generally match (may differ for near-equal values)
+            # Just check that highest logprob has highest weight
+            if len(sorted_by_logprob) > 0 and len(sorted_by_weight) > 0:
+                top_logprob_token = str(sorted_by_logprob[0]["token"])
+                top_weight_token = sorted_by_weight[0][0]
+                
+                # Allow for ties in near-equal cases
+                top_logprob_val = sorted_by_logprob[0]["logprob"]
+                second_logprob_val = sorted_by_logprob[1]["logprob"] if len(sorted_by_logprob) > 1 else -999
+                
+                if top_logprob_val - second_logprob_val > 0.1:
+                    # Clear winner, should match
+                    assert top_logprob_token == top_weight_token, \
+                        f"Top tokens don't match: logprob={top_logprob_token}, weight={top_weight_token}"
+
+
+@pytest.mark.e2e
+class TestStreamingWithWeights:
+    """Test streaming responses with sampling weights."""
+    
+    def test_streaming_includes_weights(self, http_client):
+        """Test that streaming responses include sampling_weights."""
+        import requests
+        
+        response = requests.post(
+            f"{get_server_url()}/v1/chat/completions",
+            json={
+                "model": get_model_name(),
+                "messages": [{"role": "user", "content": "Hi"}],
+                "temperature": 0.99,
+                "seed": 42,
+                "logprobs": True,
+                "top_logprobs": 5,
+                "max_tokens": 5,
+                "stream": True,
+            },
+            stream=True,
+            timeout=60,
+        )
+        
+        weights_found = False
+        for line in response.iter_lines():
+            if line:
+                line = line.decode('utf-8')
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    data = json.loads(line[6:])
+                    choices = data.get("choices", [])
+                    for choice in choices:
+                        logprobs = choice.get("logprobs")
+                        if logprobs and logprobs.get("content"):
+                            for pos in logprobs["content"]:
+                                if pos.get("sampling_weights"):
+                                    weights_found = True
+                                    break
+        
+        assert weights_found, "No sampling_weights found in streaming response"
+
+
+# Utility for manual testing
+def main():
+    """Run a quick manual test."""
+    import requests
+    
+    base_url = get_server_url()
+    model = get_model_name()
+    
+    print(f"Testing server at {base_url} with model {model}")
+    
+    # Test 1: Check sampling_weights
+    print("\n=== Test 1: sampling_weights in response ===")
+    response = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.99,
+            "seed": 42,
+            "logprobs": True,
+            "top_logprobs": 5,
+            "max_tokens": 3,
+        },
+    )
+    data = response.json()
+    content = data["choices"][0]["logprobs"]["content"]
+    print(f"First token: {content[0]['token']}")
+    print(f"Weights: {content[0].get('sampling_weights')}")
+    
+    # Test 2: Reproducibility
+    print("\n=== Test 2: Reproducibility ===")
+    results = []
+    for i in range(3):
+        response = requests.post(
+            f"{base_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Count to 3"}],
+                "temperature": 0.99,
+                "seed": 12345,
+                "max_tokens": 10,
+            },
+        )
+        text = response.json()["choices"][0]["message"]["content"]
+        results.append(text)
+        print(f"Run {i+1}: {text[:50]}...")
+    
+    if len(set(results)) == 1:
+        print("✓ All runs identical")
+    else:
+        print("✗ Runs differ!")
+    
+    print("\n=== Done ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/validation/test_validation_failure_direction.py
+++ b/tests/v1/validation/test_validation_failure_direction.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Failure direction of the serving-side validator (issue #1199, review Point 6).
+
+When the validator itself cannot produce a verdict — a bug, an unexpected
+exception, a version it cannot replay — it must NOT translate that into
+"executor honest" (fraud=False). A validator-side failure yields *no verdict*,
+never a silent pass. This mirrors detsample.VerifyPosition's principle that a
+validator-side problem is inconclusive, never a fraud judgement about the
+executor.
+
+Tests the pure decision function, not the full serving stack (which needs torch
++ fastapi). Loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _load_by_path(mod_name: str, rel_path: str):
+    path = os.path.join(_REPO_ROOT, rel_path)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_du = _load_by_path("deterministic_utils",
+                    "vllm/v1/sample/deterministic_utils.py")
+sys.modules["vllm.v1.sample.deterministic_utils"] = _du
+_vs = _load_by_path("validation_sampling", "vllm/validation_sampling.py")
+
+
+def test_validator_error_yields_no_verdict_not_pass():
+    """A validator-side error must yield None (no verdict), never a silent
+    fraud=False pass."""
+    err = RuntimeError("weights consistency check blew up")
+
+    result = _vs.result_for_validator_error(err)
+
+    assert result is None, (
+        "a validator-side error must not be translated into a verdict; "
+        "returning a fraud=False result silently passes the executor")

--- a/tests/v1/validation/test_validation_flow.py
+++ b/tests/v1/validation/test_validation_flow.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Integration tests for validation flow.
+
+These tests verify the full validation flow with synthetic/mocked data,
+without requiring a running vLLM server.
+"""
+
+import pytest
+from typing import List, Dict
+
+from vllm.validation import EnforcedToken, EnforcedTokens
+from vllm.validation_logic import (
+    validate_before_model,
+    validate_after_model,
+    validate_full,
+    recompute_weights_from_logprobs,
+    WEIGHT_SCALE,
+    DEFAULT_FRAUD_DISTANCE_THRESHOLD,
+)
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical_weights,
+)
+
+
+def build_honest_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+) -> EnforcedTokens:
+    """
+    Build an honest artifact with correct sampling.
+    
+    This simulates what an honest executor would produce.
+    """
+    seed_str = f"{seed}|{prompt}"
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    
+    tokens = []
+    for i in range(n_tokens):
+        # Generate synthetic logprobs
+        # Dominant token has high prob, others lower
+        logprobs = {}
+        token_ids = [str(100 + j) for j in range(top_k)]
+        
+        # Create descending logprobs
+        for j, tid in enumerate(token_ids):
+            logprobs[tid] = -(0.5 + j * 1.5)  # -0.5, -2.0, -3.5, ...
+        
+        # Compute weights from logprobs
+        weights = recompute_weights_from_logprobs(logprobs, temperature)
+        
+        # Sample token using RNG
+        sorted_items = sorted(weights.items(), key=lambda x: int(x[0]))
+        weight_list = [w for _, w in sorted_items]
+        token_list = [t for t, _ in sorted_items]
+        
+        idx = sample_categorical_weights(weight_list, rng)
+        sampled_token = token_list[idx]
+        
+        tokens.append(EnforcedToken(
+            token=sampled_token,
+            top_tokens=token_ids,
+            logprobs=logprobs,
+            sampling_weights=weights,
+        ))
+    
+    return EnforcedTokens(tokens=tokens)
+
+
+def build_prefill_attack_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+) -> EnforcedTokens:
+    """
+    Build an artifact simulating a pre-fill attack.
+    
+    The attacker used a cheap model to generate tokens, then computed
+    logprobs from the expensive model. The tokens don't match what
+    would be sampled from the logprobs.
+    """
+    seed_str = f"{seed}|{prompt}"
+    
+    tokens = []
+    for i in range(n_tokens):
+        # Generate synthetic logprobs
+        logprobs = {}
+        token_ids = [str(100 + j) for j in range(top_k)]
+        
+        for j, tid in enumerate(token_ids):
+            logprobs[tid] = -(0.5 + j * 1.5)
+        
+        # Compute weights
+        weights = recompute_weights_from_logprobs(logprobs, temperature)
+        
+        # ATTACK: Use a WRONG token (not sampled from weights)
+        # Pick the least likely token instead
+        wrong_token = token_ids[-1]
+        
+        tokens.append(EnforcedToken(
+            token=wrong_token,
+            top_tokens=token_ids,
+            logprobs=logprobs,
+            sampling_weights=weights,
+        ))
+    
+    return EnforcedTokens(tokens=tokens)
+
+
+def build_tampered_weights_artifact(
+    prompt: str,
+    seed: int,
+    n_tokens: int = 10,
+    temperature: float = 0.99,
+    top_k: int = 5,
+) -> EnforcedTokens:
+    """
+    Build an artifact with tampered weights.
+    
+    The attacker modified the sampling_weights to match their desired tokens,
+    but the weights are inconsistent with the logprobs.
+    """
+    seed_str = f"{seed}|{prompt}"
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    
+    tokens = []
+    for i in range(n_tokens):
+        logprobs = {}
+        token_ids = [str(100 + j) for j in range(top_k)]
+        
+        for j, tid in enumerate(token_ids):
+            logprobs[tid] = -(0.5 + j * 1.5)
+        
+        # ATTACK: Create fake weights that would sample the wrong token
+        # Put all weight on the last token
+        fake_weights = {tid: 0 for tid in token_ids}
+        fake_weights[token_ids[-1]] = WEIGHT_SCALE  # All weight on last
+        
+        # Sample from fake weights (will always pick last)
+        sorted_items = sorted(fake_weights.items(), key=lambda x: int(x[0]))
+        weight_list = [w for _, w in sorted_items]
+        token_list = [t for t, _ in sorted_items]
+        
+        idx = sample_categorical_weights(weight_list, rng)
+        sampled_token = token_list[idx]
+        
+        tokens.append(EnforcedToken(
+            token=sampled_token,
+            top_tokens=token_ids,
+            logprobs=logprobs,
+            sampling_weights=fake_weights,
+        ))
+    
+    return EnforcedTokens(tokens=tokens)
+
+
+class TestValidateBeforeModel:
+    """Test pre-model validation (Stage 1)."""
+
+    def test_honest_artifact_passes(self):
+        """Honest artifact should pass Stage 1."""
+        artifact = build_honest_artifact("What is 2+2?", seed=42)
+        seed_str = "42|What is 2+2?"
+        
+        result = validate_before_model(
+            artifact,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert not result.fraud
+        assert result.correct_sampling
+        assert result.correct_processed_logprobs
+
+    def test_prefill_attack_detected(self):
+        """Pre-fill attack should be detected in Stage 1b."""
+        artifact = build_prefill_attack_artifact("What is 2+2?", seed=42)
+        seed_str = "42|What is 2+2?"
+        
+        result = validate_before_model(
+            artifact,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert result.fraud
+        assert not result.correct_sampling
+        assert result.distance == 10.0
+
+    def test_tampered_weights_detected(self):
+        """Tampered weights should be detected in Stage 1a."""
+        artifact = build_tampered_weights_artifact("What is 2+2?", seed=42)
+        seed_str = "42|What is 2+2?"
+        
+        result = validate_before_model(
+            artifact,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert result.fraud
+        assert not result.correct_processed_logprobs
+        assert result.distance == 10.0
+
+    def test_no_weights_skips_validation(self):
+        """Artifact without weights should skip Stage 1."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                logprobs={"100": -0.5, "200": -1.2},
+                sampling_weights=None,  # No weights
+            )
+        ]
+        artifact = EnforcedTokens(tokens=tokens)
+        
+        result = validate_before_model(
+            artifact,
+            "test_seed",
+            temperature=0.99,
+        )
+        
+        # Should pass (nothing to verify)
+        assert not result.fraud
+
+
+class TestValidateAfterModel:
+    """Test post-model validation (Stage 2)."""
+
+    def test_identical_logprobs_pass(self):
+        """Identical logprobs should pass with low distance."""
+        logprobs = [
+            {"100": -0.5, "200": -1.2, "300": -2.1},
+            {"100": -0.8, "200": -0.9, "300": -2.5},
+        ]
+        
+        result = validate_after_model(logprobs, logprobs)
+        
+        assert not result.fraud
+        assert result.correct_raw_logprobs
+        assert result.distance < DEFAULT_FRAUD_DISTANCE_THRESHOLD
+
+    def test_small_differences_pass(self):
+        """Small differences (numerical precision) should pass."""
+        executor_lp = [
+            {"100": -0.5, "200": -1.2},
+            {"100": -0.8, "200": -1.5},
+        ]
+        validator_lp = [
+            {"100": -0.5001, "200": -1.2002},  # Tiny difference
+            {"100": -0.8001, "200": -1.5001},
+        ]
+        
+        result = validate_after_model(executor_lp, validator_lp)
+        
+        assert not result.fraud
+        assert result.correct_raw_logprobs
+
+    def test_large_differences_fail(self):
+        """Large differences (wrong model) should fail."""
+        executor_lp = [
+            {"100": -0.1, "200": -5.0},  # Token 100 dominates
+        ] * 100
+        validator_lp = [
+            {"100": -5.0, "200": -0.1},  # Token 200 dominates
+        ] * 100
+        
+        result = validate_after_model(executor_lp, validator_lp)
+        
+        assert result.fraud
+        assert not result.correct_raw_logprobs
+        assert result.distance > DEFAULT_FRAUD_DISTANCE_THRESHOLD
+
+    def test_length_mismatch_fails(self):
+        """Mismatched sequence lengths should fail."""
+        executor_lp = [{"100": -0.5}] * 10
+        validator_lp = [{"100": -0.5}] * 5  # Different length
+        
+        result = validate_after_model(executor_lp, validator_lp)
+        
+        assert result.fraud
+        assert result.distance == 10.0
+
+
+class TestValidateFull:
+    """Test full two-stage validation."""
+
+    def test_honest_execution_passes_all(self):
+        """Honest execution should pass all checks."""
+        artifact = build_honest_artifact("Hello world", seed=123, n_tokens=20)
+        seed_str = "123|Hello world"
+        
+        # Validator's logprobs (same as executor's in honest case)
+        validator_logprobs = [t.logprobs for t in artifact.tokens]
+        
+        result = validate_full(
+            artifact,
+            validator_logprobs,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert not result.fraud
+        assert result.correct_sampling
+        assert result.correct_processed_logprobs
+        assert result.correct_raw_logprobs
+        assert result.distance < DEFAULT_FRAUD_DISTANCE_THRESHOLD
+
+    def test_prefill_attack_fails_stage1(self):
+        """Pre-fill attack should fail at Stage 1."""
+        artifact = build_prefill_attack_artifact("Hello world", seed=123)
+        seed_str = "123|Hello world"
+        
+        # Even with matching validator logprobs, should fail Stage 1
+        validator_logprobs = [t.logprobs for t in artifact.tokens]
+        
+        result = validate_full(
+            artifact,
+            validator_logprobs,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert result.fraud
+        assert not result.correct_sampling  # Failed Stage 1b
+
+    def test_wrong_model_fails_stage2(self):
+        """Wrong model should pass Stage 1 but fail Stage 2."""
+        artifact = build_honest_artifact("Hello world", seed=123, n_tokens=100)
+        seed_str = "123|Hello world"
+        
+        # Validator's logprobs are different (simulating wrong model)
+        validator_logprobs = []
+        for t in artifact.tokens:
+            # Shift all logprobs
+            shifted = {k: v - 2.0 for k, v in t.logprobs.items()}
+            validator_logprobs.append(shifted)
+        
+        result = validate_full(
+            artifact,
+            validator_logprobs,
+            seed_str,
+            temperature=0.99,
+        )
+        
+        assert result.fraud
+        assert result.correct_sampling  # Stage 1 passed
+        assert result.correct_processed_logprobs  # Stage 1a passed
+        assert not result.correct_raw_logprobs  # Stage 2 failed
+
+
+class TestValidationResultFields:
+    """Test ValidationResult field semantics."""
+
+    def test_fraud_false_by_default(self):
+        """Result should not indicate fraud by default."""
+        from vllm.entrypoints.openai.protocol import ValidationResult
+        
+        result = ValidationResult()
+        
+        assert not result.fraud
+        assert result.correct_raw_logprobs
+        assert result.correct_processed_logprobs
+        assert result.correct_sampling
+
+    def test_fraud_indicators_set_correctly(self):
+        """Fraud indicators should be set based on which check failed."""
+        # Pre-fill attack
+        artifact = build_prefill_attack_artifact("test", seed=1)
+        result = validate_before_model(artifact, "1|test", temperature=0.99)
+        
+        assert result.fraud
+        assert not result.correct_sampling
+        assert result.correct_processed_logprobs  # Didn't fail this
+
+        # Tampered weights
+        artifact = build_tampered_weights_artifact("test", seed=1)
+        result = validate_before_model(artifact, "1|test", temperature=0.99)
+        
+        assert result.fraud
+        assert not result.correct_processed_logprobs
+
+
+class TestEnforcedTokensHelpers:
+    """Test EnforcedTokens helper methods."""
+
+    def test_has_validation_data_with_logprobs(self):
+        """Should return True when logprobs present."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                logprobs={"100": -0.5, "200": -1.2},
+            )
+        ]
+        artifact = EnforcedTokens(tokens=tokens)
+        
+        assert artifact.has_validation_data()
+
+    def test_has_validation_data_with_weights(self):
+        """Should return True when weights present."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+                sampling_weights={"100": 60000, "200": 5536},
+            )
+        ]
+        artifact = EnforcedTokens(tokens=tokens)
+        
+        assert artifact.has_validation_data()
+
+    def test_has_validation_data_without_data(self):
+        """Should return False when no validation data."""
+        tokens = [
+            EnforcedToken(
+                token="100",
+                top_tokens=["100", "200"],
+            )
+        ]
+        artifact = EnforcedTokens(tokens=tokens)
+        
+        assert not artifact.has_validation_data()
+
+    def test_from_content_with_logprobs(self):
+        """Test creating from OpenAI-format content."""
+        content = [
+            {
+                "token": "100",
+                "logprob": -0.5,
+                "top_logprobs": [
+                    {"token": "100", "logprob": -0.5},
+                    {"token": "200", "logprob": -1.2},
+                ],
+            },
+        ]
+        
+        artifact = EnforcedTokens.from_content(
+            content,
+            include_logprobs=True,
+            include_sampling_weights=False,
+        )
+        
+        assert len(artifact.tokens) == 1
+        assert artifact.tokens[0].token == "100"
+        assert artifact.tokens[0].logprobs == {"100": -0.5, "200": -1.2}
+
+    def test_from_content_with_weights(self):
+        """Test creating with sampling weights."""
+        content = [
+            {
+                "token": "100",
+                "logprob": -0.5,
+                "top_logprobs": [
+                    {"token": "100", "logprob": -0.5},
+                    {"token": "200", "logprob": -1.2},
+                ],
+                "sampling_weights": {"100": 60000, "200": 5536},
+            },
+        ]
+        
+        artifact = EnforcedTokens.from_content(
+            content,
+            include_logprobs=True,
+            include_sampling_weights=True,
+        )
+        
+        assert artifact.tokens[0].sampling_weights == {"100": 60000, "200": 5536}

--- a/tests/v1/validation/test_verdict_three_valued.py
+++ b/tests/v1/validation/test_verdict_three_valued.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Three-valued verdict for single-position replay (Python side of Go's
+``detsample.VerifyPosition``).
+
+A replay mismatch is only *fraud* when the validator could faithfully reproduce
+the executor's computation. An unsupported contract version, a greedy position,
+a non-positive temperature, or a validator-side replay error is *inconclusive*,
+never fraud — so a validator-side or version problem does not punish an honest
+executor. Mirrors ``verify.go`` clause-for-clause (gonka
+decentralized-api/internal/validation/detsample/verify.go).
+
+Scope: single position only. Sequence/response-level aggregation is intentionally
+out of scope (not yet defined on the Go side either).
+
+Pure CPU, no torch/GPU — loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _load_by_path(mod_name: str, rel_path: str):
+    path = os.path.join(_REPO_ROOT, rel_path)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_du = _load_by_path("deterministic_utils",
+                    "vllm/v1/sample/deterministic_utils.py")
+sys.modules["vllm.v1.sample.deterministic_utils"] = _du
+_vs = _load_by_path("validation_sampling", "vllm/validation_sampling.py")
+
+
+# An honest position: token "1" is what the pipeline samples for these
+# logprobs / seed / temperature (computed with the reference pipeline).
+_LOGPROBS = {"1": -0.5, "2": -1.2, "3": -2.0}
+_SEED = "reference_seed_v1"
+_TEMP = "1.0"
+_HONEST_TOKEN = "1"
+_SUPPORTED_VERSION = "1.0.0"
+
+
+def _pos(**overrides):
+    """Build a keyword dict for verify_position with honest defaults."""
+    kw = dict(
+        contract_version=_SUPPORTED_VERSION,
+        logprobs=_LOGPROBS,
+        seed_str=_SEED,
+        temperature=_TEMP,
+        top_p=None,
+        top_k=None,
+        min_p=None,
+        reported_token=_HONEST_TOKEN,
+        greedy=False,
+    )
+    kw.update(overrides)
+    return kw
+
+
+def test_honest_position_returns_honest():
+    assert _vs.verify_position(**_pos()).verdict == _vs.Verdict.HONEST
+
+
+def test_tampered_token_returns_fraud():
+    assert _vs.verify_position(
+        **_pos(reported_token="3")).verdict == _vs.Verdict.FRAUD
+
+
+def test_unsupported_contract_version_is_inconclusive_not_fraud():
+    v = _vs.verify_position(**_pos(contract_version="9.9.9",
+                                   reported_token="3")).verdict
+    assert v == _vs.Verdict.INCONCLUSIVE  # version skew, not fraud
+
+
+def test_greedy_position_is_inconclusive():
+    # temperature 0 / greedy bypasses the RNG (contract §7): no sequence signal.
+    assert _vs.verify_position(
+        **_pos(greedy=True)).verdict == _vs.Verdict.INCONCLUSIVE
+
+
+def test_non_positive_temperature_without_greedy_is_inconclusive():
+    # An inconsistent artifact (temp<=0 but greedy flag unset) is not fraud.
+    assert _vs.verify_position(
+        **_pos(temperature="0")).verdict == _vs.Verdict.INCONCLUSIVE

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -134,10 +134,10 @@ class FrontendArgs:
     is provided, vLLM will add it to the server using
     `@app.middleware('http')`. If a class is provided, vLLM will
     add it to the server using `app.add_middleware()`."""
-    return_tokens_as_token_ids: bool = False
+    return_tokens_as_token_ids: bool = True
     """When `--max-logprobs` is specified, represents single tokens as
-    strings of the form 'token_id:{token_id}' so that tokens that are not
-    JSON-encodable can be identified."""
+    plain token-id strings (e.g. '641') for compatibility with enforced-token
+    validation utilities and older vLLM variants."""
     disable_frontend_multiprocessing: bool = False
     """If specified, will run the OpenAI frontend server in the same process as
     the model serving engine."""

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -6,8 +6,11 @@
 import json
 import time
 from http import HTTPStatus
-from typing import Annotated, Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import (
+    Annotated, Any, ClassVar, Generic, Literal, TypeAlias, TypeVar, Optional
+)
 
+import msgspec
 import regex as re
 import torch
 from fastapi import HTTPException, UploadFile
@@ -56,6 +59,9 @@ from vllm.utils.serial_utils import (
     EncodingFormat,
     Endianness,
 )
+
+from vllm.validation import EnforcedToken, EnforcedTokens
+
 
 # Backward compatibility for OpenAI client versions
 try:  # For older openai versions (< 1.100.0)
@@ -742,8 +748,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         default=None,
         description=(
             "If specified with 'logprobs', tokens are represented "
-            " as strings of the form 'token_id:{token_id}' so that tokens "
-            "that are not JSON-encodable can be identified."
+            " as plain token-id strings (e.g. '641') for compatibility with"
+            " enforced-token validation utilities and older vLLM variants."
         ),
     )
     return_token_ids: bool | None = Field(
@@ -780,6 +786,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    enforced_str: Optional[str] = Field(default=None)
+    enforced_tokens: Optional[EnforcedTokens] = Field(default=None)
+
     # --8<-- [end:chat-completion-extra-params]
 
     # Default sampling parameters for chat completion requests
@@ -814,6 +823,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         max_tokens: int,
         logits_processor_pattern: str | None,
         default_sampling_params: dict,
+        tokenizer,
     ) -> SamplingParams:
         # Default parameters
         if (repetition_penalty := self.repetition_penalty) is None:
@@ -887,6 +897,29 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if self.kv_transfer_params:
             # Pass in kv_transfer_params via extra_args
             extra_args["kv_transfer_params"] = self.kv_transfer_params
+
+        enforced_token_ids: list[int] | None = None
+        if self.enforced_str:
+            enforced_token_ids = tokenizer.encode(self.enforced_str, add_special_tokens=False)
+            if enforced_token_ids[-1] != tokenizer.eos_token_id:
+                enforced_token_ids.append(tokenizer.eos_token_id)
+        
+        enforced_top_tokens: dict | None = None
+        if self.enforced_tokens:
+            self.enforced_tokens.encode(tokenizer)
+            if self.enforced_tokens.tokens[-1].token_id != tokenizer.eos_token_id:
+                self.enforced_tokens.tokens.append(EnforcedToken(
+                    token=tokenizer.eos_token,
+                    top_tokens=[str(tokenizer.eos_token_id)],
+                    token_id=tokenizer.eos_token_id,
+                    top_token_ids=[tokenizer.eos_token_id]
+                ))
+            enforced_top_tokens = self.enforced_tokens.get_top_tokens()
+            enforced_token_ids = self.enforced_tokens.get_enforced_token_ids()
+
+            
+
+
         return SamplingParams.from_optional(
             n=self.n,
             best_of=self.best_of,
@@ -920,6 +953,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             bad_words=self.bad_words,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
+            enforced_token_ids=enforced_token_ids,
+            enforced_tokens=enforced_top_tokens
         )
 
     @model_validator(mode="before")
@@ -1229,8 +1264,8 @@ class CompletionRequest(OpenAIBaseModel):
         default=None,
         description=(
             "If specified with 'logprobs', tokens are represented "
-            " as strings of the form 'token_id:{token_id}' so that tokens "
-            "that are not JSON-encodable can be identified."
+            " as plain token-id strings (e.g. '641') for compatibility with"
+            " enforced-token validation utilities and older vLLM variants."
         ),
     )
     return_token_ids: bool | None = Field(
@@ -2124,10 +2159,35 @@ class ChatCompletionLogProbsContent(ChatCompletionLogProb):
     # shared with the super class.
     field_names: ClassVar[set[str] | None] = None
     top_logprobs: list[ChatCompletionLogProb] = Field(default_factory=list)
+    # Integer weights (2^16 scale) for deterministic sampling verification
+    # Only populated when VLLM_DETERMINISTIC_SAMPLING=1 and logprobs requested
+    # Maps token ID (string) to integer weight
+    sampling_weights: Optional[dict[str, int]] = None
 
 
 class ChatCompletionLogProbs(OpenAIBaseModel):
     content: list[ChatCompletionLogProbsContent] | None = None
+
+
+class ValidationResult(OpenAIBaseModel):
+    """
+    Result of inference validation (for decentralized inference networks).
+
+    This is returned when a validator sends a request with enforced_tokens
+    containing validation data (logprobs and/or sampling_weights).
+
+    Attributes:
+        fraud: True if any validation check failed
+        distance: Normalized distance between executor and validator logprobs
+        correct_raw_logprobs: True if Stage 2 (logprob distribution) passed
+        correct_processed_logprobs: True if Stage 1a (weight consistency) passed
+        correct_sampling: True if Stage 1b (sampling verification) passed
+    """
+    fraud: bool = False
+    distance: float = 0.0
+    correct_raw_logprobs: bool = True
+    correct_processed_logprobs: bool = True
+    correct_sampling: bool = True
 
 
 class ChatCompletionResponseChoice(OpenAIBaseModel):
@@ -2159,6 +2219,9 @@ class ChatCompletionResponse(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None, description="KVTransfer parameters."
     )
+    # Validation result for decentralized inference verification
+    # Only populated when enforced_tokens with validation data is provided
+    validation: ValidationResult | None = None
 
 
 class DeltaMessage(OpenAIBaseModel):
@@ -2195,6 +2258,9 @@ class ChatCompletionStreamResponse(OpenAIBaseModel):
     usage: UsageInfo | None = Field(default=None)
     # not part of the OpenAI spec but for tracing the tokens
     prompt_token_ids: list[int] | None = None
+    # Validation result for decentralized inference verification
+    # Only populated in final chunk when enforced_tokens with validation data
+    validation: ValidationResult | None = None
 
 
 class TranscriptionResponseStreamChoice(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -2182,12 +2182,16 @@ class ValidationResult(OpenAIBaseModel):
         correct_raw_logprobs: True if Stage 2 (logprob distribution) passed
         correct_processed_logprobs: True if Stage 1a (weight consistency) passed
         correct_sampling: True if Stage 1b (sampling verification) passed
+        verdict: Three-valued Stage-1 verdict ("honest"/"fraud"/"inconclusive").
+            The boolean ``fraud`` remains for backward compatibility; ``verdict``
+            carries the Inconclusive state that ``fraud`` cannot (#1199).
     """
     fraud: bool = False
     distance: float = 0.0
     correct_raw_logprobs: bool = True
     correct_processed_logprobs: bool = True
     correct_sampling: bool = True
+    verdict: Optional[str] = None
 
 
 class ChatCompletionResponseChoice(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1806,18 +1806,28 @@ class OpenAIServingChat(OpenAIServing):
         """
         Perform validation when enforced_tokens contains validation data.
 
-        This implements the two-stage validation protocol:
-        - Stage 1a: Verify sampling_weights are consistent with logprobs
-        - Stage 1b: Verify token was sampled correctly from weights
-        - Stage 2: Compare probability distributions
+        Contract-faithful two-stage path (gonka-ai/gonka#1199 follow-up):
+        - Stage 1: replay the SIGNED logprobs per position via the decimal
+          pipeline (``verify_sequence``); three-valued Honest/Fraud/Inconclusive.
+        - Stage 2: MAE distance over the signed top-K support (``mae_distance``).
+
+        This replaces the legacy ``validation_logic.validate_full`` recompute
+        path (unfiltered float softmax, relative-diff distance, two-valued).
         """
-        from vllm.validation_logic import validate_full
+        from vllm.entrypoints.openai.protocol import ValidationResult
+        from vllm.validation_sampling import (
+            STAGE2_MAE_FRAUD_THRESHOLD,
+            Verdict,
+            mae_distance,
+            result_for_validator_error,
+            verify_sequence,
+        )
 
         enforced_tokens = request.enforced_tokens
         if not enforced_tokens or not enforced_tokens.has_validation_data():
             return None
 
-        # Get validator's logprobs from the model output
+        # Get validator's logprobs from the model output (Stage-2 source).
         validator_logprobs_list = []
         for output in final_res.outputs:
             if output.logprobs:
@@ -1829,31 +1839,60 @@ class OpenAIServingChat(OpenAIServing):
                             for tid, lp in step_logprobs.items()
                         })
 
-        # Derive seed string for sampling verification
-        # Use the same format as gpu_model_runner.py
+        # Base seed (same request-seed+prompt form as gpu_model_runner.py). The
+        # per-position seed is composed inside verify_sequence (Decision B =
+        # per-position). Chain-bound seed (S1) is a separate wiring item.
         prompt_repr = ",".join(
             str(t) for t in (final_res.prompt_token_ids or []))
         if request.seed is not None:
-            seed_str = f"{request.seed}|{prompt_repr}"
+            base_seed = f"{request.seed}|{prompt_repr}"
         else:
-            seed_str = prompt_repr
+            base_seed = prompt_repr
 
-        # `is not None`, not falsy: temperature 0 is greedy (§7), not unspecified.
+        # Resolved sampling params. `is not None`, not falsy: temperature 0 is
+        # greedy (§7), not unspecified. Normalize vLLM's "disabled" sentinels
+        # (top_p>=1, top_k<=0, min_p<=0) to None so the support-boundedness gate
+        # in verify_sequence sees the real filter set.
         temperature = (request.temperature
                        if request.temperature is not None else 1.0)
+        greedy = temperature == 0
+        req_top_p = getattr(request, "top_p", None)
+        top_p = str(req_top_p) if req_top_p is not None and req_top_p < 1.0 else None
+        req_top_k = getattr(request, "top_k", None)
+        top_k = int(req_top_k) if req_top_k is not None and req_top_k > 0 else None
+        req_min_p = getattr(request, "min_p", None)
+        min_p = str(req_min_p) if req_min_p is not None and req_min_p > 0 else None
 
         try:
-            result = validate_full(
-                artifact=enforced_tokens,
-                validator_logprobs=validator_logprobs_list,
-                seed_str=seed_str,
-                temperature=temperature,
+            # Stage 1: contract-faithful replay (three-valued).
+            seq = verify_sequence(
+                enforced_tokens.tokens, base_seed, str(temperature),
+                top_p=top_p, top_k=top_k, min_p=min_p, greedy=greedy,
             )
+            result = ValidationResult(verdict=seq.verdict.value)
+
+            if seq.verdict is Verdict.FRAUD:
+                result.fraud = True
+                result.correct_sampling = False
+                result.distance = 10.0
+                return result
+
+            # Stage 2: MAE distance over the signed support (non-enforcing;
+            # threshold is a Decision-D placeholder). Inconclusive Stage-1
+            # verdicts fall through to here and rely on the distance check.
+            executor_logprobs = [
+                t.logprobs for t in enforced_tokens.tokens
+                if t.logprobs is not None
+            ]
+            result.distance = mae_distance(
+                executor_logprobs, validator_logprobs_list)
+            if result.distance > STAGE2_MAE_FRAUD_THRESHOLD:
+                result.fraud = True
+                result.correct_raw_logprobs = False
             return result
         except Exception as e:
             # A validator-side error yields no verdict, never a silent pass/fail
             # about the executor. See result_for_validator_error (#1199).
-            from vllm.validation_sampling import result_for_validator_error
             logger.warning("Validation produced no verdict: %s", e)
             return result_for_validator_error(e)
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import Final
+from typing import Final, Optional
 
 import jinja2
 import partial_json_parser
@@ -69,6 +69,8 @@ from vllm.transformers_utils.tokenizers import (
 )
 from vllm.utils.collection_utils import as_list
 from vllm.v1.sample.logits_processor import validate_logits_processors_parameters
+from vllm.validation import EnforcedToken, EnforcedTokens
+from vllm.entrypoints.openai.protocol import ValidationResult
 
 logger = init_logger(__name__)
 
@@ -289,11 +291,21 @@ class OpenAIServingChat(OpenAIServing):
                     sampling_params = request.to_beam_search_params(
                         max_tokens, self.default_sampling_params
                     )
+                elif request.enforced_str or request.enforced_tokens:
+                    sampling_params = request.to_sampling_params(
+                        max_tokens,
+                        self.model_config.logits_processor_pattern,
+                        self.default_sampling_params,
+                        tokenizer,
+                    )
+
+                    request.return_tokens_as_token_ids = True
                 else:
                     sampling_params = request.to_sampling_params(
                         max_tokens,
                         self.model_config.logits_processor_pattern,
                         self.default_sampling_params,
+                        tokenizer,
                     )
                     validate_logits_processors_parameters(
                         self.logits_processors,
@@ -713,6 +725,9 @@ class OpenAIServingChat(OpenAIServing):
                             tokenizer=tokenizer,
                             num_output_top_logprobs=request.top_logprobs,
                             return_as_token_id=request.return_tokens_as_token_ids,
+                            enforced_tokens=request.enforced_tokens,
+                            temperature=request.temperature
+                            if request.temperature else 1.0,
                         )
                     else:
                         logprobs = None
@@ -1199,7 +1214,6 @@ class OpenAIServingChat(OpenAIServing):
                         )
 
                         finish_reason_sent[i] = True
-
                     chunk = ChatCompletionStreamResponse(
                         id=request_id,
                         object=chunk_object_type,
@@ -1325,6 +1339,9 @@ class OpenAIServingChat(OpenAIServing):
                     num_output_top_logprobs=request.top_logprobs,
                     tokenizer=tokenizer,
                     return_as_token_id=request.return_tokens_as_token_ids,
+                    enforced_tokens=request.enforced_tokens,
+                    temperature=request.temperature
+                    if request.temperature else 1.0,
                 )
             else:
                 logprobs = None
@@ -1562,6 +1579,16 @@ class OpenAIServingChat(OpenAIServing):
 
         request_metadata.final_usage_info = usage
 
+        # Perform validation if enforced_tokens has validation data
+        validation_result = None
+        if (request.enforced_tokens
+                and request.enforced_tokens.has_validation_data()):
+            validation_result = self._perform_validation(
+                request=request,
+                final_res=final_res,
+                tokenizer=tokenizer,
+            )
+
         response = ChatCompletionResponse(
             id=request_id,
             created=created_time,
@@ -1573,6 +1600,7 @@ class OpenAIServingChat(OpenAIServing):
                 final_res.prompt_token_ids if request.return_token_ids else None
             ),
             kv_transfer_params=final_res.kv_transfer_params,
+            validation=validation_result,
         )
 
         # Log complete response if output logging is enabled
@@ -1617,7 +1645,12 @@ class OpenAIServingChat(OpenAIServing):
         top_logprobs: int | None,
         tokenizer: AnyTokenizer,
         should_return_as_token_id: bool,
+        enforced_tokens: Optional[EnforcedTokens] = None
     ) -> list[ChatCompletionLogProb]:
+        
+        if enforced_tokens:
+            top_logprobs = len(logprobs)
+
         return [
             ChatCompletionLogProb(
                 token=(
@@ -1626,6 +1659,7 @@ class OpenAIServingChat(OpenAIServing):
                         p[0],
                         tokenizer,
                         return_as_token_id=should_return_as_token_id,
+                        enforced_tokens=enforced_tokens
                     )
                 ),
                 logprob=max(p[1].logprob, -9999.0),
@@ -1642,9 +1676,17 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: AnyTokenizer,
         num_output_top_logprobs: int | None = None,
         return_as_token_id: bool | None = None,
+        enforced_tokens: Optional[EnforcedTokens] = None,
+        temperature: float = 1.0,
     ) -> ChatCompletionLogProbs:
         """Create OpenAI-style logprobs."""
+        from vllm import envs
+
         logprobs_content: list[ChatCompletionLogProbsContent] = []
+
+        # Check if we should include sampling weights
+        include_sampling_weights = (envs.VLLM_DETERMINISTIC_SAMPLING
+                                    and temperature > 0)
 
         should_return_as_token_id = (
             return_as_token_id
@@ -1655,7 +1697,7 @@ class OpenAIServingChat(OpenAIServing):
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is None or step_top_logprobs.get(token_id) is None:
                 if should_return_as_token_id:
-                    token = f"token_id:{token_id}"
+                    token = str(token_id)
                 else:
                     token = tokenizer.decode(token_id)
 
@@ -1669,6 +1711,12 @@ class OpenAIServingChat(OpenAIServing):
                 step_token = step_top_logprobs[token_id]
                 step_decoded = step_token.decoded_token
 
+                # Compute sampling weights if deterministic sampling is enabled
+                sampling_weights = None
+                if include_sampling_weights and step_top_logprobs:
+                    sampling_weights = self._compute_sampling_weights(
+                        step_top_logprobs, temperature)
+
                 logprobs_content.append(
                     ChatCompletionLogProbsContent(
                         token=self._get_decoded_token(
@@ -1676,6 +1724,7 @@ class OpenAIServingChat(OpenAIServing):
                             token_id,
                             tokenizer,
                             should_return_as_token_id,
+                            enforced_tokens
                         ),
                         logprob=max(step_token.logprob, -9999.0),
                         bytes=(
@@ -1688,11 +1737,125 @@ class OpenAIServingChat(OpenAIServing):
                             num_output_top_logprobs,
                             tokenizer,
                             should_return_as_token_id,
+                            enforced_tokens
                         ),
+                        sampling_weights=sampling_weights,
                     )
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    def _compute_sampling_weights(
+        self,
+        logprobs: dict[int, Logprob],
+        temperature: float,
+    ) -> dict[str, int]:
+        """
+        Compute integer sampling weights from logprobs.
+
+        Uses 2^16 scale for cross-platform reproducibility.
+        Applies temperature scaling before quantization.
+
+        Args:
+            logprobs: Dict mapping token_id to Logprob
+            temperature: Temperature for scaling
+
+        Returns:
+            Dict mapping token_id (as string) to integer weight
+        """
+        import math
+
+        WEIGHT_SCALE = 2**16
+
+        if not logprobs:
+            return {}
+
+        # Apply temperature scaling in log space: logprob / temperature
+        scaled_logprobs = {}
+        for tid, lp in logprobs.items():
+            if temperature > 0:
+                scaled_logprobs[tid] = lp.logprob / temperature
+            else:
+                scaled_logprobs[tid] = lp.logprob
+
+        # Compute softmax (exp and normalize)
+        max_lp = max(scaled_logprobs.values())
+        exp_values = {
+            tid: math.exp(lp - max_lp)
+            for tid, lp in scaled_logprobs.items()
+        }
+        total = sum(exp_values.values())
+
+        if total <= 0:
+            return {}
+
+        # Quantize to integer weights
+        weights = {}
+        for tid, ev in exp_values.items():
+            prob = ev / total
+            weights[str(tid)] = round(prob * WEIGHT_SCALE)
+
+        return weights
+
+    def _perform_validation(
+        self,
+        request: ChatCompletionRequest,
+        final_res: RequestOutput,
+        tokenizer: AnyTokenizer,
+    ) -> Optional[ValidationResult]:
+        """
+        Perform validation when enforced_tokens contains validation data.
+
+        This implements the two-stage validation protocol:
+        - Stage 1a: Verify sampling_weights are consistent with logprobs
+        - Stage 1b: Verify token was sampled correctly from weights
+        - Stage 2: Compare probability distributions
+        """
+        from vllm.validation_logic import validate_full
+
+        enforced_tokens = request.enforced_tokens
+        if not enforced_tokens or not enforced_tokens.has_validation_data():
+            return None
+
+        # Get validator's logprobs from the model output
+        validator_logprobs_list = []
+        for output in final_res.outputs:
+            if output.logprobs:
+                for step_logprobs in output.logprobs:
+                    if step_logprobs:
+                        # Convert from {token_id: Logprob} to {str: float}
+                        validator_logprobs_list.append({
+                            str(tid): lp.logprob
+                            for tid, lp in step_logprobs.items()
+                        })
+
+        # Derive seed string for sampling verification
+        # Use the same format as gpu_model_runner.py
+        prompt_repr = ",".join(
+            str(t) for t in (final_res.prompt_token_ids or []))
+        if request.seed is not None:
+            seed_str = f"{request.seed}|{prompt_repr}"
+        else:
+            seed_str = prompt_repr
+
+        # `is not None`, not falsy: temperature 0 is greedy (§7), not unspecified.
+        temperature = (request.temperature
+                       if request.temperature is not None else 1.0)
+
+        try:
+            result = validate_full(
+                artifact=enforced_tokens,
+                validator_logprobs=validator_logprobs_list,
+                seed_str=seed_str,
+                temperature=temperature,
+            )
+            return result
+        except Exception as e:
+            # A validator-side error yields no verdict, never a silent pass/fail
+            # about the executor. See result_for_validator_error (#1199).
+            from vllm.validation_sampling import result_for_validator_error
+            logger.warning("Validation produced no verdict: %s", e)
+            return result_for_validator_error(e)
 
     def _should_stream_with_auto_tool_parsing(self, request: ChatCompletionRequest):
         """

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -649,7 +649,7 @@ class OpenAIServingCompletion(OpenAIServing):
             if step_top_logprobs is None:
                 token = tokenizer.decode(token_id)
                 if should_return_as_token_id:
-                    token = f"token_id:{token_id}"
+                    token = str(token_id)
 
                 out_tokens.append(token)
                 out_token_logprobs.append(None)

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -107,6 +107,7 @@ from vllm.utils.async_utils import (
 from vllm.utils.collection_utils import is_list_of
 from vllm.v1.engine import EngineCoreRequest
 
+from vllm.validation import EnforcedTokens
 logger = init_logger(__name__)
 
 CompletionLikeRequest: TypeAlias = (
@@ -255,7 +256,7 @@ class OpenAIServing:
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
-        return_tokens_as_token_ids: bool = False,
+        return_tokens_as_token_ids: bool = True,
         log_error_stack: bool = False,
     ):
         super().__init__()
@@ -1389,9 +1390,13 @@ class OpenAIServing:
         token_id: int,
         tokenizer: AnyTokenizer,
         return_as_token_id: bool = False,
+        enforced_tokens: EnforcedTokens = None
     ) -> str:
         if return_as_token_id:
-            return f"token_id:{token_id}"
+            # Return token ids as plain strings for compatibility with older
+            # OpenAI-compatible vLLM variants and enforced-token validation
+            # utilities that expect int(token).
+            return str(token_id)
 
         if logprob.decoded_token is not None:
             return logprob.decoded_token

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -224,6 +224,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_FLAT_LOGPROBS: bool = False
+    VLLM_DETERMINISTIC_SAMPLING: bool = False
 
 
 def get_default_cache_root():
@@ -1486,6 +1487,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # After enabled, PromptLogprobs and SampleLogprobs would populated as
     # FlatLogprobs.
     "VLLM_FLAT_LOGPROBS": lambda: bool(int(os.getenv("VLLM_FLAT_LOGPROBS", "0"))),
+
+    # If set, vLLM will use SHA256-based deterministic sampling for all
+    # requests. This enables cross-platform reproducible sampling for
+    # validation purposes. When enabled:
+    # - ALL requests use deterministic RNG (Sha256CounterRNG)
+    # - If user provides seed: use SHA256(str(seed) + "|" + prompt)
+    # - If no seed: use SHA256(prompt) to derive seed
+    # - Same seed + same prompt = same output tokens (reproducible)
+    "VLLM_DETERMINISTIC_SAMPLING":
+    lambda: bool(int(os.getenv("VLLM_DETERMINISTIC_SAMPLING", "0"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -225,6 +225,7 @@ if TYPE_CHECKING:
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_FLAT_LOGPROBS: bool = False
     VLLM_DETERMINISTIC_SAMPLING: bool = False
+    VLLM_DETERMINISTIC_SAMPLING_SHADOW: bool = False
 
 
 def get_default_cache_root():
@@ -1497,6 +1498,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # - Same seed + same prompt = same output tokens (reproducible)
     "VLLM_DETERMINISTIC_SAMPLING":
     lambda: bool(int(os.getenv("VLLM_DETERMINISTIC_SAMPLING", "0"))),
+
+    # E1 shadow mode (gonka-ai/gonka#1199). When set alongside
+    # VLLM_DETERMINISTIC_SAMPLING, the executor still samples via the float
+    # weight path (unchanged behaviour), but additionally recomputes the decimal
+    # validator-pipeline token per position from the SAME RNG state and logs how
+    # often the two diverge. Non-driving; for collecting float-vs-decimal
+    # divergence data before the decimal path becomes the artifact source.
+    "VLLM_DETERMINISTIC_SAMPLING_SHADOW":
+    lambda: bool(int(os.getenv("VLLM_DETERMINISTIC_SAMPLING_SHADOW", "0"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -15,6 +15,7 @@ from pydantic.dataclasses import dataclass
 from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.validation import EnforcedTokens
 
 logger = init_logger(__name__)
 
@@ -26,7 +27,7 @@ class SamplingType(IntEnum):
     GREEDY = 0
     RANDOM = 1
     RANDOM_SEED = 2
-
+    ENFORCED = 3
 
 # maybe make msgspec?
 @dataclass
@@ -251,6 +252,8 @@ class SamplingParams(
     last token of a corresponding token sequence is not allowed when the next
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
+    enforced_token_ids: list[int] | None = None
+    enforced_tokens: list[dict[int, list[int]]] | None = None
 
     @staticmethod
     def from_optional(
@@ -283,6 +286,8 @@ class SamplingParams(
         guided_decoding: GuidedDecodingParams | None = None,
         logit_bias: dict[int, float] | dict[str, float] | None = None,
         allowed_token_ids: list[int] | None = None,
+        enforced_token_ids: list[int] | None = None,
+        enforced_tokens: list[dict[int, list[int]]] | None = None,
         extra_args: dict[str, Any] | None = None,
     ) -> "SamplingParams":
         if logit_bias is not None:
@@ -302,7 +307,6 @@ class SamplingParams(
             )
             structured_outputs = guided_decoding
             guided_decoding = None
-
         return SamplingParams(
             n=1 if n is None else n,
             best_of=best_of,
@@ -335,6 +339,8 @@ class SamplingParams(
             logit_bias=logit_bias,
             allowed_token_ids=allowed_token_ids,
             extra_args=extra_args,
+            enforced_token_ids=enforced_token_ids,
+            enforced_tokens=enforced_tokens,
         )
 
     def __post_init__(self) -> None:
@@ -580,6 +586,8 @@ class SamplingParams(
 
     @cached_property
     def sampling_type(self) -> SamplingType:
+        if self.enforced_token_ids or self.enforced_tokens:
+            return SamplingType.ENFORCED
         if self.temperature < _SAMPLING_EPS:
             return SamplingType.GREEDY
         if self.seed is not None:
@@ -639,7 +647,8 @@ class SamplingParams(
             f"{self.spaces_between_special_tokens}, "
             f"truncate_prompt_tokens={self.truncate_prompt_tokens}, "
             f"structured_outputs={self.structured_outputs}, "
-            f"extra_args={self.extra_args})"
+            f"extra_args={self.extra_args}, "
+            f"enforced_token_ids={self.enforced_token_ids})"
         )
 
 

--- a/vllm/v1/sample/deterministic_sampler.py
+++ b/vllm/v1/sample/deterministic_sampler.py
@@ -1,0 +1,718 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+A deterministic sampler that uses cryptographic (SHA256-based) RNG for
+fully reproducible sampling across different hardware and implementations.
+
+STATUS: NOT WIRED INTO THE LIVE SAMPLING PATH.
+``DeterministicSampler`` / ``DeterministicSamplingState`` are currently
+referenced only by tests, not by the runtime. The production sampling path
+is ``Sampler`` -> ``TopKTopPSampler`` -> ``deterministic_sample`` (see
+vllm/v1/sample/ops/topk_topp_sampler.py), which still derives weights with
+float ``(probs * WEIGHT_SCALE).round()`` and does NOT use the exact-2^16
+decimal pipeline. Adopting this module (or the decimal pipeline) on the
+executor path is the "E1" follow-up in gonka-ai/gonka#1199; until then this
+class is a not-yet-wired reference implementation, kept for that integration.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+
+from vllm.config.model import LogprobsMode
+from vllm.utils.platform_utils import is_pin_memory_available
+from vllm.v1.outputs import LogprobsTensors, SamplerOutput
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical,
+)
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words
+from vllm.v1.sample.ops.logprobs import batched_count_greater_than
+from vllm.v1.sample.ops.penalties import apply_all_penalties
+
+
+_SAMPLING_EPS = 1e-5
+
+
+@dataclass
+class DeterministicSamplingState:
+    """
+    Holds RNG state for deterministic sampling across requests.
+    Each request has its own RNG instance seeded by request-specific data.
+    """
+    rngs: Dict[int, Sha256CounterRNG]
+    
+    @classmethod
+    def from_seeds(cls, seeds: Dict[int, str]) -> "DeterministicSamplingState":
+        """Create state from a mapping of request_index -> seed_string."""
+        return cls(
+            rngs={
+                idx: Sha256CounterRNG.from_seed_string(seed)
+                for idx, seed in seeds.items()
+            }
+        )
+    
+    def get_rng(self, request_idx: int, default_seed: str = "default") -> Sha256CounterRNG:
+        """Get RNG for a request, creating one if not exists."""
+        if request_idx not in self.rngs:
+            self.rngs[request_idx] = Sha256CounterRNG.from_seed_string(
+                f"{default_seed}_{request_idx}"
+            )
+        return self.rngs[request_idx]
+
+
+class DeterministicSampler(nn.Module):
+    """
+    A layer that samples the next tokens from the model's outputs
+    using deterministic cryptographic sampling.
+    
+    This sampler mirrors the interface of the standard Sampler but uses
+    SHA256-based RNG for cross-platform reproducibility.
+    
+    The sampling process follows these steps:
+    1. If logprobs are requested, compute them from raw logits.
+    2. Convert logits to float32.
+    3. Apply allowed token ids whitelist.
+    4. Apply bad words exclusion.
+    5. Apply logit processors (non-argmax-invariant).
+    6. Apply penalties (repetition, frequency, presence).
+    7. Sample the next tokens:
+        a) For greedy requests: argmax
+        b) For random requests: apply temperature, min_p, top_k/top_p,
+           then sample using deterministic categorical sampler.
+    8. Gather logprobs for top tokens and sampled token.
+    9. Return SamplerOutput.
+    """
+
+    def __init__(
+        self,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        default_seed: str = "deterministic_sampler",
+    ):
+        super().__init__()
+        self.pin_memory = is_pin_memory_available()
+        self.logprobs_mode = logprobs_mode
+        self.default_seed = default_seed
+        # State is managed externally or created per-forward call
+        self._state: Optional[DeterministicSamplingState] = None
+
+    def set_state(self, state: DeterministicSamplingState) -> None:
+        """Set the sampling state (RNGs) for this sampler."""
+        self._state = state
+
+    def create_state_from_prompts(
+        self,
+        prompts: List[str],
+        base_seed: str = "",
+    ) -> DeterministicSamplingState:
+        """
+        Create deterministic sampling state from prompt strings.
+        Each prompt is hashed to create a unique RNG seed.
+        """
+        base = base_seed or self.default_seed
+        seeds = {
+            idx: f"{base}|{prompt}"
+            for idx, prompt in enumerate(prompts)
+        }
+        return DeterministicSamplingState.from_seeds(seeds)
+
+    def forward(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        predict_bonus_token: bool = False,
+        logprobs_mode_override: LogprobsMode | None = None,
+        seeds: Optional[Dict[int, str]] = None,
+    ) -> SamplerOutput:
+        """
+        Sample next tokens deterministically.
+        
+        Args:
+            logits: Tensor of shape [batch_size, vocab_size]
+            sampling_metadata: Metadata containing sampling parameters
+            predict_bonus_token: Whether this is for speculative decoding bonus token
+            logprobs_mode_override: Override the default logprobs mode
+            seeds: Optional per-request seeds for RNG (request_idx -> seed_string)
+        
+        Returns:
+            SamplerOutput containing sampled token IDs and optional logprobs
+        """
+        logprobs_mode = logprobs_mode_override or self.logprobs_mode
+        
+        # Create or use existing state
+        if seeds is not None:
+            state = DeterministicSamplingState.from_seeds(seeds)
+        elif self._state is not None:
+            state = self._state
+        else:
+            # Create default state
+            state = DeterministicSamplingState(rngs={})
+        
+        # Compute logprobs if requested (before any modifications)
+        num_logprobs = sampling_metadata.max_num_logprobs
+        if num_logprobs is not None:
+            if logprobs_mode == "raw_logprobs":
+                raw_logprobs = self.compute_logprobs(logits)
+            elif logprobs_mode == "raw_logits":
+                raw_logprobs = logits.clone()
+
+        # Use float32 for the logits
+        logits = logits.to(torch.float32)
+        
+        # Apply logits processors
+        logits = self.apply_logits_processors(
+            logits, sampling_metadata, predict_bonus_token
+        )
+        
+        # Sample the next token
+        sampled, processed_logprobs = self.sample(logits, sampling_metadata, state)
+        if processed_logprobs is not None:
+            raw_logprobs = processed_logprobs
+            
+        # Convert to int64 for compatibility
+        sampled = sampled.long()
+
+        if num_logprobs is None:
+            logprobs_tensors = None
+        elif num_logprobs == -1:
+            # Return full unsorted logprobs
+            logprobs_tensors = LogprobsTensors(
+                torch.empty(0), raw_logprobs, torch.empty(0)
+            )
+        else:
+            # Gather topk and sampled token logprobs
+            logprobs_tensors = self.gather_logprobs(
+                raw_logprobs, num_logprobs, token_ids=sampled,
+                sampling_metadata=sampling_metadata
+            )
+
+        # Use int32 to reduce tensor size
+        sampled = sampled.to(torch.int32)
+
+        return SamplerOutput(
+            sampled_token_ids=sampled.unsqueeze(-1),
+            logprobs_tensors=logprobs_tensors,
+        )
+
+    @staticmethod
+    def apply_temperature(
+        logits: torch.Tensor,
+        temp: torch.Tensor,
+        all_random: bool,
+    ) -> torch.Tensor:
+        """Apply temperature scaling to logits."""
+        if not all_random:
+            temp = torch.where(temp < _SAMPLING_EPS, 1.0, temp)
+        return logits.div_(temp.unsqueeze(dim=1))
+
+    @staticmethod
+    def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
+        """Greedy sampling (argmax)."""
+        return logits.argmax(dim=-1).view(-1)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        state: DeterministicSamplingState,
+        logprobs_mode_override: LogprobsMode | None = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Sample from logits using deterministic categorical sampling.
+        """
+        logprobs_mode = logprobs_mode_override or self.logprobs_mode
+        
+        assert not (sampling_metadata.all_greedy and sampling_metadata.all_random)
+        assert not (sampling_metadata.all_greedy and sampling_metadata.all_enforced)
+        assert not (sampling_metadata.all_random and sampling_metadata.all_enforced)
+
+        # Handle enforced tokens
+        if sampling_metadata.enforced_token_ids:
+            enforced_sampled = torch.empty(
+                (len(sampling_metadata.enforced_req_ids),),
+                dtype=torch.int64,
+                device=logits.device
+            )
+            enforced_map = sampling_metadata.enforced_token_ids
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                seq = enforced_map[req_index]
+                out = sampling_metadata.output_token_ids[req_index]
+                step = len(out)
+                if step < len(seq):
+                    next_tok = seq[step]
+                else:
+                    next_tok = seq[-1]
+                enforced_sampled[i] = next_tok
+                
+            if sampling_metadata.all_enforced:
+                result = torch.empty(
+                    (logits.size(0),), dtype=torch.int64, device=logits.device
+                )
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    result[req_index] = enforced_sampled[i]
+                return result, None
+
+        # Greedy sampling path
+        if sampling_metadata.all_random or sampling_metadata.mixed_enforced:
+            greedy_sampled = None
+        else:
+            greedy_sampled = self.greedy_sample(logits)
+            if sampling_metadata.all_greedy:
+                processed_logprobs = None
+                if sampling_metadata.max_num_logprobs is not None:
+                    if logprobs_mode == "processed_logits":
+                        processed_logprobs = logits
+                    elif logprobs_mode == "processed_logprobs":
+                        processed_logprobs = self.compute_logprobs(logits)
+                return greedy_sampled, processed_logprobs
+
+        assert sampling_metadata.temperature is not None
+
+        # Apply temperature
+        logits = self.apply_temperature(
+            logits,
+            sampling_metadata.temperature,
+            sampling_metadata.all_random or sampling_metadata.mixed_enforced
+        )
+
+        # Apply argmax-invariant logits processors
+        for processor in sampling_metadata.logitsprocs.argmax_invariant:
+            logits = processor.apply(logits)
+
+        # Apply top_k and top_p masking
+        logits = self.apply_top_k_top_p(
+            logits,
+            sampling_metadata.top_k,
+            sampling_metadata.top_p,
+        )
+
+        # Deterministic sampling using cryptographic RNG
+        random_sampled, processed_logprobs = self.deterministic_sample(
+            logits, state, logprobs_mode
+        )
+
+        if greedy_sampled is None:
+            if sampling_metadata.enforced_token_ids:
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    random_sampled[int(req_index)] = enforced_sampled[i]
+            return random_sampled, processed_logprobs
+
+        # Mix greedy and random based on temperature
+        sampled = torch.where(
+            sampling_metadata.temperature < _SAMPLING_EPS,
+            greedy_sampled,
+            random_sampled,
+            out=greedy_sampled,
+        )
+
+        if sampling_metadata.enforced_token_ids:
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                sampled[int(req_index)] = enforced_sampled[i]
+
+        return sampled, processed_logprobs
+
+    def deterministic_sample(
+        self,
+        logits: torch.Tensor,
+        state: DeterministicSamplingState,
+        logprobs_mode: LogprobsMode,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Sample from logits using deterministic cryptographic RNG.
+        
+        This is the core difference from the standard sampler - we use
+        SHA256-based RNG instead of torch random sampling.
+        """
+        batch_size = logits.size(0)
+        device = logits.device
+        
+        # Compute softmax probabilities
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        
+        # Prepare logprobs if needed
+        processed_logprobs = None
+        if logprobs_mode == "processed_logits":
+            processed_logprobs = logits
+        elif logprobs_mode == "processed_logprobs":
+            processed_logprobs = logits.log_softmax(dim=-1, dtype=torch.float32)
+        
+        # Move probs to CPU for deterministic sampling
+        probs_cpu = probs.cpu().numpy()
+        
+        # Sample each request deterministically
+        sampled_tokens = []
+        for i in range(batch_size):
+            rng = state.get_rng(i, self.default_seed)
+            token_id = sample_categorical(probs_cpu[i], rng)
+            sampled_tokens.append(token_id)
+        
+        sampled = torch.tensor(sampled_tokens, dtype=torch.int64, device=device)
+        return sampled, processed_logprobs
+
+    @staticmethod
+    def apply_top_k_top_p(
+        logits: torch.Tensor,
+        k: Optional[torch.Tensor],
+        p: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Apply top-k and top-p filtering to logits."""
+        if k is None and p is None:
+            return logits
+
+        if p is None:
+            # Top-k only (without sorting full vocab)
+            return DeterministicSampler._apply_top_k_only(logits, k)
+
+        # Sort for top-p (and optionally top-k)
+        logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+
+        if k is not None:
+            top_k_mask = logits_sort.size(1) - k.to(torch.long)
+            top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+            top_k_mask = logits_sort < top_k_mask
+            logits_sort.masked_fill_(top_k_mask, -float("inf"))
+
+        if p is not None:
+            probs_sort = logits_sort.softmax(dim=-1)
+            probs_sum = torch.cumsum(probs_sort, dim=-1, out=probs_sort)
+            top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
+            top_p_mask[:, -1] = False  # Keep at least one token
+            logits_sort.masked_fill_(top_p_mask, -float("inf"))
+
+        # Re-sort back to original order
+        logits = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
+        return logits
+
+    @staticmethod
+    def _apply_top_k_only(
+        logits: torch.Tensor,
+        k: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply top-k mask without full sorting."""
+        no_top_k_mask = k == logits.shape[1]
+        k = k.masked_fill(no_top_k_mask, 1)
+        max_top_k = k.max()
+        k_index = k.sub_(1).unsqueeze(1)
+        top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index.long())
+        top_k_mask.masked_fill_(no_top_k_mask.unsqueeze(1), -float("inf"))
+        logits.masked_fill_(logits < top_k_mask, -float("inf"))
+        return logits
+
+    @staticmethod
+    def compute_logprobs(logits: torch.Tensor) -> torch.Tensor:
+        """Compute log probabilities from logits."""
+        return logits.log_softmax(dim=-1, dtype=torch.float32)
+
+    @staticmethod
+    def gather_logprobs(
+        logprobs: torch.Tensor,
+        num_logprobs: int,
+        token_ids: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> LogprobsTensors:
+        """
+        Gather logprobs for topk and sampled/prompt token.
+        """
+        assert token_ids.dtype == torch.int64
+        
+        if sampling_metadata.enforced_tokens:
+            enforced_top_map = sampling_metadata.enforced_tokens
+            enforced_map = sampling_metadata.enforced_token_ids
+            
+            topk_indices_enforced = torch.empty(
+                (len(sampling_metadata.enforced_req_ids), num_logprobs),
+                dtype=torch.int64,
+                device=logprobs.device
+            )
+
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                seq = enforced_map[req_index]
+                seq_top_tokens = enforced_top_map[req_index]
+                out = sampling_metadata.output_token_ids[req_index]
+                step = len(out)
+
+                if step < len(seq):
+                    next_tok = seq[step]
+                    next_top_tok = seq_top_tokens[step][next_tok]
+                else:
+                    next_tok = seq[-1]
+                    step = len(seq) - 1
+                    next_top_tok = seq_top_tokens[step][next_tok]
+
+                topk_indices_enforced[i] = torch.tensor(
+                    next_top_tok, device=logprobs.device
+                )
+
+            topk_logprobs_enforced = torch.gather(
+                logprobs[sampling_metadata.enforced_req_ids],
+                dim=1,
+                index=topk_indices_enforced
+            )
+
+            if sampling_metadata.all_enforced:
+                topk_indices = torch.empty(
+                    (logprobs.size(0), num_logprobs),
+                    dtype=torch.int64,
+                    device=logprobs.device
+                )
+                topk_logprobs = torch.empty(
+                    (logprobs.size(0), num_logprobs),
+                    device=logprobs.device
+                )
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    topk_indices[req_index] = topk_indices_enforced[i]
+                    topk_logprobs[req_index] = topk_logprobs_enforced[i]
+            elif sampling_metadata.mixed_enforced:
+                all_ids = torch.arange(logprobs.size(0), device=logprobs.device)
+                mask_normal = torch.ones_like(all_ids, dtype=torch.bool)
+                mask_normal[sampling_metadata.enforced_req_ids] = False
+
+                topk_logprobs_normal, topk_indices_normal = torch.topk(
+                    logprobs[mask_normal], num_logprobs, dim=-1
+                )
+
+                topk_indices = torch.empty_like(
+                    logprobs, device=logprobs.device, dtype=torch.int64
+                )[:, :num_logprobs]
+                topk_logprobs = torch.empty_like(
+                    logprobs, device=logprobs.device
+                )[:, :num_logprobs]
+
+                topk_indices[mask_normal] = topk_indices_normal
+                topk_logprobs[mask_normal] = topk_logprobs_normal
+
+                topk_indices[sampling_metadata.enforced_req_ids] = topk_indices_enforced
+                topk_logprobs[sampling_metadata.enforced_req_ids] = topk_logprobs_enforced
+        else:
+            topk_logprobs, topk_indices = torch.topk(logprobs, num_logprobs, dim=-1)
+
+        # Get the logprob of the prompt or sampled token
+        token_ids = token_ids.unsqueeze(-1)
+        token_logprobs = logprobs.gather(-1, token_ids)
+
+        # Compute ranks
+        token_ranks = batched_count_greater_than(logprobs, token_logprobs)
+
+        # Concatenate with topk
+        indices = torch.cat((token_ids, topk_indices), dim=1)
+        logprobs = torch.cat((token_logprobs, topk_logprobs), dim=1)
+
+        # Use int32 to reduce tensor size
+        indices = indices.to(torch.int32)
+        return LogprobsTensors(indices, logprobs, token_ranks)
+
+    @staticmethod
+    def _combine_outputs_with_spec_tokens(
+        output_token_ids: List[List[int]],
+        spec_token_ids: Optional[List[List[int]]] = None,
+    ) -> List[List[int]]:
+        if spec_token_ids is None:
+            return output_token_ids
+        return [
+            [*out, *spec] if spec else out
+            for out, spec in zip(output_token_ids, spec_token_ids)
+        ]
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        predict_bonus_token: bool,
+    ) -> torch.Tensor:
+        """Apply all logits processors."""
+        bad_words_token_ids = sampling_metadata.bad_words_token_ids
+        any_penalties_or_bad_words = (
+            bool(bad_words_token_ids) or not sampling_metadata.no_penalties
+        )
+
+        output_token_ids = sampling_metadata.output_token_ids
+
+        if predict_bonus_token and any_penalties_or_bad_words:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        # Apply allowed token ids
+        if sampling_metadata.allowed_token_ids_mask is not None:
+            logits.masked_fill_(
+                sampling_metadata.allowed_token_ids_mask, float("-inf")
+            )
+
+        # Apply bad words exclusion
+        if bad_words_token_ids:
+            apply_bad_words(logits, bad_words_token_ids, output_token_ids)
+
+        # Apply non-argmax-invariant logits processors
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            logits = processor.apply(logits)
+
+        # Apply penalties
+        logits = self.apply_penalties(logits, sampling_metadata, output_token_ids)
+        return logits
+
+    @staticmethod
+    def apply_penalties(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        output_token_ids: List[List[int]],
+    ) -> torch.Tensor:
+        """Apply repetition, frequency, and presence penalties."""
+        if sampling_metadata.no_penalties:
+            return logits
+
+        assert sampling_metadata.prompt_token_ids is not None
+        return apply_all_penalties(
+            logits,
+            sampling_metadata.prompt_token_ids,
+            sampling_metadata.presence_penalties,
+            sampling_metadata.frequency_penalties,
+            sampling_metadata.repetition_penalties,
+            output_token_ids,
+        )
+
+
+# =============================================================================
+# Standalone functions for sampling from logprobs/probs directly
+# =============================================================================
+
+def deterministic_sample_from_logprobs(
+    logprobs: Sequence[Dict[int, float]],
+    seed: str,
+    temperature: float = 1.0,
+    top_k: Optional[int] = None,
+    top_p: Optional[float] = None,
+) -> List[int]:
+    """
+    Sample tokens deterministically from a sequence of logprob dictionaries.
+    
+    Args:
+        logprobs: List of dictionaries mapping token_id -> logprob
+        seed: Seed string for deterministic RNG
+        temperature: Temperature for sampling (1.0 = no change)
+        top_k: If set, only sample from top-k tokens
+        top_p: If set, only sample from tokens with cumulative prob <= top_p
+    
+    Returns:
+        List of sampled token IDs
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    sampled_tokens = []
+    
+    for step_logprobs in logprobs:
+        if not step_logprobs:
+            raise ValueError("Empty logprobs at step")
+        
+        # Convert logprobs to probabilities
+        token_ids = list(step_logprobs.keys())
+        log_values = [step_logprobs[tid] for tid in token_ids]
+        
+        # Apply temperature
+        if temperature != 1.0 and temperature > 0:
+            log_values = [lv / temperature for lv in log_values]
+        
+        # Convert to probabilities via softmax
+        max_log = max(log_values)
+        exp_values = [math.exp(lv - max_log) for lv in log_values]
+        sum_exp = sum(exp_values)
+        probs = [ev / sum_exp for ev in exp_values]
+        
+        # Apply top-k
+        if top_k is not None and top_k < len(token_ids):
+            # Sort by probability descending
+            sorted_items = sorted(
+                zip(token_ids, probs, log_values),
+                key=lambda x: x[1],
+                reverse=True
+            )[:top_k]
+            token_ids = [x[0] for x in sorted_items]
+            probs = [x[1] for x in sorted_items]
+            # Renormalize
+            sum_probs = sum(probs)
+            probs = [p / sum_probs for p in probs]
+        
+        # Apply top-p (nucleus sampling)
+        if top_p is not None and top_p < 1.0:
+            # Sort by probability descending
+            sorted_items = sorted(
+                zip(token_ids, probs),
+                key=lambda x: x[1],
+                reverse=True
+            )
+            cumsum = 0.0
+            filtered = []
+            for tid, p in sorted_items:
+                if cumsum >= top_p and filtered:
+                    break
+                filtered.append((tid, p))
+                cumsum += p
+            token_ids = [x[0] for x in filtered]
+            probs = [x[1] for x in filtered]
+            # Renormalize
+            sum_probs = sum(probs)
+            probs = [p / sum_probs for p in probs]
+        
+        # Sample using deterministic categorical sampler
+        idx = sample_categorical(probs, rng)
+        sampled_tokens.append(token_ids[idx])
+    
+    return sampled_tokens
+
+
+def deterministic_sample_from_probs(
+    probs_2d: Sequence[Sequence[float]],
+    seed: str,
+) -> List[int]:
+    """
+    Sample tokens deterministically from 2D probability array.
+    
+    Args:
+        probs_2d: Shape [seq_len, vocab_size] probabilities
+        seed: Seed string for deterministic RNG
+    
+    Returns:
+        List of sampled token IDs
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    return [sample_categorical(step_probs, rng) for step_probs in probs_2d]
+
+
+def resample_from_inference_logprobs(
+    inference_results: List[Dict],
+    prompt: str,
+    temperature: float = 1.0,
+    seed_prefix: str = "resample",
+) -> List[int]:
+    """
+    Re-sample tokens from inference result logprobs.
+    
+    Args:
+        inference_results: List of {token: int, logprobs: {token_id: logprob}}
+        prompt: The original prompt (used as part of seed)
+        temperature: Temperature for sampling
+        seed_prefix: Prefix for the seed string
+    
+    Returns:
+        List of sampled token IDs
+    """
+    seed = f"{seed_prefix}|{prompt}"
+    
+    # Extract logprobs from results
+    logprobs_seq = []
+    for result in inference_results:
+        lp = result.get("logprobs", {})
+        # Convert string keys to int if needed
+        lp_int = {int(k): v for k, v in lp.items()}
+        logprobs_seq.append(lp_int)
+    
+    return deterministic_sample_from_logprobs(
+        logprobs_seq,
+        seed=seed,
+        temperature=temperature,
+    )

--- a/vllm/v1/sample/deterministic_utils.py
+++ b/vllm/v1/sample/deterministic_utils.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Deterministic sampling utilities for cross-platform reproducibility.
+
+This module provides:
+1. A portable, fully-specified RNG based on SHA256 that produces identical
+   sequences across Python and Go implementations.
+2. A decimal-arithmetic pipeline that converts logprob strings to integer
+   weights, guaranteeing bit-identical results on any CPython 3.3+ machine.
+
+The decimal context (prec=10, ROUND_HALF_EVEN) is applied *locally* inside
+the pipeline functions via ``localcontext()`` -- importing this module does
+NOT mutate the process-wide default Decimal context.
+"""
+
+from __future__ import annotations
+
+import bisect
+import hashlib
+import struct
+from dataclasses import dataclass
+from decimal import ROUND_HALF_EVEN, Decimal, localcontext
+from typing import Dict, List, Optional, Sequence
+
+# Scale factor for integer weight quantization (2^16 = 65536).
+WEIGHT_SCALE = 2**16
+
+
+def _u64_be(x: int) -> bytes:
+    return struct.pack(">Q", x & 0xFFFFFFFFFFFFFFFF)
+
+
+@dataclass
+class Sha256CounterRNG:
+    """
+    Portable, fully-specified RNG:
+      u64 = first_8_bytes(SHA256(seed_bytes || counter_be_u64))
+    """
+
+    seed_bytes: bytes
+    counter: int = 0
+
+    @classmethod
+    def from_seed_string(cls, seed: str) -> "Sha256CounterRNG":
+        # Specify UTF-8 for portability.
+        return cls(seed.encode("utf-8"), 0)
+
+    def next_u64(self) -> int:
+        h = hashlib.sha256(self.seed_bytes + _u64_be(self.counter)).digest()
+        self.counter += 1
+        return int.from_bytes(h[:8], byteorder="big", signed=False)
+
+    def next_uniform01(self) -> float:
+        """
+        Uniform in [0,1) using top 53 bits (exactly representable in float64):
+          u = (u64 >> 11) / 2^53
+        """
+        x = self.next_u64()
+        return (x >> 11) * (1.0 / (1 << 53))
+
+
+def iter_u64(seed: str, count: int) -> List[int]:
+    """
+    Return a list of `count` u64 values from a fresh RNG seeded with `seed`.
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    return [rng.next_u64() for _ in range(count)]
+
+
+# =============================================================================
+# Chain-bound seed derivation (from gonka-ai/vllm#56, @neuron7xLab)
+# =============================================================================
+
+# Versioned domain separator for chain-bound deterministic sampling seeds.
+_SEED_DOMAIN_TAG = "gonka-deterministic-sampling-v1"
+
+# Canonical contract bounds. These make the derivation reproduce identically
+# across languages (Python executor, Go/Rust validator): the accept/reject
+# boundary must not depend on any runtime's Unicode or integer semantics.
+#
+# Chain id: printable ASCII only (0x21..0x7E). This is deliberately stricter
+# than "non-whitespace": a whitespace/`strip()` predicate rejects a different
+# set of code points in Python vs Go vs JS (e.g. U+001C-1F, U+0085, U+00A0),
+# which would split consensus on validity itself. Printable ASCII removes the
+# whole ambiguity class and also rules out NUL/control bytes.
+_ID_MIN_ORD = 0x21
+_ID_MAX_ORD = 0x7E
+_MAX_INFERENCE_ID_LEN = 256
+
+# user_seed: pin to signed 64-bit range. A Python executor hashes an arbitrary
+# big int fine, but a Go/Rust validator on int64 would overflow -> divergent
+# or crashed validation. Pinning the range keeps the contract portable.
+_MIN_USER_SEED = -(2**63)
+_MAX_USER_SEED = 2**63 - 1
+
+
+def derive_chain_bound_seed(
+    user_seed: int,
+    inference_id_from_chain: str,
+) -> str:
+    """Derive a chain-bound deterministic sampling seed.
+
+    Stage-1 replay must be bound to chain provenance; prompt-derived seed
+    material is request-controlled and must not be used for this path.
+
+    Args:
+        user_seed: Integer sampling seed (vLLM's public seed type is
+            ``Optional[int]``; a str would collide with its int form).
+            Must be within the signed 64-bit range for cross-language
+            reproducibility.
+        inference_id_from_chain: Chain-provided inference identifier.
+            Must be printable ASCII (``0x21``..``0x7E``), non-empty, and at
+            most ``_MAX_INFERENCE_ID_LEN`` characters.
+
+    Returns:
+        Lowercase SHA256 hex digest usable as a Sha256CounterRNG seed.
+
+    Raises:
+        ValueError: If inference_id_from_chain is missing, empty, too long,
+            or contains a non-printable-ASCII character; or if user_seed is
+            outside the signed 64-bit range.
+        TypeError: If inference_id_from_chain is not a str, or if user_seed
+            is not an exact int (bool and int subclasses excluded).
+    """
+    # Chain id must be canonical chain-provided text: reject None and any
+    # non-str so arbitrary objects/bytes/ints are never stringified into
+    # provenance material.
+    if inference_id_from_chain is None:
+        raise ValueError(
+            "inference_id_from_chain is required for chain-bound "
+            "deterministic sampling; refusing to fall back to "
+            "request-controlled seed material."
+        )
+    if not isinstance(inference_id_from_chain, str):
+        raise TypeError(
+            "inference_id_from_chain must be a str (chain-provided text), "
+            f"got {type(inference_id_from_chain).__name__}."
+        )
+    if inference_id_from_chain == "":
+        raise ValueError("inference_id_from_chain must be non-empty.")
+    if len(inference_id_from_chain) > _MAX_INFERENCE_ID_LEN:
+        raise ValueError(
+            "inference_id_from_chain too long "
+            f"(>{_MAX_INFERENCE_ID_LEN} characters)."
+        )
+    # Language-invariant charset: reject anything outside printable ASCII so
+    # the accept/reject boundary is identical in Python/Go/Rust/JS and no
+    # control/NUL/whitespace/non-ASCII byte enters the hashed material.
+    for ch in inference_id_from_chain:
+        if not (_ID_MIN_ORD <= ord(ch) <= _ID_MAX_ORD):
+            raise ValueError(
+                "inference_id_from_chain must be printable ASCII "
+                "(0x21..0x7E); no whitespace/control/NUL/non-ASCII. "
+                f"Found U+{ord(ch):04X}."
+            )
+
+    # vLLM's seed is int-only (SamplingParams.seed / OpenAI seed are
+    # Optional[int]). Require an EXACT int: `type(...) is int` rejects bool
+    # (True == 1) and any int subclass whose `__str__` is overridden (which
+    # would hash the repr, not the value). This also stops "7" colliding with
+    # int 7 and any object being stringified into the seed.
+    if type(user_seed) is not int:
+        raise TypeError(
+            "user_seed must be an exact int deterministic seed value "
+            "(bool and int subclasses excluded), "
+            f"got {type(user_seed).__name__}."
+        )
+    if not (_MIN_USER_SEED <= user_seed <= _MAX_USER_SEED):
+        raise ValueError(
+            "user_seed must be within the signed 64-bit range "
+            "for cross-language reproducibility."
+        )
+
+    # Byte-length-prefixed framing over UTF-8 bytes: prefixes count BYTES (not
+    # Python codepoints) so the contract reproduces in Go/Rust/JS. The chain id
+    # is hashed byte-exact (no stripping) to preserve provenance.
+    seed_bytes = bytes(str(user_seed), "utf-8")
+    inference_id_bytes = bytes(inference_id_from_chain, "utf-8")
+    material = b"".join([
+        _SEED_DOMAIN_TAG.encode("ascii"),
+        b"\nuser_seed_len=",
+        str(len(seed_bytes)).encode("ascii"),
+        b"\n",
+        seed_bytes,
+        b"\ninference_id_len=",
+        str(len(inference_id_bytes)).encode("ascii"),
+        b"\n",
+        inference_id_bytes,
+    ])
+    return hashlib.sha256(material).hexdigest()
+
+
+def uint64_below(rng: Sha256CounterRNG, n: int) -> int:
+    """
+    Unbiased draw in [0, n) from 64-bit uniform values via rejection sampling.
+    """
+    if n <= 0:
+        raise ValueError("n must be > 0")
+    two64 = 1 << 64
+    limit = two64 - (two64 % n)  # largest multiple of n below 2^64
+    while True:
+        x = rng.next_u64()
+        if x < limit:
+            return x % n
+
+
+def sample_categorical_weights(weights: Sequence[int], rng: Sha256CounterRNG) -> int:
+    """
+    Deterministic categorical sampler on integer weights (recommended for
+    cross-language reproducibility when probs may differ in float rounding).
+    """
+    if not weights:
+        raise ValueError("weights is empty")
+    total = 0
+    last_nonzero = -1
+    for i, w in enumerate(weights):
+        if w < 0:
+            raise ValueError(f"Negative weight at index {i}: {w}")
+        if w > 0:
+            last_nonzero = i
+        total += w
+    if total <= 0:
+        return len(weights) - 1
+
+    r = uint64_below(rng, total)
+    cum = 0
+    for i, w in enumerate(weights):
+        cum += w
+        if r < cum:
+            return i
+    return last_nonzero if last_nonzero >= 0 else len(weights) - 1
+
+
+@dataclass(frozen=True)
+class WeightedPrefixSampler:
+    """
+    Fast categorical sampler for *fixed* non-negative integer weights.
+    Build once: O(vocab). Sample: O(log vocab) via binary search on prefix sums.
+    """
+
+    prefix: List[int]  # strictly increasing at non-zero weights
+    total: int
+    last_nonzero: int
+
+    @classmethod
+    def from_weights(cls, weights: Sequence[int]) -> "WeightedPrefixSampler":
+        if not weights:
+            raise ValueError("weights is empty")
+        prefix: List[int] = [0] * len(weights)
+        total = 0
+        last_nonzero = -1
+        for i, w in enumerate(weights):
+            if w < 0:
+                raise ValueError(f"Negative weight at index {i}: {w}")
+            if w > 0:
+                last_nonzero = i
+            total += w
+            prefix[i] = total
+        return cls(prefix=prefix, total=total, last_nonzero=last_nonzero)
+
+    def sample(self, rng: Sha256CounterRNG) -> int:
+        if self.total <= 0:
+            return len(self.prefix) - 1
+        r = uint64_below(rng, self.total)  # in [0,total)
+        # find first i with prefix[i] > r
+        i = bisect.bisect_right(self.prefix, r)
+        if i >= len(self.prefix):
+            return self.last_nonzero if self.last_nonzero >= 0 else len(self.prefix) - 1
+        return i
+
+
+def sample_categorical(probs: Sequence[float], rng: Sha256CounterRNG) -> int:
+    """
+    Deterministic categorical sampler.
+
+    Requirements:
+      - probs[i] >= 0
+      - sum(probs) ~ 1 (tolerate small float error)
+    """
+    u = rng.next_uniform01()
+
+    cum = 0.0
+    last_nonzero = -1
+    for i, p in enumerate(probs):
+        if p < 0.0:
+            raise ValueError(f"Negative probability at index {i}: {p}")
+        if p > 0.0:
+            last_nonzero = i
+        cum += p
+        if cum > u:
+            return i
+
+    # If u is very close to 1 or probs sum to slightly < 1 due to rounding,
+    # return the last non-zero (or last index if all zeros).
+    if last_nonzero >= 0:
+        return last_nonzero
+    return len(probs) - 1
+
+
+def sample_sequence(
+    probs_2d: Sequence[Sequence[float]], seed: str
+) -> List[int]:
+    """
+    Sample one token per time step.
+    probs_2d: shape [seq_len][vocab_size]
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    return [sample_categorical(step_probs, rng) for step_probs in probs_2d]
+
+
+# =============================================================================
+# Decimal Pipeline: logprob strings -> integer weights
+#
+# The decimal context is applied locally via ``localcontext()`` so importing
+# this module never mutates the process-wide default. All Decimal
+# arithmetic in the pipeline must run inside the ``with`` block; anything left
+# outside would fall back to the default precision and break reproducibility.
+# =============================================================================
+
+def logprobs_to_weights(
+    logprob_strings: Dict[str, str],
+    temperature: str,
+    top_p: Optional[str] = None,
+    top_k: Optional[int] = None,
+    min_p: Optional[str] = None,
+) -> Dict[str, int]:
+    """
+    Deterministic logprobs -> integer weights pipeline.
+
+    Both executor and validator call this with identical inputs. Produces
+    bit-identical results on any machine running CPython 3.3+ (backed by
+    libmpdec with IEEE 754-2008 decimal arithmetic).
+
+    All token iteration uses a fixed order: sorted by token ID string
+    (lexicographic). This eliminates accumulation-order ambiguity in Decimal
+    sums.
+
+    Note: the final weight list order and residual tie-break both rely on this
+    lexicographic order. The executor production path must build its weight list
+    in the *same* order for Check 2 to agree.
+
+    Args:
+        logprob_strings: {token_id_str: logprob_str} -- post-penalty logprobs
+            as string values (e.g. {"791": "-0.05000000074505806"}).
+        temperature: Temperature as string (e.g. "0.7"). Must be > 0.
+        top_p: Optional nucleus sampling threshold as string (e.g. "0.9").
+        top_k: Optional top-k filter count.
+        min_p: Optional min-p threshold as string (e.g. "0.05").
+
+    Returns:
+        {token_id_str: int_weight} -- integer weights summing to exactly
+        WEIGHT_SCALE (2^16 = 65536).
+    """
+    with localcontext() as ctx:
+        # prec=10 gives ~3 guard digits beyond float32's ~7 significant
+        # digits; ROUND_HALF_EVEN is the IEEE 754-2008 default.
+        ctx.prec = 10
+        ctx.rounding = ROUND_HALF_EVEN
+
+        T = Decimal(temperature)
+        sorted_tids = sorted(logprob_strings.keys())
+
+        # Temperature scaling
+        scaled = {tid: Decimal(logprob_strings[tid]) / T for tid in sorted_tids}
+
+        # Softmax with log-sum-exp stability shift
+        max_val = max(scaled[tid] for tid in sorted_tids)
+        exps = {tid: (scaled[tid] - max_val).exp() for tid in sorted_tids}
+        total_exp = sum(exps[tid] for tid in sorted_tids)
+        probs = {tid: exps[tid] / total_exp for tid in sorted_tids}
+
+        # top_k filtering
+        if top_k is not None and top_k < len(sorted_tids):
+            top_k_tids = sorted(
+                sorted_tids, key=lambda t: probs[t], reverse=True
+            )[:top_k]
+            probs = {tid: probs[tid] for tid in top_k_tids}
+            sorted_tids = sorted(top_k_tids)
+
+        # top_p filtering
+        if top_p is not None:
+            tp = Decimal(top_p)
+            sorted_by_prob = sorted(
+                sorted_tids, key=lambda t: probs[t], reverse=True
+            )
+            cumsum = Decimal(0)
+            kept: List[str] = []
+            for tid in sorted_by_prob:
+                cumsum += probs[tid]
+                kept.append(tid)
+                if cumsum >= tp:
+                    break
+            probs = {tid: probs[tid] for tid in kept}
+            sorted_tids = sorted(kept)
+
+        # min_p filtering
+        if min_p is not None:
+            mp = Decimal(min_p)
+            max_prob = max(probs[tid] for tid in sorted_tids)
+            threshold = max_prob * mp
+            kept = [tid for tid in sorted_tids if probs[tid] >= threshold]
+            if not kept:
+                kept = [max(sorted_tids, key=lambda t: probs[t])]
+            probs = {tid: probs[tid] for tid in kept}
+            sorted_tids = sorted(kept)
+
+        # Re-normalize after filtering
+        kept_total = sum(probs[tid] for tid in sorted_tids)
+        norm_probs = {tid: probs[tid] / kept_total for tid in sorted_tids}
+
+        # Quantize to integer weights
+        d_scale = Decimal(WEIGHT_SCALE)
+        weights = {
+            tid: int((norm_probs[tid] * d_scale).to_integral_value())
+            for tid in sorted_tids
+        }
+
+        # Fix total to exactly WEIGHT_SCALE (deterministic residual
+        # assignment). Ties broken by token ID string (lexicographic).
+        residual = WEIGHT_SCALE - sum(weights.values())
+        max_tid = max(sorted_tids, key=lambda t: (weights[t], t))
+        weights[max_tid] += residual
+
+    return weights
+
+
+def decimal_sample_from_logprobs(
+    logprob_strings: Dict[str, str],
+    rng: Sha256CounterRNG,
+    temperature: str,
+    top_p: Optional[str] = None,
+    top_k: Optional[int] = None,
+    min_p: Optional[str] = None,
+) -> str:
+    """
+    Full decimal pipeline + sample: logprob strings -> sampled token ID.
+
+    Calls logprobs_to_weights() to derive integer weights, then
+    sample_categorical_weights() to pick a token. Returns the sampled token ID
+    as a string.
+
+    The weight list is built in lexicographic token-ID-string order; the
+    returned index maps back through the same order.
+
+    Args:
+        logprob_strings: {token_id_str: logprob_str}
+        rng: SHA256 counter-mode RNG (state is advanced by one sample).
+        temperature: Temperature as string (e.g. "0.7").
+        top_p: Optional nucleus sampling threshold as string.
+        top_k: Optional top-k filter count.
+        min_p: Optional min-p threshold as string.
+
+    Returns:
+        Sampled token ID as string (e.g. "791").
+    """
+    weights = logprobs_to_weights(
+        logprob_strings, temperature,
+        top_p=top_p, top_k=top_k, min_p=min_p,
+    )
+
+    # Build parallel lists in deterministic order (sorted by token ID string).
+    sorted_tids = sorted(weights.keys())
+    weight_list = [weights[tid] for tid in sorted_tids]
+
+    idx = sample_categorical_weights(weight_list, rng)
+    return sorted_tids[idx]

--- a/vllm/v1/sample/deterministic_utils.py
+++ b/vllm/v1/sample/deterministic_utils.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import bisect
 import hashlib
+import math
 import struct
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal, localcontext
@@ -465,3 +466,31 @@ def decimal_sample_from_logprobs(
 
     idx = sample_categorical_weights(weight_list, rng)
     return sorted_tids[idx]
+
+
+def decimal_token_from_probs(
+    token_ids: Sequence[int],
+    probs: Sequence[float],
+    rng: Sha256CounterRNG,
+) -> str:
+    """E1 shadow: the token the decimal validator pipeline would sample from an
+    already temperature/filter-applied distribution, for comparison against the
+    float executor path (``(probs*2^16).round()``).
+
+    Feed the *nonzero support* of the post-filter distribution as parallel
+    ``token_ids`` and ``probs``. This runs the decimal softmax+quantize with
+    temperature 1 and no further filter (the temperature/filters are already in
+    the probs), and samples in canonical token-ID-string order — exactly what the
+    validator does — so a divergence from the float path is the E1 (float vs
+    decimal, plus token-order) effect. ``rng`` is advanced by one sample; pass a
+    snapshot to avoid disturbing the executor's live RNG.
+    """
+    support = {
+        str(int(t)): repr(math.log(float(p)))
+        for t, p in zip(token_ids, probs)
+        if p > 0.0
+    }
+    weights = logprobs_to_weights(support, "1.0")
+    sorted_tids = sorted(weights.keys())
+    weight_list = [weights[tid] for tid in sorted_tids]
+    return sorted_tids[sample_categorical_weights(weight_list, rng)]

--- a/vllm/v1/sample/deterministic_utils.py
+++ b/vllm/v1/sample/deterministic_utils.py
@@ -222,7 +222,11 @@ def sample_categorical_weights(weights: Sequence[int], rng: Sha256CounterRNG) ->
             last_nonzero = i
         total += w
     if total <= 0:
-        return len(weights) - 1
+        # Degenerate input (all weights zero). Raise rather than silently return
+        # the last index: in zero-tolerance replay a silent fallback would mask an
+        # upstream bug (§6.9). Matches the Go validator, which errors here; a
+        # validator catches it and returns Inconclusive, never Fraud.
+        raise ValueError("weights sum to zero")
 
     r = uint64_below(rng, total)
     cum = 0
@@ -262,7 +266,9 @@ class WeightedPrefixSampler:
 
     def sample(self, rng: Sha256CounterRNG) -> int:
         if self.total <= 0:
-            return len(self.prefix) - 1
+            # See sample_categorical_weights: raise rather than silently fall back
+            # to the last index (§6.9), consistent with the Go validator.
+            raise ValueError("weights sum to zero")
         r = uint64_below(rng, self.total)  # in [0,total)
         # find first i with prefix[i] > r
         i = bisect.bisect_right(self.prefix, r)

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -1,18 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import torch
 
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.validation import EnforcedTokens
 
+if TYPE_CHECKING:
+    from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
 
 @dataclass
 class SamplingMetadata:
     temperature: torch.Tensor | None
     all_greedy: bool
     all_random: bool
+    all_enforced: bool
+    mixed_enforced: bool
+
+    enforced_token_ids: dict[list[int]]
+    enforced_tokens: dict[EnforcedTokens]
+    enforced_req_ids: list[int]
 
     top_p: torch.Tensor | None
     top_k: torch.Tensor | None
@@ -42,3 +52,9 @@ class SamplingMetadata:
 
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+
+    # Deterministic RNGs for cross-platform reproducible sampling (validation)
+    # When VLLM_DETERMINISTIC_SAMPLING=1, this contains Sha256CounterRNG
+    # instances keyed by request index
+    deterministic_rngs: "dict[int, Sha256CounterRNG]" = field(
+        default_factory=dict)

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -10,6 +11,10 @@ from vllm import envs
 from vllm.config.model import LogprobsMode
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
+
+if TYPE_CHECKING:
+    from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
+    from vllm.v1.sample.metadata import SamplingMetadata
 
 logger = init_logger(__name__)
 
@@ -63,15 +68,24 @@ class TopKTopPSampler(nn.Module):
     def forward_native(
         self,
         logits: torch.Tensor,
-        generators: dict[int, torch.Generator],
-        k: torch.Tensor | None,
-        p: torch.Tensor | None,
+        sampling_metadata: "SamplingMetadata",
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling.
 
         The logits tensor may be updated in-place.
+
+        Args:
+            logits: The logits tensor of shape [batch_size, vocab_size]
+            sampling_metadata: Metadata containing sampling parameters including
+                generators, top_k, top_p, and deterministic_rngs
         """
+        # Extract fields from sampling_metadata
+        generators = sampling_metadata.generators
+        k = sampling_metadata.top_k
+        p = sampling_metadata.top_p
+        deterministic_rngs = sampling_metadata.deterministic_rngs
+
         logits = self.apply_top_k_top_p(logits, k, p)
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
@@ -79,16 +93,36 @@ class TopKTopPSampler(nn.Module):
         elif self.logprobs_mode == "processed_logprobs":
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
         probs = logits.softmax(dim=-1, dtype=torch.float32)
+
+        # Check for deterministic mode (VLLM_DETERMINISTIC_SAMPLING)
+        if deterministic_rngs:
+            return deterministic_sample(probs, deterministic_rngs), logits_to_return
+
         return random_sample(probs, generators), logits_to_return
 
     def forward_cuda(
         self,
         logits: torch.Tensor,
-        generators: dict[int, torch.Generator],
-        k: torch.Tensor | None,
-        p: torch.Tensor | None,
+        sampling_metadata: "SamplingMetadata",
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """More optimized implementation for top-k and top-p sampling."""
+        """More optimized implementation for top-k and top-p sampling.
+
+        Args:
+            logits: The logits tensor of shape [batch_size, vocab_size]
+            sampling_metadata: Metadata containing sampling parameters including
+                generators, top_k, top_p, and deterministic_rngs
+        """
+        # Extract fields from sampling_metadata
+        generators = sampling_metadata.generators
+        k = sampling_metadata.top_k
+        p = sampling_metadata.top_p
+        deterministic_rngs = sampling_metadata.deterministic_rngs
+
+        # Check for deterministic mode first (VLLM_DETERMINISTIC_SAMPLING)
+        # Deterministic mode always uses the native path for reproducibility
+        if deterministic_rngs:
+            return self.forward_native(logits, sampling_metadata)
+
         # We prefer `random_sample` over `flashinfer_sample` when sorting is
         # not needed. This is because `random_sample` does not require
         # CPU-GPU synchronization while `flashinfer_sample` does.
@@ -99,7 +133,7 @@ class TopKTopPSampler(nn.Module):
                     "per-request generators. Falling back to "
                     "PyTorch-native implementation."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(logits, sampling_metadata)
         assert self.logprobs_mode not in ("processed_logits", "processed_logprobs"), (
             "FlashInfer does not support returning logits/logprobs"
         )
@@ -111,15 +145,28 @@ class TopKTopPSampler(nn.Module):
     def forward_cpu(
         self,
         logits: torch.Tensor,
-        generators: dict[int, torch.Generator],
-        k: torch.Tensor | None,
-        p: torch.Tensor | None,
+        sampling_metadata: "SamplingMetadata",
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling for CPU.
 
         The logits tensor may be updated in-place.
+
+        Args:
+            logits: The logits tensor of shape [batch_size, vocab_size]
+            sampling_metadata: Metadata containing sampling parameters including
+                generators, top_k, top_p, and deterministic_rngs
         """
+        # Extract fields from sampling_metadata
+        generators = sampling_metadata.generators
+        k = sampling_metadata.top_k
+        p = sampling_metadata.top_p
+        deterministic_rngs = sampling_metadata.deterministic_rngs
+
+        # Check for deterministic mode first (VLLM_DETERMINISTIC_SAMPLING)
+        if deterministic_rngs:
+            return self.forward_native(logits, sampling_metadata)
+
         logits = self.apply_top_k_top_p(logits, k, p)
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
@@ -239,6 +286,51 @@ def random_sample(
         for i, generator in generators.items():
             q[i].exponential_(generator=generator)
     return probs.div_(q).argmax(dim=-1).view(-1)
+
+
+def deterministic_sample(
+    probs: torch.Tensor,
+    deterministic_rngs: dict[int, "Sha256CounterRNG"],
+) -> torch.Tensor:
+    """
+    Sample using SHA256-based deterministic RNG for cross-platform
+    reproducibility.
+
+    This function uses integer weights (quantized from probabilities) to ensure
+    identical sampling results across different platforms and implementations.
+
+    Args:
+        probs: Probability tensor of shape [batch_size, vocab_size]
+        deterministic_rngs: Dict mapping request index to Sha256CounterRNG
+
+    Returns:
+        Sampled token IDs tensor of shape [batch_size]
+    """
+    from vllm.v1.sample.deterministic_utils import sample_categorical_weights
+
+    batch_size = probs.size(0)
+    device = probs.device
+
+    # Quantize probabilities to integer weights (2^16 scale) for reproducibility
+    # Using integer arithmetic ensures identical results across platforms
+    WEIGHT_SCALE = 2**16
+    weights = (probs * WEIGHT_SCALE).round().to(torch.int64)
+    weights_cpu = weights.cpu().numpy()
+
+    sampled_tokens = []
+    for i in range(batch_size):
+        if i in deterministic_rngs:
+            rng = deterministic_rngs[i]
+            # Convert to list and sample using integer weights
+            weight_list = weights_cpu[i].tolist()
+            token_id = sample_categorical_weights(weight_list, rng)
+        else:
+            # Fallback for requests without deterministic RNG (shouldn't happen
+            # when VLLM_DETERMINISTIC_SAMPLING is enabled, but handle gracefully)
+            token_id = probs[i].argmax().item()
+        sampled_tokens.append(token_id)
+
+    return torch.tensor(sampled_tokens, dtype=torch.int64, device=device)
 
 
 def flashinfer_sample(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -86,6 +86,14 @@ class TopKTopPSampler(nn.Module):
         p = sampling_metadata.top_p
         deterministic_rngs = sampling_metadata.deterministic_rngs
 
+        # E1 + §6.6 fix: the deterministic path samples via the decimal pipeline
+        # over the RAW (pre-filter, post-temperature) logprobs in string token
+        # order — the identical computation the validator replays. Capture the raw
+        # logprobs before the float top-k/top-p mask is applied to `logits`.
+        pre_filter_logprobs = None
+        if deterministic_rngs:
+            pre_filter_logprobs = logits.log_softmax(dim=-1, dtype=torch.float32)
+
         logits = self.apply_top_k_top_p(logits, k, p)
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
@@ -96,20 +104,9 @@ class TopKTopPSampler(nn.Module):
 
         # Check for deterministic mode (VLLM_DETERMINISTIC_SAMPLING)
         if deterministic_rngs:
-            # E1 shadow: snapshot the RNGs *before* sampling so we can replay the
-            # decimal validator path from the identical state. Non-driving — the
-            # float path below is still what is returned.
-            snapshots = None
-            if envs.VLLM_DETERMINISTIC_SAMPLING_SHADOW:
-                from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
-                snapshots = {
-                    i: Sha256CounterRNG(r.seed_bytes, r.counter)
-                    for i, r in deterministic_rngs.items()
-                }
-            sampled = deterministic_sample(probs, deterministic_rngs)
-            if snapshots is not None:
-                _log_e1_shadow_divergence(probs, snapshots, sampled)
-            return sampled, logits_to_return
+            return (deterministic_sample(pre_filter_logprobs, deterministic_rngs,
+                                         k, p),
+                    logits_to_return)
 
         return random_sample(probs, generators), logits_to_return
 
@@ -301,87 +298,77 @@ def random_sample(
     return probs.div_(q).argmax(dim=-1).view(-1)
 
 
-def deterministic_sample(
-    probs: torch.Tensor,
-    deterministic_rngs: dict[int, "Sha256CounterRNG"],
-) -> torch.Tensor:
-    """
-    Sample using SHA256-based deterministic RNG for cross-platform
-    reproducibility.
+# Signed support size the executor computes decimal weights over. Provisional —
+# the real value is the signed support-set contract (Decision D2, #1199).
+DETERMINISTIC_SUPPORT_K = 64
 
-    This function uses integer weights (quantized from probabilities) to ensure
-    identical sampling results across different platforms and implementations.
+
+def deterministic_sample(
+    logprobs: torch.Tensor,
+    deterministic_rngs: dict[int, "Sha256CounterRNG"],
+    top_k: torch.Tensor | None,
+    top_p: torch.Tensor | None,
+) -> torch.Tensor:
+    """Contract-faithful deterministic sampling (E1 + §6.6, gonka-ai/gonka#1199).
+
+    Replaces the old float `(probs*2^16).round()` + numeric-order path. Per row,
+    samples via the **decimal** pipeline over the raw (pre-filter, post-temperature)
+    logprobs, in canonical token-ID **string** order, with a **per-position** seed
+    `f"{base}|{pos}"` — the identical computation the chain validator replays, so an
+    honest artifact verifies HONEST (float weights + numeric order + single stream
+    diverged ~50–70%; see the fix decomposition).
+
+    ``logprobs`` is log_softmax BEFORE the top-k/top-p mask; the decimal pipeline
+    re-applies the filters (matching the validator). The per-request RNG's
+    ``counter`` is repurposed as the position index (advanced once per sampled
+    position); the actual draw uses a fresh RNG seeded from base|position.
 
     Args:
-        probs: Probability tensor of shape [batch_size, vocab_size]
-        deterministic_rngs: Dict mapping request index to Sha256CounterRNG
-
-    Returns:
-        Sampled token IDs tensor of shape [batch_size]
+        logprobs: raw logprobs [batch, vocab] (pre-filter, post-temperature)
+        deterministic_rngs: request-row -> Sha256CounterRNG (seed_bytes = base
+            seed; counter = position)
+        top_k, top_p: per-request filter tensors (or None)
     """
-    from vllm.v1.sample.deterministic_utils import sample_categorical_weights
+    from vllm.v1.sample.deterministic_utils import (
+        Sha256CounterRNG,
+        logprobs_to_weights,
+        sample_categorical_weights,
+    )
 
-    batch_size = probs.size(0)
-    device = probs.device
+    batch_size = logprobs.size(0)
+    device = logprobs.device
+    support_k = min(DETERMINISTIC_SUPPORT_K, logprobs.size(-1))
 
-    # Quantize probabilities to integer weights (2^16 scale) for reproducibility
-    # Using integer arithmetic ensures identical results across platforms
-    WEIGHT_SCALE = 2**16
-    weights = (probs * WEIGHT_SCALE).round().to(torch.int64)
-    weights_cpu = weights.cpu().numpy()
-
-    sampled_tokens = []
+    out: list[int] = []
     for i in range(batch_size):
-        if i in deterministic_rngs:
-            rng = deterministic_rngs[i]
-            # Convert to list and sample using integer weights
-            weight_list = weights_cpu[i].tolist()
-            token_id = sample_categorical_weights(weight_list, rng)
-        else:
-            # Fallback for requests without deterministic RNG (shouldn't happen
-            # when VLLM_DETERMINISTIC_SAMPLING is enabled, but handle gracefully)
-            token_id = probs[i].argmax().item()
-        sampled_tokens.append(token_id)
-
-    return torch.tensor(sampled_tokens, dtype=torch.int64, device=device)
-
-
-def _log_e1_shadow_divergence(
-    probs: torch.Tensor,
-    snapshots: dict[int, "Sha256CounterRNG"],
-    float_tokens: torch.Tensor,
-) -> None:
-    """E1 shadow (gonka-ai/gonka#1199): per deterministic row, compare the float
-    executor token with the decimal validator token sampled from the SAME RNG
-    state, and log how often they diverge. Non-driving — ``float_tokens`` is what
-    the caller returns. Cost is O(support) per row; gate with
-    VLLM_DETERMINISTIC_SAMPLING_SHADOW.
-    """
-    from vllm.v1.sample.deterministic_utils import decimal_token_from_probs
-
-    probs_cpu = probs.detach().to("cpu")
-    ft = float_tokens.detach().to("cpu").tolist()
-    diverged = 0
-    checked = 0
-    for i, rng in snapshots.items():
-        row = probs_cpu[i]
-        nz = (row > 0).nonzero(as_tuple=True)[0]
-        if nz.numel() == 0:
+        state = deterministic_rngs.get(i)
+        if state is None:
+            # No deterministic RNG for this row — fall back to argmax.
+            out.append(int(logprobs[i].argmax()))
             continue
-        try:
-            decimal_tok = int(decimal_token_from_probs(
-                nz.tolist(), row[nz].tolist(), rng))
-        except Exception as e:  # noqa: BLE001 — shadow must never break sampling
-            logger.warning("E1 shadow skipped a row: %s", e)
-            continue
-        checked += 1
-        if decimal_tok != int(ft[i]):
-            diverged += 1
-    if checked:
-        logger.info(
-            "E1 shadow: %d/%d deterministic positions diverge "
-            "(float executor vs decimal validator) = %.1f%%",
-            diverged, checked, 100.0 * diverged / checked)
+
+        base_seed = state.seed_bytes.decode("utf-8")
+        position = state.counter
+
+        topv, topi = torch.topk(logprobs[i], support_k)
+        lp = {str(int(t)): repr(float(v))
+              for t, v in zip(topi.tolist(), topv.tolist())}
+
+        tk = int(top_k[i]) if top_k is not None else None
+        if tk is not None and tk <= 0:
+            tk = None
+        tp = float(top_p[i]) if top_p is not None else None
+        tp_str = str(tp) if tp is not None and tp < 1.0 else None
+
+        weights = logprobs_to_weights(lp, "1.0", top_p=tp_str, top_k=tk, min_p=None)
+        tids = sorted(weights.keys())
+        weight_list = [weights[t] for t in tids]
+        rng = Sha256CounterRNG.from_seed_string(f"{base_seed}|{position}")
+        out.append(int(tids[sample_categorical_weights(weight_list, rng)]))
+
+        state.counter += 1  # advance the per-request position
+
+    return torch.tensor(out, dtype=torch.int64, device=device)
 
 
 def flashinfer_sample(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -96,7 +96,20 @@ class TopKTopPSampler(nn.Module):
 
         # Check for deterministic mode (VLLM_DETERMINISTIC_SAMPLING)
         if deterministic_rngs:
-            return deterministic_sample(probs, deterministic_rngs), logits_to_return
+            # E1 shadow: snapshot the RNGs *before* sampling so we can replay the
+            # decimal validator path from the identical state. Non-driving — the
+            # float path below is still what is returned.
+            snapshots = None
+            if envs.VLLM_DETERMINISTIC_SAMPLING_SHADOW:
+                from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
+                snapshots = {
+                    i: Sha256CounterRNG(r.seed_bytes, r.counter)
+                    for i, r in deterministic_rngs.items()
+                }
+            sampled = deterministic_sample(probs, deterministic_rngs)
+            if snapshots is not None:
+                _log_e1_shadow_divergence(probs, snapshots, sampled)
+            return sampled, logits_to_return
 
         return random_sample(probs, generators), logits_to_return
 
@@ -331,6 +344,44 @@ def deterministic_sample(
         sampled_tokens.append(token_id)
 
     return torch.tensor(sampled_tokens, dtype=torch.int64, device=device)
+
+
+def _log_e1_shadow_divergence(
+    probs: torch.Tensor,
+    snapshots: dict[int, "Sha256CounterRNG"],
+    float_tokens: torch.Tensor,
+) -> None:
+    """E1 shadow (gonka-ai/gonka#1199): per deterministic row, compare the float
+    executor token with the decimal validator token sampled from the SAME RNG
+    state, and log how often they diverge. Non-driving — ``float_tokens`` is what
+    the caller returns. Cost is O(support) per row; gate with
+    VLLM_DETERMINISTIC_SAMPLING_SHADOW.
+    """
+    from vllm.v1.sample.deterministic_utils import decimal_token_from_probs
+
+    probs_cpu = probs.detach().to("cpu")
+    ft = float_tokens.detach().to("cpu").tolist()
+    diverged = 0
+    checked = 0
+    for i, rng in snapshots.items():
+        row = probs_cpu[i]
+        nz = (row > 0).nonzero(as_tuple=True)[0]
+        if nz.numel() == 0:
+            continue
+        try:
+            decimal_tok = int(decimal_token_from_probs(
+                nz.tolist(), row[nz].tolist(), rng))
+        except Exception as e:  # noqa: BLE001 — shadow must never break sampling
+            logger.warning("E1 shadow skipped a row: %s", e)
+            continue
+        checked += 1
+        if decimal_tok != int(ft[i]):
+            diverged += 1
+    if checked:
+        logger.info(
+            "E1 shadow: %d/%d deterministic positions diverge "
+            "(float executor vs decimal validator) = %.1f%%",
+            diverged, checked, 100.0 * diverged / checked)
 
 
 def flashinfer_sample(

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -85,9 +85,10 @@ class Sampler(nn.Module):
 
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
-
+        
         logits = self.apply_logits_processors(
-            logits, sampling_metadata, predict_bonus_token
+            logits, sampling_metadata, predict_bonus_token,
+            # sampling_metadata.output_token_ids_len_cpu
         )
         # Sample the next token.
         sampled, processed_logprobs = self.sample(logits, sampling_metadata)
@@ -109,7 +110,7 @@ class Sampler(nn.Module):
         else:
             # Gather the logprobs and ranks of the topk and sampled token.
             logprobs_tensors = self.gather_logprobs(
-                raw_logprobs, num_logprobs, token_ids=sampled
+                raw_logprobs, num_logprobs, token_ids=sampled, sampling_metadata=sampling_metadata
             )
 
         # Use int32 to reduce the tensor size.
@@ -152,10 +153,35 @@ class Sampler(nn.Module):
         The various logits processing functions called in this method
         may update the logits tensor in-place.
         """
-
+        
         logprobs_mode = logprobs_mode_override or self.logprobs_mode
         assert not (sampling_metadata.all_greedy and sampling_metadata.all_random)
-        if sampling_metadata.all_random:
+        assert not (sampling_metadata.all_greedy and sampling_metadata.all_enforced)
+        assert not (sampling_metadata.all_random and sampling_metadata.all_enforced)
+
+        if sampling_metadata.enforced_token_ids:
+            enforced_sampled = torch.empty((len(sampling_metadata.enforced_req_ids),), dtype=torch.int64, device=logits.device)
+            enforced_map = sampling_metadata.enforced_token_ids
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                seq = enforced_map[req_index]
+                out = sampling_metadata.output_token_ids[req_index]
+
+                step = len(out)
+
+                if step < len(seq):
+                    next_tok = seq[step]
+                else:
+                    next_tok = seq[-1]
+
+                enforced_sampled[i] = next_tok
+            if sampling_metadata.all_enforced:
+                # Reorder so result[pos] = token for batch position pos
+                # (enforced_req_ids may be out of order after condense)
+                result = torch.empty((logits.size(0),), dtype=torch.int64, device=logits.device)
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    result[req_index] = enforced_sampled[i]
+                return result, None                   
+        if sampling_metadata.all_random or sampling_metadata.mixed_enforced:
             greedy_sampled = None
         else:
             greedy_sampled = self.greedy_sample(logits)
@@ -172,7 +198,7 @@ class Sampler(nn.Module):
 
         # Apply temperature.
         logits = self.apply_temperature(
-            logits, sampling_metadata.temperature, sampling_metadata.all_random
+            logits, sampling_metadata.temperature, sampling_metadata.all_random or sampling_metadata.mixed_enforced
         )
 
         # Apply logits processors that only apply to random sampling
@@ -183,12 +209,13 @@ class Sampler(nn.Module):
         # Apply top_k and/or top_p.
         random_sampled, processed_logprobs = self.topk_topp_sampler(
             logits,
-            sampling_metadata.generators,
-            sampling_metadata.top_k,
-            sampling_metadata.top_p,
+            sampling_metadata,
         )
 
         if greedy_sampled is None:
+            if sampling_metadata.enforced_token_ids:
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    random_sampled[int(req_index)] = enforced_sampled[i]
             return random_sampled, processed_logprobs
 
         sampled = torch.where(
@@ -197,6 +224,12 @@ class Sampler(nn.Module):
             random_sampled,
             out=greedy_sampled,  # Reuse tensor
         )
+       
+
+        if sampling_metadata.enforced_token_ids:
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                sampled[int(req_index)] = enforced_sampled[i]
+
         return sampled, processed_logprobs
 
     @staticmethod
@@ -208,6 +241,7 @@ class Sampler(nn.Module):
         logprobs: torch.Tensor,
         num_logprobs: int,
         token_ids: torch.Tensor,
+        sampling_metadata: SamplingMetadata
     ) -> LogprobsTensors:
         """
         Gather logprobs for topk and sampled/prompt token.
@@ -228,8 +262,63 @@ class Sampler(nn.Module):
           Sampled token rank tensor, (num tokens)
         """
         assert token_ids.dtype == torch.int64
-        # Find the topK values.
-        topk_logprobs, topk_indices = torch.topk(logprobs, num_logprobs, dim=-1)
+        if sampling_metadata.enforced_tokens:
+            enforced_top_map = sampling_metadata.enforced_tokens
+            enforced_map = sampling_metadata.enforced_token_ids
+            
+            topk_indices_enforced = torch.empty((len(sampling_metadata.enforced_req_ids), num_logprobs), dtype=torch.int64, device=logprobs.device)
+
+            for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                seq = enforced_map[req_index]
+                seq_top_tokens = enforced_top_map[req_index]
+                out = sampling_metadata.output_token_ids[req_index]
+
+                step = len(out)
+
+                if step < len(seq):
+                    next_tok = seq[step]
+                    next_top_tok = seq_top_tokens[step][next_tok]
+
+                else:
+                    next_tok = seq[-1]
+                    step = len(seq) - 1
+                    next_top_tok = seq_top_tokens[step][next_tok]
+
+                topk_indices_enforced[i] = torch.tensor(next_top_tok, device=logprobs.device)
+            
+
+            topk_logprobs_enforced = torch.gather(
+                logprobs[sampling_metadata.enforced_req_ids],
+                dim=1,
+                index=topk_indices_enforced
+            )
+
+            if sampling_metadata.all_enforced:
+                topk_indices = torch.empty((logprobs.size(0), num_logprobs), dtype=torch.int64, device=logprobs.device)
+                topk_logprobs = torch.empty((logprobs.size(0), num_logprobs), device=logprobs.device)
+                for i, req_index in enumerate(sampling_metadata.enforced_req_ids):
+                    topk_indices[req_index] = topk_indices_enforced[i]
+                    topk_logprobs[req_index] = topk_logprobs_enforced[i]
+            elif sampling_metadata.mixed_enforced:
+                all_ids = torch.arange(logprobs.size(0), device=logprobs.device)
+                mask_normal = torch.ones_like(all_ids, dtype=torch.bool)
+                mask_normal[sampling_metadata.enforced_req_ids] = False
+
+                topk_logprobs_normal, topk_indices_normal = torch.topk(
+                    logprobs[mask_normal], num_logprobs, dim=-1
+                )
+
+                topk_indices = torch.empty_like(logprobs, device=logprobs.device, dtype=torch.int64)[:, :num_logprobs]
+                topk_logprobs = torch.empty_like(logprobs, device=logprobs.device)[:, :num_logprobs]
+
+                topk_indices[mask_normal] = topk_indices_normal
+                topk_logprobs[mask_normal] = topk_logprobs_normal
+
+                topk_indices[sampling_metadata.enforced_req_ids] = topk_indices_enforced
+                topk_logprobs[sampling_metadata.enforced_req_ids] = topk_logprobs_enforced
+        else:
+            # Find the topK values.
+            topk_logprobs, topk_indices = torch.topk(logprobs, num_logprobs, dim=-1)
 
         # Get with the logprob of the prompt or sampled token.
         token_ids = token_ids.unsqueeze(-1)
@@ -238,13 +327,13 @@ class Sampler(nn.Module):
         # Compute the ranks of the actual token.
         token_ranks = batched_count_greater_than(logprobs, token_logprobs)
 
+    
         # Concatenate together with the topk.
         indices = torch.cat((token_ids, topk_indices), dim=1)
         logprobs = torch.cat((token_logprobs, topk_logprobs), dim=1)
 
         # Use int32 to reduce the tensor size.
         indices = indices.to(torch.int32)
-
         return LogprobsTensors(indices, logprobs, token_ranks)
 
     @staticmethod
@@ -265,13 +354,17 @@ class Sampler(nn.Module):
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
         predict_bonus_token: bool,
+        # output_token_ids_len: torch.Tensor,
     ) -> torch.Tensor:
         bad_words_token_ids = sampling_metadata.bad_words_token_ids
         any_penalties_or_bad_words = (
             bool(bad_words_token_ids) or not sampling_metadata.no_penalties
         )
 
+        # output_token_ids: list[list[int]] | torch.Tensor = sampling_metadata.output_token_ids
+        # if sampling_metadata.output_token_ids_tensor is not None:
         output_token_ids = sampling_metadata.output_token_ids
+
         if predict_bonus_token and any_penalties_or_bad_words:
             # Combine base outputs with spec tokens when speculative decoding
             # is enabled.

--- a/vllm/v1/sample/test_deterministic_sampler.py
+++ b/vllm/v1/sample/test_deterministic_sampler.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""
+Test suite for the deterministic sampler.
+
+This test file has two modes:
+1. If vllm is importable (C extension works), it tests the full DeterministicSampler class
+2. If vllm is not importable, it falls back to testing standalone functions
+
+Tests:
+1. Basic reproducibility: same seed produces same results
+2. Different seeds produce different results
+3. Cross-run reproducibility: can reproduce results across multiple invocations
+4. Real data test: resample from actual inference logprobs
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+# Optional real-data fixture. Point VLLM_DETSAMPLE_REPRO_DATA at a repro JSONL
+# to exercise the real-data tests; when unset (the default, e.g. CI) those
+# tests skip / fall back to synthetic. No private absolute path is baked in.
+_REPRO_DATA_ENV = "VLLM_DETSAMPLE_REPRO_DATA"
+from typing import Dict, List, Sequence
+
+# Try to import pytest
+try:
+    import pytest
+    HAS_PYTEST = True
+except ImportError:
+    HAS_PYTEST = False
+    class _FakeFixture:
+        def __call__(self, func):
+            return func
+    class _FakePytest:
+        skip = staticmethod(lambda msg: None)
+        fixture = _FakeFixture()
+    pytest = _FakePytest()
+
+# Always import the core utils (no dependencies)
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical,
+    sample_categorical_weights,
+    iter_u64,
+)
+
+# Try to import the full sampler (has torch/vllm dependencies)
+VLLM_AVAILABLE = False
+try:
+    from vllm.v1.sample.deterministic_sampler import (
+        DeterministicSampler,
+        DeterministicSamplingState,
+        deterministic_sample_from_logprobs,
+        deterministic_sample_from_probs,
+        resample_from_inference_logprobs,
+    )
+    VLLM_AVAILABLE = True
+except ImportError as e:
+    print(f"Note: Full vllm import failed ({e}), using standalone implementations")
+    
+    # Define standalone implementations when vllm is not available
+    def deterministic_sample_from_logprobs(
+        logprobs: Sequence[Dict[int, float]],
+        seed: str,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+        top_p: float | None = None,
+    ) -> List[int]:
+        """Sample tokens deterministically from logprob dictionaries."""
+        rng = Sha256CounterRNG.from_seed_string(seed)
+        sampled_tokens = []
+        
+        for step_logprobs in logprobs:
+            if not step_logprobs:
+                raise ValueError("Empty logprobs at step")
+            
+            token_ids = list(step_logprobs.keys())
+            log_values = [step_logprobs[tid] for tid in token_ids]
+            
+            # Apply temperature
+            if temperature != 1.0 and temperature > 0:
+                log_values = [lv / temperature for lv in log_values]
+            
+            # Softmax
+            max_log = max(log_values)
+            exp_values = [math.exp(lv - max_log) for lv in log_values]
+            sum_exp = sum(exp_values)
+            probs = [ev / sum_exp for ev in exp_values]
+            
+            # Top-k
+            if top_k is not None and top_k < len(token_ids):
+                sorted_items = sorted(
+                    zip(token_ids, probs), key=lambda x: x[1], reverse=True
+                )[:top_k]
+                token_ids = [x[0] for x in sorted_items]
+                probs = [x[1] for x in sorted_items]
+                sum_probs = sum(probs)
+                probs = [p / sum_probs for p in probs]
+            
+            # Top-p
+            if top_p is not None and top_p < 1.0:
+                sorted_items = sorted(
+                    zip(token_ids, probs), key=lambda x: x[1], reverse=True
+                )
+                cumsum = 0.0
+                filtered = []
+                for tid, p in sorted_items:
+                    if cumsum >= top_p and filtered:
+                        break
+                    filtered.append((tid, p))
+                    cumsum += p
+                token_ids = [x[0] for x in filtered]
+                probs = [x[1] for x in filtered]
+                sum_probs = sum(probs)
+                probs = [p / sum_probs for p in probs]
+            
+            idx = sample_categorical(probs, rng)
+            sampled_tokens.append(token_ids[idx])
+        
+        return sampled_tokens
+
+    def deterministic_sample_from_probs(
+        probs_2d: Sequence[Sequence[float]],
+        seed: str,
+    ) -> List[int]:
+        """Sample tokens deterministically from 2D probability array."""
+        rng = Sha256CounterRNG.from_seed_string(seed)
+        return [sample_categorical(step_probs, rng) for step_probs in probs_2d]
+
+    def resample_from_inference_logprobs(
+        inference_results: List[Dict],
+        prompt: str,
+        temperature: float = 1.0,
+        seed_prefix: str = "resample",
+    ) -> List[int]:
+        """Re-sample tokens from inference result logprobs."""
+        seed = f"{seed_prefix}|{prompt}"
+        logprobs_seq = []
+        for result in inference_results:
+            lp = result.get("logprobs", {})
+            lp_int = {int(k): v for k, v in lp.items()}
+            logprobs_seq.append(lp_int)
+        return deterministic_sample_from_logprobs(
+            logprobs_seq, seed=seed, temperature=temperature
+        )
+
+
+# =============================================================================
+# Unit Tests for RNG
+# =============================================================================
+
+class TestSha256CounterRNG:
+    """Test the SHA256-based RNG."""
+    
+    def test_reproducibility(self):
+        """Same seed should produce same sequence."""
+        rng1 = Sha256CounterRNG.from_seed_string("test_seed")
+        rng2 = Sha256CounterRNG.from_seed_string("test_seed")
+        
+        for _ in range(100):
+            assert rng1.next_u64() == rng2.next_u64()
+    
+    def test_different_seeds_different_output(self):
+        """Different seeds should produce different sequences."""
+        rng1 = Sha256CounterRNG.from_seed_string("seed_a")
+        rng2 = Sha256CounterRNG.from_seed_string("seed_b")
+        
+        vals1 = [rng1.next_u64() for _ in range(10)]
+        vals2 = [rng2.next_u64() for _ in range(10)]
+        assert vals1 != vals2
+    
+    def test_uniform01_range(self):
+        """Uniform values should be in [0, 1)."""
+        rng = Sha256CounterRNG.from_seed_string("uniform_test")
+        for _ in range(1000):
+            u = rng.next_uniform01()
+            assert 0.0 <= u < 1.0
+    
+    def test_iter_u64_reproducibility(self):
+        """iter_u64 helper should be reproducible."""
+        vals1 = iter_u64("test", 50)
+        vals2 = iter_u64("test", 50)
+        assert vals1 == vals2
+
+
+# =============================================================================
+# Unit Tests for Categorical Sampling
+# =============================================================================
+
+class TestCategoricalSampling:
+    """Test categorical sampling functions."""
+    
+    def test_sample_categorical_reproducibility(self):
+        """Same RNG state should produce same samples."""
+        probs = [0.1, 0.2, 0.3, 0.4]
+        
+        rng1 = Sha256CounterRNG.from_seed_string("cat_test")
+        rng2 = Sha256CounterRNG.from_seed_string("cat_test")
+        
+        for _ in range(100):
+            s1 = sample_categorical(probs, rng1)
+            s2 = sample_categorical(probs, rng2)
+            assert s1 == s2
+    
+    def test_sample_categorical_distribution(self):
+        """Sampled distribution should roughly match input probs."""
+        probs = [0.1, 0.2, 0.3, 0.4]
+        rng = Sha256CounterRNG.from_seed_string("dist_test")
+        
+        counts = [0, 0, 0, 0]
+        n_samples = 10000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        for i, p in enumerate(probs):
+            empirical = counts[i] / n_samples
+            assert abs(empirical - p) < 0.05, f"Index {i}: expected ~{p}, got {empirical}"
+    
+    def test_sample_categorical_weights(self):
+        """Test integer weight sampling."""
+        weights = [1, 2, 3, 4]
+        
+        rng1 = Sha256CounterRNG.from_seed_string("weight_test")
+        rng2 = Sha256CounterRNG.from_seed_string("weight_test")
+        
+        for _ in range(50):
+            s1 = sample_categorical_weights(weights, rng1)
+            s2 = sample_categorical_weights(weights, rng2)
+            assert s1 == s2
+    
+    def test_degenerate_distribution(self):
+        """Test with a degenerate distribution (all mass on one token)."""
+        probs = [0.0, 0.0, 1.0, 0.0]
+        rng = Sha256CounterRNG.from_seed_string("degen_test")
+        
+        for _ in range(100):
+            idx = sample_categorical(probs, rng)
+            assert idx == 2
+
+
+# =============================================================================
+# Unit Tests for Deterministic Sampler Functions
+# =============================================================================
+
+class TestDeterministicSamplerFunctions:
+    """Test standalone sampling functions."""
+    
+    def test_sample_from_probs_reproducibility(self):
+        """Sampling from probs should be reproducible."""
+        probs_2d = [
+            [0.1, 0.2, 0.3, 0.4],
+            [0.25, 0.25, 0.25, 0.25],
+            [0.9, 0.05, 0.03, 0.02],
+        ]
+        
+        result1 = deterministic_sample_from_probs(probs_2d, "test_seed")
+        result2 = deterministic_sample_from_probs(probs_2d, "test_seed")
+        
+        assert result1 == result2
+    
+    def test_sample_from_logprobs_reproducibility(self):
+        """Sampling from logprobs dicts should be reproducible."""
+        logprobs = [
+            {0: -2.3, 1: -1.6, 2: -1.2, 3: -0.9},
+            {0: -1.4, 1: -1.4, 2: -1.4, 3: -1.4},
+        ]
+        
+        result1 = deterministic_sample_from_logprobs(logprobs, "logprob_test")
+        result2 = deterministic_sample_from_logprobs(logprobs, "logprob_test")
+        
+        assert result1 == result2
+    
+    def test_sample_from_logprobs_with_temperature(self):
+        """Temperature should affect sampling distribution."""
+        logprobs = [{0: -0.1, 1: -2.3}]
+        
+        low_temp_results = []
+        for i in range(100):
+            result = deterministic_sample_from_logprobs(
+                logprobs, f"temp_test_{i}", temperature=0.1
+            )
+            low_temp_results.append(result[0])
+        
+        assert low_temp_results.count(0) > 90
+    
+    def test_different_seeds_different_results(self):
+        """Different seeds should (usually) produce different results."""
+        probs_2d = [[0.25, 0.25, 0.25, 0.25] for _ in range(20)]
+        
+        result1 = deterministic_sample_from_probs(probs_2d, "seed_a")
+        result2 = deterministic_sample_from_probs(probs_2d, "seed_b")
+        
+        assert result1 != result2
+
+
+# =============================================================================
+# Integration Test with Real Data
+# =============================================================================
+
+class TestRealData:
+    """Test with real inference data."""
+    
+    _env = os.environ.get(_REPRO_DATA_ENV)
+    DATA_PATH = Path(_env) if _env else None
+
+    def _load_sample_data(self, n_samples: int = 5) -> List[Dict]:
+        """Load samples from the real data file."""
+        if self.DATA_PATH is None or not self.DATA_PATH.exists():
+            return []
+        
+        samples = []
+        with open(self.DATA_PATH, "r") as f:
+            for i, line in enumerate(f):
+                if i >= n_samples:
+                    break
+                samples.append(json.loads(line))
+        return samples
+    
+    def test_resample_reproducibility(self):
+        """Resampling should be reproducible."""
+        sample_data = self._load_sample_data()
+        if not sample_data:
+            print("SKIP: Data file not found")
+            return
+        
+        for data in sample_data:
+            prompt = data["prompt"]
+            inference_results = data["inference_result"]["results"]
+            
+            tokens1 = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=1.0, seed_prefix="test"
+            )
+            tokens2 = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=1.0, seed_prefix="test"
+            )
+            
+            assert tokens1 == tokens2, f"Reproducibility failed for prompt: {prompt[:50]}..."
+    
+    def test_cross_run_reproducibility(self):
+        """Results should be reproducible across multiple function calls."""
+        sample_data = self._load_sample_data(1)
+        if not sample_data:
+            print("SKIP: No sample data available")
+            return
+        
+        data = sample_data[0]
+        prompt = data["prompt"]
+        inference_results = data["inference_result"]["results"]
+        
+        all_results = []
+        for _ in range(10):
+            tokens = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="cross_run"
+            )
+            all_results.append(tokens)
+        
+        for i, result in enumerate(all_results):
+            assert result == all_results[0], f"Run {i} differs from run 0"
+        
+        print(f"All 10 runs produced identical results: {len(all_results[0])} tokens")
+    
+    def test_original_vs_resampled(self):
+        """Compare original tokens with resampled tokens."""
+        sample_data = self._load_sample_data()
+        if not sample_data:
+            print("SKIP: No sample data available")
+            return
+        
+        for data in sample_data:
+            prompt = data["prompt"]
+            inference_results = data["inference_result"]["results"]
+            
+            original_tokens = [r["token"] for r in inference_results]
+            
+            resampled = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="compare"
+            )
+            
+            for i, (orig, resampled_tok) in enumerate(zip(original_tokens, resampled)):
+                logprobs_dict = inference_results[i]["logprobs"]
+                token_ids = [int(k) for k in logprobs_dict.keys()]
+                
+                assert resampled_tok in token_ids, \
+                    f"Step {i}: Resampled token {resampled_tok} not in logprobs {token_ids}"
+            
+            match_count = sum(1 for o, r in zip(original_tokens, resampled) if o == r)
+            print(f"Prompt '{prompt[:30]}...': {match_count}/{len(original_tokens)} tokens match original")
+
+
+# =============================================================================
+# Test for DeterministicSampler class (only if vllm is available)
+# =============================================================================
+
+class TestDeterministicSamplerClass:
+    """Test the DeterministicSampler class (requires full vllm)."""
+    
+    def test_sampler_state_creation(self):
+        """Test creating sampling state from seeds."""
+        if not VLLM_AVAILABLE:
+            print("SKIP: vllm not available")
+            return
+        
+        state = DeterministicSamplingState.from_seeds({
+            0: "prompt_0",
+            1: "prompt_1",
+        })
+        
+        # Get RNGs
+        rng0 = state.get_rng(0)
+        rng1 = state.get_rng(1)
+        
+        # Should be different
+        assert rng0.next_u64() != rng1.next_u64()
+        
+        print("PASS: DeterministicSamplingState creation")
+    
+    def test_sampler_state_reproducibility(self):
+        """Test that state produces reproducible RNGs."""
+        if not VLLM_AVAILABLE:
+            print("SKIP: vllm not available")
+            return
+        
+        state1 = DeterministicSamplingState.from_seeds({0: "test"})
+        state2 = DeterministicSamplingState.from_seeds({0: "test"})
+        
+        for _ in range(100):
+            assert state1.get_rng(0).next_u64() == state2.get_rng(0).next_u64()
+        
+        print("PASS: DeterministicSamplingState reproducibility")
+
+
+# =============================================================================
+# Comprehensive Reproducibility Test
+# =============================================================================
+
+def test_full_reproducibility_pipeline():
+    """
+    Comprehensive test: Load data, sample twice, verify identical results.
+    """
+    _env = os.environ.get(_REPRO_DATA_ENV)
+    data_path = Path(_env) if _env else None
+
+    if data_path is None or not data_path.exists():
+        print(f"Data file not found: {data_path}")
+        print("Skipping real data test, running synthetic test instead...")
+        
+        probs_2d = [[0.1, 0.2, 0.3, 0.4] for _ in range(100)]
+        seed = "synthetic_test_seed"
+        
+        run1 = deterministic_sample_from_probs(probs_2d, seed)
+        run2 = deterministic_sample_from_probs(probs_2d, seed)
+        
+        assert run1 == run2
+        print("PASS: Synthetic reproducibility test passed")
+        return
+    
+    samples = []
+    with open(data_path, "r") as f:
+        for i, line in enumerate(f):
+            if i >= 10:
+                break
+            samples.append(json.loads(line))
+    
+    print(f"Loaded {len(samples)} samples")
+    
+    all_pass = True
+    for idx, data in enumerate(samples):
+        prompt = data["prompt"]
+        inference_results = data["inference_result"]["results"]
+        
+        tokens1 = resample_from_inference_logprobs(
+            inference_results, prompt, temperature=0.99, seed_prefix="full_test"
+        )
+        tokens2 = resample_from_inference_logprobs(
+            inference_results, prompt, temperature=0.99, seed_prefix="full_test"
+        )
+        tokens3 = resample_from_inference_logprobs(
+            inference_results, prompt, temperature=0.99, seed_prefix="full_test"
+        )
+        
+        if tokens1 != tokens2 or tokens2 != tokens3:
+            print(f"FAIL: Sample {idx} - Results not reproducible!")
+            all_pass = False
+        else:
+            print(f"PASS: Sample {idx} - {len(tokens1)} tokens reproducible across 3 runs")
+    
+    assert all_pass, "Some samples failed reproducibility test"
+    print("\n=== ALL REPRODUCIBILITY TESTS PASSED ===")
+
+
+# =============================================================================
+# Main execution
+# =============================================================================
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Running Deterministic Sampler Tests")
+    print("=" * 60)
+    print(f"vllm available: {VLLM_AVAILABLE}")
+    
+    print("\n--- RNG Tests ---")
+    test_rng = TestSha256CounterRNG()
+    test_rng.test_reproducibility()
+    print("PASS: RNG reproducibility")
+    test_rng.test_different_seeds_different_output()
+    print("PASS: Different seeds produce different output")
+    test_rng.test_uniform01_range()
+    print("PASS: Uniform values in [0, 1)")
+    test_rng.test_iter_u64_reproducibility()
+    print("PASS: iter_u64 reproducibility")
+    
+    print("\n--- Categorical Sampling Tests ---")
+    test_cat = TestCategoricalSampling()
+    test_cat.test_sample_categorical_reproducibility()
+    print("PASS: Categorical sampling reproducibility")
+    test_cat.test_sample_categorical_distribution()
+    print("PASS: Categorical distribution matches probs")
+    test_cat.test_sample_categorical_weights()
+    print("PASS: Integer weight sampling")
+    test_cat.test_degenerate_distribution()
+    print("PASS: Degenerate distribution")
+    
+    print("\n--- Deterministic Sampler Function Tests ---")
+    test_func = TestDeterministicSamplerFunctions()
+    test_func.test_sample_from_probs_reproducibility()
+    print("PASS: Sample from probs reproducibility")
+    test_func.test_sample_from_logprobs_reproducibility()
+    print("PASS: Sample from logprobs reproducibility")
+    test_func.test_sample_from_logprobs_with_temperature()
+    print("PASS: Temperature affects sampling")
+    test_func.test_different_seeds_different_results()
+    print("PASS: Different seeds produce different results")
+    
+    print("\n--- DeterministicSampler Class Tests ---")
+    test_class = TestDeterministicSamplerClass()
+    test_class.test_sampler_state_creation()
+    test_class.test_sampler_state_reproducibility()
+    
+    print("\n--- Real Data Tests ---")
+    test_real = TestRealData()
+    test_real.test_resample_reproducibility()
+    print("PASS: Real data resample reproducibility")
+    test_real.test_cross_run_reproducibility()
+    print("PASS: Real data cross-run reproducibility")
+    test_real.test_original_vs_resampled()
+    print("PASS: Real data original vs resampled")
+    
+    print("\n--- Full Pipeline Test ---")
+    test_full_reproducibility_pipeline()

--- a/vllm/v1/sample/test_deterministic_standalone.py
+++ b/vllm/v1/sample/test_deterministic_standalone.py
@@ -1,0 +1,1064 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test suite for deterministic sampling utilities.
+Does not require full vLLM installation - only tests the core cryptographic sampling.
+
+Tests include:
+- RNG reproducibility and statistical properties
+- Categorical sampling correctness
+- Edge cases (degenerate distributions, extreme values)
+- Real data reproducibility with larger sample sizes
+- Cross-run consistency validation
+- Temperature and top-k/top-p filtering
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+# Optional real-data fixture. Point VLLM_DETSAMPLE_REPRO_DATA at a repro JSONL
+# to exercise the real-data tests; when unset (the default, e.g. CI) those
+# tests skip. No private absolute path is baked in.
+_REPRO_DATA_ENV = "VLLM_DETSAMPLE_REPRO_DATA"
+from typing import Dict, List, Sequence, Tuple
+
+# Add the vllm path for local imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    sample_categorical,
+    sample_categorical_weights,
+    iter_u64,
+    WeightedPrefixSampler,
+    uint64_below,
+)
+
+
+# =============================================================================
+# Standalone sampling functions (no torch dependency)
+# =============================================================================
+
+def deterministic_sample_from_logprobs(
+    logprobs: Sequence[Dict[int, float]],
+    seed: str,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    top_p: float | None = None,
+) -> List[int]:
+    """
+    Sample tokens deterministically from a sequence of logprob dictionaries.
+    """
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    sampled_tokens = []
+    
+    for step_logprobs in logprobs:
+        if not step_logprobs:
+            raise ValueError("Empty logprobs at step")
+        
+        # Convert logprobs to probabilities
+        token_ids = list(step_logprobs.keys())
+        log_values = [step_logprobs[tid] for tid in token_ids]
+        
+        # Apply temperature
+        if temperature != 1.0 and temperature > 0:
+            log_values = [lv / temperature for lv in log_values]
+        
+        # Convert to probabilities via softmax
+        max_log = max(log_values)
+        exp_values = [math.exp(lv - max_log) for lv in log_values]
+        sum_exp = sum(exp_values)
+        probs = [ev / sum_exp for ev in exp_values]
+        
+        # Apply top-k
+        if top_k is not None and top_k < len(token_ids):
+            sorted_items = sorted(
+                zip(token_ids, probs),
+                key=lambda x: x[1],
+                reverse=True
+            )[:top_k]
+            token_ids = [x[0] for x in sorted_items]
+            probs = [x[1] for x in sorted_items]
+            sum_probs = sum(probs)
+            probs = [p / sum_probs for p in probs]
+        
+        # Apply top-p
+        if top_p is not None and top_p < 1.0:
+            sorted_items = sorted(
+                zip(token_ids, probs),
+                key=lambda x: x[1],
+                reverse=True
+            )
+            cumsum = 0.0
+            filtered = []
+            for tid, p in sorted_items:
+                if cumsum >= top_p and filtered:
+                    break
+                filtered.append((tid, p))
+                cumsum += p
+            token_ids = [x[0] for x in filtered]
+            probs = [x[1] for x in filtered]
+            sum_probs = sum(probs)
+            probs = [p / sum_probs for p in probs]
+        
+        # Sample using deterministic categorical sampler
+        idx = sample_categorical(probs, rng)
+        sampled_tokens.append(token_ids[idx])
+    
+    return sampled_tokens
+
+
+def deterministic_sample_from_probs(
+    probs_2d: Sequence[Sequence[float]],
+    seed: str,
+) -> List[int]:
+    """Sample tokens deterministically from 2D probability array."""
+    rng = Sha256CounterRNG.from_seed_string(seed)
+    return [sample_categorical(step_probs, rng) for step_probs in probs_2d]
+
+
+def resample_from_inference_logprobs(
+    inference_results: List[Dict],
+    prompt: str,
+    temperature: float = 1.0,
+    seed_prefix: str = "resample",
+    top_k: int | None = None,
+    top_p: float | None = None,
+) -> List[int]:
+    """Re-sample tokens from inference result logprobs."""
+    seed = f"{seed_prefix}|{prompt}"
+    
+    logprobs_seq = []
+    for result in inference_results:
+        lp = result.get("logprobs", {})
+        lp_int = {int(k): v for k, v in lp.items()}
+        logprobs_seq.append(lp_int)
+    
+    return deterministic_sample_from_logprobs(
+        logprobs_seq,
+        seed=seed,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+    )
+
+
+# =============================================================================
+# Test Utilities
+# =============================================================================
+
+def chi_squared_test(observed: List[int], expected: List[float], alpha: float = 0.01) -> Tuple[float, bool]:
+    """
+    Perform chi-squared goodness of fit test.
+    Returns (chi_squared_statistic, passes_test).
+    """
+    n = sum(observed)
+    expected_counts = [e * n for e in expected]
+    
+    chi_sq = 0.0
+    for obs, exp in zip(observed, expected_counts):
+        if exp > 0:
+            chi_sq += (obs - exp) ** 2 / exp
+    
+    df = len(observed) - 1
+    
+    # Critical values for chi-squared at alpha=0.01 (99% confidence)
+    # Pre-computed for common df values
+    critical_values = {
+        1: 6.635, 2: 9.210, 3: 11.345, 4: 13.277, 5: 15.086,
+        6: 16.812, 7: 18.475, 8: 20.090, 9: 21.666, 10: 23.209,
+        19: 36.191, 20: 37.566, 49: 74.919, 50: 76.154, 99: 135.807,
+    }
+    
+    if df in critical_values:
+        critical = critical_values[df]
+    else:
+        # Wilson-Hilferty approximation for larger df
+        critical = df * (1 - 2.0 / (9 * df) + 2.33 * math.sqrt(2.0 / (9 * df))) ** 3
+    
+    return chi_sq, chi_sq < critical
+
+
+# =============================================================================
+# Core RNG Tests
+# =============================================================================
+
+class TestRNG:
+    """Comprehensive RNG tests."""
+    
+    def test_reproducibility(self):
+        """Same seed should produce same sequence."""
+        rng1 = Sha256CounterRNG.from_seed_string("test_seed")
+        rng2 = Sha256CounterRNG.from_seed_string("test_seed")
+        
+        for _ in range(1000):
+            assert rng1.next_u64() == rng2.next_u64()
+        print("PASS: RNG reproducibility (1000 values)")
+    
+    def test_different_seeds(self):
+        """Different seeds should produce different sequences."""
+        seeds = ["seed_a", "seed_b", "seed_c", "123", "test", ""]
+        all_vals = []
+        for seed in seeds:
+            rng = Sha256CounterRNG.from_seed_string(seed)
+            vals = tuple(rng.next_u64() for _ in range(10))
+            all_vals.append(vals)
+        
+        # All should be unique
+        assert len(set(all_vals)) == len(all_vals)
+        print(f"PASS: {len(seeds)} different seeds produce different sequences")
+    
+    def test_uniform_range(self):
+        """Uniform values should be in [0, 1)."""
+        rng = Sha256CounterRNG.from_seed_string("uniform_test")
+        for _ in range(10000):
+            u = rng.next_uniform01()
+            assert 0.0 <= u < 1.0
+        print("PASS: 10000 uniform values all in [0, 1)")
+    
+    def test_uniform_distribution(self):
+        """Uniform values should be evenly distributed."""
+        rng = Sha256CounterRNG.from_seed_string("uniform_dist_test")
+        n_bins = 10
+        n_samples = 100000
+        bins = [0] * n_bins
+        
+        for _ in range(n_samples):
+            u = rng.next_uniform01()
+            bin_idx = min(int(u * n_bins), n_bins - 1)
+            bins[bin_idx] += 1
+        
+        expected = [1.0 / n_bins] * n_bins
+        chi_sq, passed = chi_squared_test(bins, expected)
+        
+        assert passed, f"Uniform distribution failed chi-squared test: {chi_sq}"
+        print(f"PASS: Uniform distribution chi-squared test (χ²={chi_sq:.2f})")
+    
+    def test_uint64_below_unbiased(self):
+        """uint64_below should be unbiased for various n values."""
+        rng = Sha256CounterRNG.from_seed_string("uint64_below_test")
+        
+        for n in [2, 3, 7, 10, 100, 1000]:
+            counts = [0] * n
+            n_samples = n * 1000
+            
+            for _ in range(n_samples):
+                val = uint64_below(rng, n)
+                assert 0 <= val < n
+                counts[val] += 1
+            
+            expected = [1.0 / n] * n
+            chi_sq, passed = chi_squared_test(counts, expected)
+            
+            assert passed, f"uint64_below({n}) failed chi-squared: {chi_sq}"
+        
+        print("PASS: uint64_below unbiased for n in [2, 3, 7, 10, 100, 1000]")
+    
+    def test_iter_u64_reproducibility(self):
+        """iter_u64 helper should be reproducible."""
+        vals1 = iter_u64("test", 100)
+        vals2 = iter_u64("test", 100)
+        assert vals1 == vals2
+        print("PASS: iter_u64 reproducibility")
+    
+    def test_empty_seed(self):
+        """Empty seed should work."""
+        rng1 = Sha256CounterRNG.from_seed_string("")
+        rng2 = Sha256CounterRNG.from_seed_string("")
+        
+        for _ in range(100):
+            assert rng1.next_u64() == rng2.next_u64()
+        print("PASS: Empty seed works")
+    
+    def test_unicode_seed(self):
+        """Unicode seeds should work."""
+        seeds = ["🎲", "日本語", "emoji🔥test", "Ñoño"]
+        for seed in seeds:
+            rng1 = Sha256CounterRNG.from_seed_string(seed)
+            rng2 = Sha256CounterRNG.from_seed_string(seed)
+            for _ in range(10):
+                assert rng1.next_u64() == rng2.next_u64()
+        print("PASS: Unicode seeds work")
+    
+    def test_long_seed(self):
+        """Long seeds should work."""
+        seed = "x" * 10000
+        rng1 = Sha256CounterRNG.from_seed_string(seed)
+        rng2 = Sha256CounterRNG.from_seed_string(seed)
+        for _ in range(100):
+            assert rng1.next_u64() == rng2.next_u64()
+        print("PASS: Long seed (10000 chars) works")
+
+
+# =============================================================================
+# Categorical Sampling Tests
+# =============================================================================
+
+class TestCategoricalSampling:
+    """Comprehensive categorical sampling tests."""
+    
+    def test_reproducibility(self):
+        """Same RNG state should produce same samples."""
+        probs = [0.1, 0.2, 0.3, 0.4]
+        
+        rng1 = Sha256CounterRNG.from_seed_string("cat_test")
+        rng2 = Sha256CounterRNG.from_seed_string("cat_test")
+        
+        for _ in range(1000):
+            s1 = sample_categorical(probs, rng1)
+            s2 = sample_categorical(probs, rng2)
+            assert s1 == s2
+        print("PASS: Categorical sampling reproducibility (1000 samples)")
+    
+    def test_distribution_accuracy(self):
+        """Sampled distribution should match input probs."""
+        probs = [0.1, 0.2, 0.3, 0.4]
+        rng = Sha256CounterRNG.from_seed_string("dist_test")
+        
+        counts = [0] * len(probs)
+        n_samples = 100000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        chi_sq, passed = chi_squared_test(counts, probs)
+        assert passed, f"Distribution chi-squared failed: {chi_sq}"
+        print(f"PASS: Categorical distribution accuracy (χ²={chi_sq:.2f})")
+    
+    def test_degenerate_single_nonzero(self):
+        """Test with single non-zero probability."""
+        for idx in range(5):
+            probs = [0.0] * 5
+            probs[idx] = 1.0
+            rng = Sha256CounterRNG.from_seed_string(f"degen_{idx}")
+            
+            for _ in range(100):
+                result = sample_categorical(probs, rng)
+                assert result == idx
+        print("PASS: Degenerate distribution (single non-zero)")
+    
+    def test_two_element_distribution(self):
+        """Test binary distribution."""
+        probs = [0.3, 0.7]
+        rng = Sha256CounterRNG.from_seed_string("binary_test")
+        
+        counts = [0, 0]
+        n_samples = 50000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        chi_sq, passed = chi_squared_test(counts, probs)
+        assert passed, f"Binary distribution chi-squared failed: {chi_sq}"
+        print(f"PASS: Binary distribution accuracy (χ²={chi_sq:.2f})")
+    
+    def test_many_element_distribution(self):
+        """Test distribution with many elements."""
+        n = 100
+        probs = [1.0 / n] * n  # Uniform
+        rng = Sha256CounterRNG.from_seed_string("many_elem_test")
+        
+        counts = [0] * n
+        n_samples = n * 1000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        chi_sq, passed = chi_squared_test(counts, probs)
+        assert passed, f"Many-element distribution chi-squared failed: {chi_sq}"
+        print(f"PASS: 100-element uniform distribution (χ²={chi_sq:.2f})")
+    
+    def test_very_small_probabilities(self):
+        """Test with very small probabilities."""
+        probs = [0.99, 0.009, 0.0009, 0.0001]
+        rng = Sha256CounterRNG.from_seed_string("small_prob_test")
+        
+        counts = [0] * len(probs)
+        n_samples = 100000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        # Just verify it runs and index 0 dominates
+        assert counts[0] > n_samples * 0.95
+        print(f"PASS: Very small probabilities (counts: {counts})")
+    
+    def test_unnormalized_probs(self):
+        """Test with probabilities that don't sum to exactly 1."""
+        probs = [0.3333, 0.3333, 0.3333]  # Sums to 0.9999
+        rng = Sha256CounterRNG.from_seed_string("unnorm_test")
+        
+        counts = [0, 0, 0]
+        n_samples = 30000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        # Should still be roughly uniform
+        for c in counts:
+            assert abs(c / n_samples - 1/3) < 0.05
+        print("PASS: Unnormalized probabilities handled correctly")
+    
+    def test_integer_weights(self):
+        """Test integer weight sampling."""
+        weights = [1, 2, 3, 4]
+        expected_probs = [w / sum(weights) for w in weights]
+        
+        rng = Sha256CounterRNG.from_seed_string("weight_test")
+        counts = [0] * len(weights)
+        n_samples = 100000
+        
+        for _ in range(n_samples):
+            idx = sample_categorical_weights(weights, rng)
+            counts[idx] += 1
+        
+        chi_sq, passed = chi_squared_test(counts, expected_probs)
+        assert passed, f"Integer weights chi-squared failed: {chi_sq}"
+        print(f"PASS: Integer weight sampling (χ²={chi_sq:.2f})")
+    
+    def test_weighted_prefix_sampler(self):
+        """Test WeightedPrefixSampler consistency and efficiency."""
+        weights = [10, 20, 30, 40, 50]
+        expected_probs = [w / sum(weights) for w in weights]
+        sampler = WeightedPrefixSampler.from_weights(weights)
+        
+        rng1 = Sha256CounterRNG.from_seed_string("prefix_test")
+        rng2 = Sha256CounterRNG.from_seed_string("prefix_test")
+        
+        # Test reproducibility
+        for _ in range(100):
+            s1 = sampler.sample(rng1)
+            s2 = sampler.sample(rng2)
+            assert s1 == s2
+        
+        # Test distribution
+        rng = Sha256CounterRNG.from_seed_string("prefix_dist")
+        counts = [0] * len(weights)
+        n_samples = 100000
+        
+        for _ in range(n_samples):
+            idx = sampler.sample(rng)
+            counts[idx] += 1
+        
+        chi_sq, passed = chi_squared_test(counts, expected_probs)
+        assert passed, f"WeightedPrefixSampler chi-squared failed: {chi_sq}"
+        print(f"PASS: WeightedPrefixSampler (χ²={chi_sq:.2f})")
+
+
+# =============================================================================
+# Sampling Function Tests
+# =============================================================================
+
+class TestSamplingFunctions:
+    """Test high-level sampling functions."""
+    
+    def test_sample_from_probs_reproducibility(self):
+        """Sampling from probs should be reproducible."""
+        probs_2d = [
+            [0.1, 0.2, 0.3, 0.4],
+            [0.25, 0.25, 0.25, 0.25],
+            [0.9, 0.05, 0.03, 0.02],
+        ] * 10  # 30 steps
+        
+        result1 = deterministic_sample_from_probs(probs_2d, "test_seed")
+        result2 = deterministic_sample_from_probs(probs_2d, "test_seed")
+        
+        assert result1 == result2
+        print("PASS: Sample from probs reproducibility (30 steps)")
+    
+    def test_sample_from_logprobs_reproducibility(self):
+        """Sampling from logprobs should be reproducible."""
+        logprobs = [
+            {0: -2.3, 1: -1.6, 2: -1.2, 3: -0.9},
+            {0: -1.4, 1: -1.4, 2: -1.4, 3: -1.4},
+        ] * 20  # 40 steps
+        
+        result1 = deterministic_sample_from_logprobs(logprobs, "logprob_test")
+        result2 = deterministic_sample_from_logprobs(logprobs, "logprob_test")
+        
+        assert result1 == result2
+        print("PASS: Sample from logprobs reproducibility (40 steps)")
+    
+    def test_temperature_effect(self):
+        """Temperature should affect sampling distribution."""
+        logprobs = [{0: -0.1, 1: -2.0, 2: -3.0}] * 1000
+        
+        # Low temperature -> more peaked (token 0 dominates)
+        low_temp_results = deterministic_sample_from_logprobs(
+            logprobs, "temp_low", temperature=0.1
+        )
+        low_temp_token0_count = sum(1 for t in low_temp_results if t == 0)
+        
+        # High temperature -> more uniform
+        high_temp_results = deterministic_sample_from_logprobs(
+            logprobs, "temp_high", temperature=2.0
+        )
+        high_temp_token0_count = sum(1 for t in high_temp_results if t == 0)
+        
+        # Low temp should have more token 0
+        assert low_temp_token0_count > high_temp_token0_count
+        assert low_temp_token0_count > 950  # Should be almost all token 0
+        print(f"PASS: Temperature effect (low={low_temp_token0_count}/1000, high={high_temp_token0_count}/1000)")
+    
+    def test_top_k_filtering(self):
+        """Top-k should limit sampling to top k tokens."""
+        logprobs = [{0: -0.5, 1: -1.0, 2: -1.5, 3: -2.0, 4: -2.5}] * 1000
+        
+        results = deterministic_sample_from_logprobs(
+            logprobs, "topk_test", temperature=1.0, top_k=2
+        )
+        
+        # Should only sample from top 2 tokens (0 and 1)
+        for t in results:
+            assert t in [0, 1], f"Token {t} should not be sampled with top_k=2"
+        print("PASS: Top-k filtering")
+    
+    def test_top_p_filtering(self):
+        """Top-p should limit sampling by cumulative probability."""
+        # Token 0 has ~90% probability after softmax
+        logprobs = [{0: -0.1, 1: -2.5, 2: -3.0, 3: -4.0, 4: -5.0}] * 1000
+        
+        results = deterministic_sample_from_logprobs(
+            logprobs, "topp_test", temperature=1.0, top_p=0.95
+        )
+        
+        # With top_p=0.95, should mostly sample token 0
+        token0_count = sum(1 for t in results if t == 0)
+        assert token0_count > 800
+        print(f"PASS: Top-p filtering (token 0: {token0_count}/1000)")
+    
+    def test_different_seeds_different_results(self):
+        """Different seeds should produce different results."""
+        probs_2d = [[0.25, 0.25, 0.25, 0.25] for _ in range(50)]
+        
+        results = [
+            deterministic_sample_from_probs(probs_2d, f"seed_{i}")
+            for i in range(10)
+        ]
+        
+        # All should be different
+        unique_results = set(tuple(r) for r in results)
+        assert len(unique_results) == 10
+        print("PASS: 10 different seeds produce 10 different results")
+
+
+# =============================================================================
+# Real Data Tests
+# =============================================================================
+
+class TestRealData:
+    """Test with real inference data."""
+    
+    _env = os.environ.get(_REPRO_DATA_ENV)
+    DATA_PATH = Path(_env) if _env else None
+
+    def _load_samples(self, n: int = 100) -> List[Dict]:
+        """Load n samples from the data file."""
+        if self.DATA_PATH is None or not self.DATA_PATH.exists():
+            return []
+        
+        samples = []
+        with open(self.DATA_PATH, "r") as f:
+            for i, line in enumerate(f):
+                if i >= n:
+                    break
+                samples.append(json.loads(line))
+        return samples
+    
+    def test_large_scale_reproducibility(self):
+        """Test reproducibility across many samples."""
+        samples = self._load_samples(100)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        print(f"Testing {len(samples)} samples for reproducibility...")
+        
+        all_pass = True
+        total_tokens = 0
+        
+        for idx, data in enumerate(samples):
+            prompt = data["prompt"]
+            inference_results = data["inference_result"]["results"]
+            
+            # Run 3 times
+            tokens1 = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="scale_test"
+            )
+            tokens2 = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="scale_test"
+            )
+            tokens3 = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="scale_test"
+            )
+            
+            if tokens1 != tokens2 or tokens2 != tokens3:
+                print(f"  FAIL: Sample {idx}")
+                all_pass = False
+            
+            total_tokens += len(tokens1)
+        
+        if all_pass:
+            print(f"PASS: All {len(samples)} samples reproducible ({total_tokens} total tokens)")
+        else:
+            raise AssertionError("Some samples failed reproducibility")
+    
+    def test_cross_run_consistency(self):
+        """Test that results are consistent across many independent runs."""
+        samples = self._load_samples(10)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        data = samples[0]
+        prompt = data["prompt"]
+        inference_results = data["inference_result"]["results"]
+        
+        # Run 20 times independently
+        results = []
+        for i in range(20):
+            tokens = resample_from_inference_logprobs(
+                inference_results, prompt, temperature=0.99, seed_prefix="cross_run"
+            )
+            results.append(tuple(tokens))
+        
+        # All should be identical
+        unique = set(results)
+        assert len(unique) == 1, f"Got {len(unique)} unique results instead of 1"
+        print(f"PASS: 20 independent runs produce identical results ({len(results[0])} tokens)")
+    
+    def test_with_different_temperatures(self):
+        """Test reproducibility at different temperatures."""
+        samples = self._load_samples(5)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        temperatures = [0.5, 0.7, 0.99, 1.0, 1.5, 2.0]
+        
+        for data in samples[:3]:
+            prompt = data["prompt"]
+            inference_results = data["inference_result"]["results"]
+            
+            for temp in temperatures:
+                r1 = resample_from_inference_logprobs(
+                    inference_results, prompt, temperature=temp, seed_prefix="temp_test"
+                )
+                r2 = resample_from_inference_logprobs(
+                    inference_results, prompt, temperature=temp, seed_prefix="temp_test"
+                )
+                assert r1 == r2, f"Failed at temperature {temp}"
+        
+        print(f"PASS: Reproducibility at temperatures {temperatures}")
+    
+    def test_with_top_k(self):
+        """Test reproducibility with top-k filtering."""
+        samples = self._load_samples(5)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        for data in samples[:3]:
+            prompt = data["prompt"]
+            inference_results = data["inference_result"]["results"]
+            
+            for top_k in [1, 2, 3, 5]:
+                r1 = resample_from_inference_logprobs(
+                    inference_results, prompt, temperature=0.99, 
+                    seed_prefix="topk_test", top_k=top_k
+                )
+                r2 = resample_from_inference_logprobs(
+                    inference_results, prompt, temperature=0.99,
+                    seed_prefix="topk_test", top_k=top_k
+                )
+                assert r1 == r2, f"Failed at top_k={top_k}"
+        
+        print("PASS: Reproducibility with top_k in [1, 2, 3, 5]")
+    
+    def test_original_token_in_logprobs(self):
+        """Verify original tokens are in the logprobs."""
+        samples = self._load_samples(50)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        missing_count = 0
+        total_tokens = 0
+        
+        for data in samples:
+            inference_results = data["inference_result"]["results"]
+            
+            for result in inference_results:
+                original_token = result["token"]
+                logprobs_dict = result["logprobs"]
+                token_ids = [int(k) for k in logprobs_dict.keys()]
+                
+                total_tokens += 1
+                if original_token not in token_ids:
+                    missing_count += 1
+        
+        print(f"PASS: {total_tokens - missing_count}/{total_tokens} original tokens in top-5 logprobs")
+    
+    def test_statistics_summary(self):
+        """Generate statistics summary of the test data."""
+        samples = self._load_samples(100)
+        if not samples:
+            print("SKIP: Data file not found")
+            return
+        
+        token_counts = []
+        prompt_lengths = []
+        
+        for data in samples:
+            inference_results = data["inference_result"]["results"]
+            token_counts.append(len(inference_results))
+            prompt_lengths.append(len(data["prompt"]))
+        
+        print(f"\n  Data Statistics:")
+        print(f"  - Samples: {len(samples)}")
+        print(f"  - Total tokens: {sum(token_counts)}")
+        print(f"  - Avg tokens/sample: {sum(token_counts) / len(token_counts):.1f}")
+        print(f"  - Min/Max tokens: {min(token_counts)}/{max(token_counts)}")
+        print(f"  - Avg prompt length: {sum(prompt_lengths) / len(prompt_lengths):.0f} chars")
+
+
+# =============================================================================
+# Edge Case Tests
+# =============================================================================
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+    
+    def test_single_token_vocab(self):
+        """Test with vocabulary of size 1."""
+        probs = [1.0]
+        rng = Sha256CounterRNG.from_seed_string("single_vocab")
+        
+        for _ in range(100):
+            idx = sample_categorical(probs, rng)
+            assert idx == 0
+        print("PASS: Single token vocabulary")
+    
+    def test_all_zero_weights(self):
+        """Test with all zero weights."""
+        weights = [0, 0, 0, 0]
+        rng = Sha256CounterRNG.from_seed_string("all_zero")
+        
+        # Should return last index
+        for _ in range(10):
+            idx = sample_categorical_weights(weights, rng)
+            assert idx == 3
+        print("PASS: All zero weights returns last index")
+    
+    def test_large_vocab(self):
+        """Test with large vocabulary."""
+        n = 100000
+        probs = [1.0 / n] * n
+        rng = Sha256CounterRNG.from_seed_string("large_vocab")
+        
+        start = time.time()
+        for _ in range(100):
+            idx = sample_categorical(probs, rng)
+            assert 0 <= idx < n
+        elapsed = time.time() - start
+        
+        print(f"PASS: Large vocab ({n} tokens), 100 samples in {elapsed:.3f}s")
+    
+    def test_extreme_probabilities(self):
+        """Test with extreme probability values."""
+        # Very peaked distribution
+        probs = [0.9999999] + [0.0000001 / 99] * 99
+        rng = Sha256CounterRNG.from_seed_string("extreme_prob")
+        
+        counts = [0] * 100
+        for _ in range(10000):
+            idx = sample_categorical(probs, rng)
+            counts[idx] += 1
+        
+        assert counts[0] > 9900
+        print(f"PASS: Extreme probabilities (token 0: {counts[0]}/10000)")
+    
+    def test_negative_logprobs(self):
+        """Test with very negative logprobs."""
+        logprobs = [{0: -100.0, 1: -0.01}]  # Token 1 should dominate
+        
+        results = deterministic_sample_from_logprobs(logprobs * 1000, "neg_logprob")
+        token1_count = sum(1 for t in results if t == 1)
+        
+        assert token1_count > 990
+        print(f"PASS: Very negative logprobs handled (token 1: {token1_count}/1000)")
+    
+    def test_special_characters_in_prompt(self):
+        """Test with special characters in prompt seed."""
+        prompts = [
+            "Hello\nWorld",
+            "Tab\there",
+            "Null\x00char",
+            "Unicode: 你好世界🌍",
+            "<script>alert('xss')</script>",
+            "a" * 10000,
+        ]
+        
+        logprobs = [{0: -1.0, 1: -1.0}] * 10
+        
+        for prompt in prompts:
+            r1 = deterministic_sample_from_logprobs(
+                logprobs, f"special|{prompt}", temperature=1.0
+            )
+            r2 = deterministic_sample_from_logprobs(
+                logprobs, f"special|{prompt}", temperature=1.0
+            )
+            assert r1 == r2
+        
+        print(f"PASS: Special characters in prompt ({len(prompts)} cases)")
+
+
+# =============================================================================
+# Performance Tests
+# =============================================================================
+
+class TestPerformance:
+    """Performance benchmarks."""
+    
+    def test_sampling_throughput(self):
+        """Measure sampling throughput."""
+        probs = [0.1, 0.2, 0.3, 0.4]
+        rng = Sha256CounterRNG.from_seed_string("perf_test")
+        
+        n_samples = 100000
+        start = time.time()
+        for _ in range(n_samples):
+            sample_categorical(probs, rng)
+        elapsed = time.time() - start
+        
+        throughput = n_samples / elapsed
+        print(f"PASS: Sampling throughput: {throughput:.0f} samples/sec")
+    
+    def test_rng_throughput(self):
+        """Measure RNG throughput."""
+        rng = Sha256CounterRNG.from_seed_string("rng_perf")
+        
+        n_samples = 1000000
+        start = time.time()
+        for _ in range(n_samples):
+            rng.next_u64()
+        elapsed = time.time() - start
+        
+        throughput = n_samples / elapsed
+        print(f"PASS: RNG throughput: {throughput:.0f} u64/sec")
+
+
+# =============================================================================
+# Cross-Implementation Reference Tests
+# =============================================================================
+
+def test_reference_values():
+    """
+    Test against known reference values for cross-implementation verification.
+    These values can be used to verify other implementations produce the same results.
+    """
+    # Reference test 1: RNG sequence
+    rng = Sha256CounterRNG.from_seed_string("reference_seed_v1")
+    expected_u64s = [
+        rng.next_u64() for _ in range(5)
+    ]
+    
+    # Verify we can reproduce
+    rng2 = Sha256CounterRNG.from_seed_string("reference_seed_v1")
+    actual_u64s = [rng2.next_u64() for _ in range(5)]
+    assert expected_u64s == actual_u64s
+    
+    print(f"\n  Reference u64 values for seed 'reference_seed_v1':")
+    print(f"  {expected_u64s}")
+    
+    # Reference test 2: Categorical sampling
+    probs = [0.1, 0.2, 0.3, 0.4]
+    rng = Sha256CounterRNG.from_seed_string("categorical_ref_v1")
+    expected_samples = [sample_categorical(probs, rng) for _ in range(10)]
+    
+    rng2 = Sha256CounterRNG.from_seed_string("categorical_ref_v1")
+    actual_samples = [sample_categorical(probs, rng2) for _ in range(10)]
+    assert expected_samples == actual_samples
+    
+    print(f"\n  Reference samples for probs [0.1, 0.2, 0.3, 0.4], seed 'categorical_ref_v1':")
+    print(f"  {expected_samples}")
+    
+    # Reference test 3: Full sampling from logprobs
+    logprobs = [
+        {100: -0.5, 200: -1.2, 300: -2.1},
+        {100: -1.0, 200: -1.0, 300: -1.0},
+        {100: -0.1, 200: -3.5, 300: -4.2},
+    ]
+    expected_tokens = deterministic_sample_from_logprobs(logprobs, "logprobs_ref_v1")
+    
+    print(f"\n  Reference tokens for logprobs test, seed 'logprobs_ref_v1':")
+    print(f"  {expected_tokens}")
+    
+    print("\nPASS: Reference values generated and verified")
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+def run_all_tests():
+    """Run all tests."""
+    print("=" * 70)
+    print("Comprehensive Deterministic Sampler Test Suite")
+    print("=" * 70)
+    
+    # RNG Tests
+    print("\n" + "=" * 70)
+    print("RNG Tests")
+    print("=" * 70)
+    test_rng = TestRNG()
+    test_rng.test_reproducibility()
+    test_rng.test_different_seeds()
+    test_rng.test_uniform_range()
+    test_rng.test_uniform_distribution()
+    test_rng.test_uint64_below_unbiased()
+    test_rng.test_iter_u64_reproducibility()
+    test_rng.test_empty_seed()
+    test_rng.test_unicode_seed()
+    test_rng.test_long_seed()
+    
+    # Categorical Sampling Tests
+    print("\n" + "=" * 70)
+    print("Categorical Sampling Tests")
+    print("=" * 70)
+    test_cat = TestCategoricalSampling()
+    test_cat.test_reproducibility()
+    test_cat.test_distribution_accuracy()
+    test_cat.test_degenerate_single_nonzero()
+    test_cat.test_two_element_distribution()
+    test_cat.test_many_element_distribution()
+    test_cat.test_very_small_probabilities()
+    test_cat.test_unnormalized_probs()
+    test_cat.test_integer_weights()
+    test_cat.test_weighted_prefix_sampler()
+    
+    # Sampling Function Tests
+    print("\n" + "=" * 70)
+    print("Sampling Function Tests")
+    print("=" * 70)
+    test_func = TestSamplingFunctions()
+    test_func.test_sample_from_probs_reproducibility()
+    test_func.test_sample_from_logprobs_reproducibility()
+    test_func.test_temperature_effect()
+    test_func.test_top_k_filtering()
+    test_func.test_top_p_filtering()
+    test_func.test_different_seeds_different_results()
+    
+    # Edge Case Tests
+    print("\n" + "=" * 70)
+    print("Edge Case Tests")
+    print("=" * 70)
+    test_edge = TestEdgeCases()
+    test_edge.test_single_token_vocab()
+    test_edge.test_all_zero_weights()
+    test_edge.test_large_vocab()
+    test_edge.test_extreme_probabilities()
+    test_edge.test_negative_logprobs()
+    test_edge.test_special_characters_in_prompt()
+    
+    # Performance Tests
+    print("\n" + "=" * 70)
+    print("Performance Tests")
+    print("=" * 70)
+    test_perf = TestPerformance()
+    test_perf.test_sampling_throughput()
+    test_perf.test_rng_throughput()
+    
+    # Real Data Tests
+    print("\n" + "=" * 70)
+    print("Real Data Tests")
+    print("=" * 70)
+    test_real = TestRealData()
+    test_real.test_large_scale_reproducibility()
+    test_real.test_cross_run_consistency()
+    test_real.test_with_different_temperatures()
+    test_real.test_with_top_k()
+    test_real.test_original_token_in_logprobs()
+    test_real.test_statistics_summary()
+    
+    # Reference Values
+    print("\n" + "=" * 70)
+    print("Reference Values for Cross-Implementation Verification")
+    print("=" * 70)
+    test_reference_values()
+    
+    print("\n" + "=" * 70)
+    print("ALL TESTS PASSED")
+    print("=" * 70)
+
+
+# =============================================================================
+# Decimal pipeline tests. Pure CPU, no torch.
+# Run with: pytest test_deterministic_standalone.py
+# =============================================================================
+
+from vllm.v1.sample.deterministic_utils import (  # noqa: E402
+    decimal_sample_from_logprobs,
+    logprobs_to_weights,
+)
+
+_LP = {
+    "791": "-0.05000000074505806",
+    "1": "-3.0",
+    "2": "-3.5",
+    "10": "-4.0",
+}
+
+
+def test_import_has_no_global_decimal_side_effect():
+    """Importing deterministic_utils must NOT mutate the process default
+    Decimal context. The module uses localcontext() internally."""
+    import decimal
+    import importlib
+
+    before = decimal.getcontext().prec
+    importlib.import_module("vllm.v1.sample.deterministic_utils")
+    assert decimal.getcontext().prec == before
+
+
+def test_iter_u64_reference_value():
+    """§7 reference: a Go port must match this bit-for-bit."""
+    assert iter_u64("reference_seed_v1", 5)[0] == 4286832458236889005
+
+
+def test_logprobs_to_weights_sums_to_scale():
+    """§7: integer weights sum to exactly 2^16 = 65536."""
+    w = logprobs_to_weights(_LP, temperature="1.0")
+    assert sum(w.values()) == 65536
+
+
+def test_decimal_sample_is_reproducible():
+    """§7: same seed -> same token across runs."""
+    r1 = decimal_sample_from_logprobs(
+        _LP, Sha256CounterRNG.from_seed_string("42|[1,2,3]"), "1.0")
+    r2 = decimal_sample_from_logprobs(
+        _LP, Sha256CounterRNG.from_seed_string("42|[1,2,3]"), "1.0")
+    assert r1 == r2
+
+
+def test_v011_symbols_preserved():
+    """§2.1: append must not drop v011-only symbols."""
+    import vllm.v1.sample.deterministic_utils as du
+    for name in ("WeightedPrefixSampler", "sample_categorical",
+                 "sample_sequence", "sample_categorical_weights"):
+        assert hasattr(du, name)
+
+
+if __name__ == "__main__":
+    run_all_tests()

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -3,7 +3,7 @@
 # Datastructures defining a GPU input batch
 
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import numpy as np
 import torch
@@ -25,7 +25,12 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.utils import is_spec_decode_unsupported
 from vllm.v1.utils import copy_slice
 from vllm.v1.worker.block_table import MultiGroupBlockTable
+from vllm.validation import EnforcedTokens
 
+if TYPE_CHECKING:
+    from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
+
+_SAMPLING_EPS = 1e-5
 
 @dataclass
 class CachedRequestState:
@@ -45,6 +50,10 @@ class CachedRequestState:
 
     lora_request: LoRARequest | None = None
     prompt_embeds: torch.Tensor | None = None
+
+    # Deterministic RNG for cross-platform reproducible sampling (validation)
+    # Used when VLLM_DETERMINISTIC_SAMPLING=1
+    deterministic_rng: Optional["Sha256CounterRNG"] = None
 
     def __post_init__(self):
         self.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
@@ -151,6 +160,7 @@ class InputBatch:
         self.temperature_cpu = self.temperature_cpu_tensor.numpy()
         self.greedy_reqs: set[str] = set()
         self.random_reqs: set[str] = set()
+        self.enforced_reqs: set[str] = set()
 
         self.top_p = torch.empty((max_num_reqs,), dtype=torch.float32, device=device)
         self.top_p_cpu_tensor = torch.empty(
@@ -199,6 +209,9 @@ class InputBatch:
         self.repetition_penalties_cpu = self.repetition_penalties_cpu_tensor.numpy()
         self.repetition_penalties_reqs: set[str] = set()
 
+        self.enforced_token_ids: dict[int, list[int]] = {}
+        self.enforced_tokens: dict[int, dict[int, list[int]]] = {} 
+        self.enforced_req_ids: list[int] = []
         # Speculative decoding
         self.num_accepted_tokens_cpu_tensor = torch.ones(
             (max_num_reqs,), dtype=torch.int64, device="cpu", pin_memory=pin_memory
@@ -214,6 +227,9 @@ class InputBatch:
         # NOTE(woosuk): The indices of the requests that do not have their own
         # generator should not be included in the dictionary.
         self.generators: dict[int, torch.Generator] = {}
+
+        # req_index -> deterministic_rng (for VLLM_DETERMINISTIC_SAMPLING)
+        self.deterministic_rngs: dict[int, "Sha256CounterRNG"] = {}
 
         self.num_logprobs: dict[str, int] = {}
         # NOTE(rob): num_prompt_logprobs only includes reqs
@@ -346,6 +362,9 @@ class InputBatch:
                 # Should avoid division by zero later when apply_temperature.
                 self.temperature_cpu[req_index] = 0.0
                 self.greedy_reqs.add(req_id)
+            elif sampling_params.sampling_type == SamplingType.ENFORCED:
+                self.temperature_cpu[req_index] = 0.0
+                self.enforced_reqs.add(req_id)
             else:
                 self.temperature_cpu[req_index] = sampling_params.temperature
                 self.random_reqs.add(req_id)
@@ -375,6 +394,10 @@ class InputBatch:
             # do not have their own generator.
             if request.generator is not None:
                 self.generators[req_index] = request.generator
+
+            # Handle deterministic RNG (for VLLM_DETERMINISTIC_SAMPLING)
+            if request.deterministic_rng is not None:
+                self.deterministic_rngs[req_index] = request.deterministic_rng
 
             if sampling_params.logprobs is not None:
                 self.num_logprobs[req_id] = (
@@ -416,6 +439,16 @@ class InputBatch:
                 self.bad_words_token_ids[req_index] = (
                     sampling_params.bad_words_token_ids
                 )
+            if sampling_params.enforced_token_ids:
+                self.enforced_token_ids[req_index] = (
+                    sampling_params.enforced_token_ids
+                )
+                if req_index not in self.enforced_req_ids:
+                    self.enforced_req_ids.append(req_index)
+            if sampling_params.enforced_tokens:
+                self.enforced_tokens[req_index] = (
+                    sampling_params.enforced_tokens
+                )
         elif pooling_params := request.pooling_params:
             self.pooling_params[req_id] = pooling_params
             self.logits_processing_needs_token_ids[req_index] = (
@@ -451,7 +484,6 @@ class InputBatch:
         Returns:
           Removed request index, or `None` if `req_id` not recognized
         """
-
         req_index = self.req_id_to_index.pop(req_id, None)
         if req_index is None:
             return None
@@ -474,9 +506,9 @@ class InputBatch:
         if self.is_pooling_model:
             self.pooling_params.pop(req_id, None)
             return req_index
-
         self.greedy_reqs.discard(req_id)
         self.random_reqs.discard(req_id)
+        self.enforced_reqs.discard(req_id)
         self.top_p_reqs.discard(req_id)
         self.top_k_reqs.discard(req_id)
         self.spec_decode_unsupported_reqs.discard(req_id)
@@ -484,6 +516,7 @@ class InputBatch:
         self.presence_penalties_reqs.discard(req_id)
         self.repetition_penalties_reqs.discard(req_id)
         self.generators.pop(req_index, None)
+        self.deterministic_rngs.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
         self.num_prompt_logprobs.pop(req_id, None)
         self.in_progress_prompt_logprobs_cpu.pop(req_id, None)
@@ -493,6 +526,11 @@ class InputBatch:
             # False means we don't fill with -inf.
             self.allowed_token_ids_mask_cpu_tensor[req_index].fill_(False)
         self.bad_words_token_ids.pop(req_index, None)
+        self.enforced_token_ids.pop(req_index, None)
+        self.enforced_tokens.pop(req_index, None)
+        if req_index in self.enforced_req_ids:
+            self.enforced_req_ids.remove(req_index)
+
         return req_index
 
     def swap_states(self, i1: int, i2: int) -> None:
@@ -539,6 +577,9 @@ class InputBatch:
         self.token_ids_cpu[i2, ...] = tmp
 
         self.is_token_ids[[i1, i2], ...] = self.is_token_ids[[i2, i1], ...]
+
+        swap_dict_values(self.generators, i1, i2)
+        swap_dict_values(self.deterministic_rngs, i1, i2)
 
         # Swap prompt embeddings if they exist
         embeds_i1 = self.req_prompt_embeds.get(i1)
@@ -592,6 +633,19 @@ class InputBatch:
 
         swap_dict_values(self.generators, i1, i2)
         swap_dict_values(self.bad_words_token_ids, i1, i2)
+        swap_dict_values(self.enforced_token_ids, i1, i2)
+        swap_dict_values(self.enforced_tokens, i1, i2)
+
+
+        has_i1 = i1 in self.enforced_req_ids
+        has_i2 = i2 in self.enforced_req_ids
+        if has_i1 and not has_i2:
+            self.enforced_req_ids.remove(i1)
+            self.enforced_req_ids.append(i2)
+        elif has_i2 and not has_i1:
+            self.enforced_req_ids.remove(i2)
+            self.enforced_req_ids.append(i1)
+
 
         if self.allowed_token_ids_mask_cpu_tensor is not None:
             (
@@ -710,6 +764,12 @@ class InputBatch:
             if generator is not None:
                 self.generators[empty_index] = generator
 
+            # Handle deterministic RNG (for VLLM_DETERMINISTIC_SAMPLING)
+            deterministic_rng = self.deterministic_rngs.pop(last_req_index,
+                                                            None)
+            if deterministic_rng is not None:
+                self.deterministic_rngs[empty_index] = deterministic_rng
+
             # TODO convert these to LogitsProcessors
             if self.allowed_token_ids_mask_cpu_tensor is not None:
                 self.allowed_token_ids_mask_cpu_tensor[empty_index] = (
@@ -720,6 +780,17 @@ class InputBatch:
             if bad_words_token_ids is not None:
                 self.bad_words_token_ids[empty_index] = bad_words_token_ids
 
+            enforced_token_ids = self.enforced_token_ids.pop(last_req_index, None)
+            if enforced_token_ids is not None:
+                self.enforced_token_ids[empty_index] = enforced_token_ids
+
+            enforced_tokens = self.enforced_tokens.pop(last_req_index, None)
+            if enforced_tokens is not None:
+                self.enforced_tokens[empty_index] = enforced_tokens
+
+            if last_req_index in self.enforced_req_ids:
+                self.enforced_req_ids.remove(last_req_index)
+                self.enforced_req_ids.append(empty_index)
             # Decrement last_req_index since it is now empty.
             last_req_index -= 1
 
@@ -793,12 +864,16 @@ class InputBatch:
             not self.no_penalties
             or bool(self.bad_words_token_ids)
             or self.logitsprocs_need_output_token_ids
+            or self.enforced_token_ids
+            or self.enforced_tokens
         )
         output_token_ids = (
             cast(list[list[int]], self.req_output_token_ids)
             if needs_output_token_ids
             else []
         )
+
+
 
         allowed_token_ids_mask: torch.Tensor | None = None
         if not self.no_allowed_token_ids:
@@ -809,14 +884,16 @@ class InputBatch:
                 num_reqs,
             )
             allowed_token_ids_mask = self.allowed_token_ids_mask[:num_reqs]
-
         return SamplingMetadata(
             temperature=temperature,
             all_greedy=self.all_greedy,
             all_random=self.all_random,
+            all_enforced=self.all_enforced,
+            mixed_enforced=self.mixed_enforced,
             top_p=None if self.no_top_p else self.top_p[:num_reqs],
             top_k=None if self.no_top_k else self.top_k[:num_reqs],
             generators=self.generators,
+            deterministic_rngs=self.deterministic_rngs,
             max_num_logprobs=self.max_num_logprobs,
             prompt_token_ids=prompt_token_ids,
             frequency_penalties=self.frequency_penalties[:num_reqs],
@@ -828,6 +905,9 @@ class InputBatch:
             allowed_token_ids_mask=allowed_token_ids_mask,
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
+            enforced_token_ids=self.enforced_token_ids,
+            enforced_tokens=self.enforced_tokens,
+            enforced_req_ids=self.enforced_req_ids
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:
@@ -937,11 +1017,19 @@ class InputBatch:
 
     @property
     def all_greedy(self) -> bool:
-        return len(self.random_reqs) == 0
+        return len(self.random_reqs) == 0 and len(self.enforced_reqs) == 0
 
     @property
     def all_random(self) -> bool:
-        return len(self.greedy_reqs) == 0
+        return len(self.greedy_reqs) == 0 and len(self.enforced_reqs) == 0
+
+    @property
+    def all_enforced(self) -> bool:
+        return len(self.enforced_reqs) > 0 and len(self.greedy_reqs) == 0 and len(self.random_reqs) == 0
+
+    @property
+    def mixed_enforced(self) -> bool:
+        return len(self.enforced_reqs) != 0 and (len(self.random_reqs) != 0 or len(self.greedy_reqs) != 0)
 
     @property
     def no_top_p(self) -> bool:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -126,6 +126,7 @@ from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.sample.deterministic_utils import Sha256CounterRNG
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.medusa import MedusaProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -695,7 +696,22 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampling_params = new_req_data.sampling_params
             pooling_params = new_req_data.pooling_params
 
-            if (
+            # Create deterministic RNG when VLLM_DETERMINISTIC_SAMPLING=1
+            # This enables cross-platform reproducible sampling for validation
+            deterministic_rng = None
+            if sampling_params and envs.VLLM_DETERMINISTIC_SAMPLING:
+                # Derive seed from user seed (if any) and prompt tokens
+                # Use comma-separated token IDs as prompt representation
+                prompt_repr = ",".join(
+                    str(t) for t in new_req_data.prompt_token_ids)
+                if sampling_params.seed is not None:
+                    seed_str = f"{sampling_params.seed}|{prompt_repr}"
+                else:
+                    seed_str = prompt_repr
+                deterministic_rng = Sha256CounterRNG.from_seed_string(seed_str)
+                # When using deterministic RNG, don't also use torch.Generator
+                generator = None
+            elif (
                 sampling_params
                 and sampling_params.sampling_type == SamplingType.RANDOM_SEED
             ):
@@ -725,6 +741,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_computed_tokens=new_req_data.num_computed_tokens,
                 output_token_ids=[],
                 lora_request=new_req_data.lora_request,
+                deterministic_rng=deterministic_rng,
             )
             self.requests[req_id] = req_state
 
@@ -3701,6 +3718,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             temperature=dummy_tensors(0.5),
             all_greedy=False,
             all_random=False,
+            all_enforced=False,
             top_p=dummy_tensors(0.9),
             top_k=dummy_tensors(logits.size(1) - 1),
             generators={},
@@ -3715,6 +3733,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             allowed_token_ids_mask=None,
             bad_words_token_ids={},
             logitsprocs=LogitsProcessors(),
+            enforced_token_ids=None,
+            enforced_tokens=None,
+            enforced_req_ids=None,
+            mixed_enforced=None
         )
         try:
             sampler_output = self.sampler(

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,0 +1,129 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+
+
+class EnforcedToken(BaseModel):
+    """
+    Represents a single token position in the enforced tokens sequence.
+
+    Used by validators to verify that:
+    1. The token was sampled correctly from the probability distribution
+    2. The probability distribution matches the claimed model
+
+    Attributes:
+        token: The token ID (as string) that was sampled at this position
+        top_tokens: List of top-k token IDs (as strings) for this position
+        logprobs: Raw logprobs for the top tokens (for distance calculation)
+        sampling_weights: Integer weights (2^16 scale) used for deterministic
+                         sampling verification
+        token_id: Parsed integer token ID (excluded from serialization)
+        top_token_ids: Parsed integer top token IDs (excluded from serialization)
+    """
+    token: str
+    top_tokens: List[str] = Field(default_factory=list)
+
+    # NEW: Raw logprobs for distance calculation (Stage 2 validation)
+    # Maps token ID (as string) to logprob value
+    logprobs: Optional[Dict[str, float]] = None
+
+    # NEW: Integer weights for deterministic sampling verification (Stage 1)
+    # Maps token ID (as string) to integer weight (2^16 scale)
+    # These are the quantized probabilities used for sampling
+    sampling_weights: Optional[Dict[str, int]] = None
+
+    # Internal parsed fields (excluded from serialization)
+    token_id: Optional[int] = Field(default=None, exclude=True)
+    top_token_ids: List[int] = Field(default_factory=list, exclude=True)
+
+    def encode(self, tokenizer: AnyTokenizer) -> None:
+        """Parse token strings to integer IDs."""
+        try:
+            self.token_id = int(self.token)
+            self.top_token_ids = [int(t) for t in self.top_tokens]
+        except Exception as e:
+            raise e
+
+
+class EnforcedTokens(BaseModel):
+    """
+    Container for a sequence of enforced tokens with optional validation data.
+
+    This is sent by validators to verify inference results. The tokens are
+    "enforced" meaning the model is forced to produce these exact tokens,
+    allowing comparison of the logprob distributions.
+    """
+    tokens: List[EnforcedToken]
+
+    def encode(self, tokenizer: AnyTokenizer) -> None:
+        """Parse all token strings to integer IDs."""
+        for token in self.tokens:
+            token.encode(tokenizer)
+
+    @classmethod
+    def from_content(
+        cls,
+        content: List[Dict[str, Any]],
+        include_logprobs: bool = False,
+        include_sampling_weights: bool = False,
+    ) -> "EnforcedTokens":
+        """
+        Create EnforcedTokens from OpenAI-format logprobs content.
+
+        Args:
+            content: List of logprobs content dicts from ChatCompletionResponse
+            include_logprobs: If True, include raw logprobs in the artifact
+            include_sampling_weights: If True, include sampling_weights in artifact
+
+        Returns:
+            EnforcedTokens instance
+        """
+        tokens = []
+        for position in content:
+            token = position["token"]
+            top_tokens = [x["token"] for x in position["top_logprobs"]]
+
+            # Optionally include logprobs for distance calculation
+            logprobs = None
+            if include_logprobs and "top_logprobs" in position:
+                logprobs = {
+                    x["token"]: x["logprob"]
+                    for x in position["top_logprobs"]
+                }
+
+            # Optionally include sampling weights for sampling verification
+            sampling_weights = None
+            if include_sampling_weights and "sampling_weights" in position:
+                sampling_weights = position["sampling_weights"]
+
+            tokens.append(
+                EnforcedToken(
+                    token=token,
+                    top_tokens=top_tokens,
+                    logprobs=logprobs,
+                    sampling_weights=sampling_weights,
+                ))
+        return cls(tokens=tokens)
+
+    def get_enforced_token_ids(self) -> List[int]:
+        """Get the list of enforced token IDs (requires encode() to be called first)."""
+        if not self.tokens or not self.tokens[0].token_id:
+            raise ValueError("Enforced tokens are not encoded")
+        return [token.token_id for token in self.tokens]
+
+    def get_top_tokens(self) -> List[Dict[int, List[int]]]:
+        return [
+            {
+                token.token_id: token.top_token_ids
+            }
+            for token in self.tokens
+        ]
+
+    def has_validation_data(self) -> bool:
+        """Check if this artifact has data for validation (logprobs or weights)."""
+        if not self.tokens:
+            return False
+        first = self.tokens[0]
+        return first.logprobs is not None or first.sampling_weights is not None

--- a/vllm/validation_logic.py
+++ b/vllm/validation_logic.py
@@ -14,17 +14,17 @@ The validation has two stages:
 2. Post-model validation (Stage 2):
    - Distance calculation: Compare executor vs validator logprob distributions
 
-STATUS: LEGACY / TRANSITIONAL PATH.
-``validate_full`` / ``validate_before_model`` here are the only end-to-end
-entry points today, but this path (a) recomputes weights from logprobs with
-plain float ``math.exp`` (no top_p/top_k/min_p filtering and no exact-2^16
-residual fix), and (b) is TWO-VALUED (boolean fraud), so it cannot emit the
-three-valued Honest/Fraud/Inconclusive verdict. The contract-faithful path is
-``vllm/validation_sampling.py`` (kept-set filtering + decimal pipeline +
-three-valued verdict); it currently has no sequence-level caller. Converging
-the two — retiring this legacy path in favour of validation_sampling — is a
-follow-up in gonka-ai/gonka#1199. Do NOT treat this module as the reference
-validator.
+STATUS: RETIRED FROM THE SERVING PATH (kept only for its unit tests).
+This path (a) recomputes weights from logprobs with plain float ``math.exp``
+(no top_p/top_k/min_p filtering and no exact-2^16 residual fix), and (b) is
+TWO-VALUED (boolean fraud), so it cannot emit the three-valued
+Honest/Fraud/Inconclusive verdict. The serving-layer orchestrator
+(``serving_chat._perform_validation``) now calls the contract-faithful path in
+``vllm/validation_sampling.py`` (``verify_sequence`` + ``mae_distance``:
+kept-set filtering, decimal pipeline, three-valued verdict, per-position seed,
+MAE-over-support distance). Convergence tracked in gonka-ai/gonka#1199. Do NOT
+re-wire this module into serving; it remains only so its existing tests keep
+documenting the old behaviour until they are ported/removed.
 """
 
 from __future__ import annotations

--- a/vllm/validation_logic.py
+++ b/vllm/validation_logic.py
@@ -1,0 +1,440 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Validation logic for decentralized inference networks.
+
+This module implements the validation protocol ported from the Go implementation
+in gonka/decentralized-api/internal/validation/inference_validation.go.
+
+The validation has two stages:
+1. Pre-model validation (Stage 1):
+   a. Weight consistency: Verify sampling_weights match logprobs
+   b. Sampling verification: Verify tokens were sampled correctly from weights
+
+2. Post-model validation (Stage 2):
+   - Distance calculation: Compare executor vs validator logprob distributions
+
+STATUS: LEGACY / TRANSITIONAL PATH.
+``validate_full`` / ``validate_before_model`` here are the only end-to-end
+entry points today, but this path (a) recomputes weights from logprobs with
+plain float ``math.exp`` (no top_p/top_k/min_p filtering and no exact-2^16
+residual fix), and (b) is TWO-VALUED (boolean fraud), so it cannot emit the
+three-valued Honest/Fraud/Inconclusive verdict. The contract-faithful path is
+``vllm/validation_sampling.py`` (kept-set filtering + decimal pipeline +
+three-valued verdict); it currently has no sequence-level caller. Converging
+the two — retiring this legacy path in favour of validation_sampling — is a
+follow-up in gonka-ai/gonka#1199. Do NOT treat this module as the reference
+validator.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.validation import EnforcedToken, EnforcedTokens
+    from vllm.entrypoints.openai.protocol import ValidationResult
+
+# Constants matching Go implementation
+DEFAULT_FRAUD_DISTANCE_THRESHOLD = 0.01
+WEIGHT_SCALE = 65536  # 2^16 for integer weight quantization
+EPSILON = 1e-10  # Small value to avoid division by zero
+
+
+# =============================================================================
+# Distance Calculation (Stage 2)
+# =============================================================================
+
+def position_distance(
+    inf_lp: Dict[str, float],
+    val_lp: Dict[str, float],
+) -> float:
+    """
+    Calculate distance for a single position.
+    
+    Uses formula: |a - b| / (eps + |a| + |b|) / 2
+    Summed across all tokens in the position.
+    
+    Args:
+        inf_lp: Executor's logprobs for this position {token_id: logprob}
+        val_lp: Validator's logprobs for this position {token_id: logprob}
+    
+    Returns:
+        Distance metric for this position
+    """
+    if not inf_lp or not val_lp:
+        return 0.0
+    
+    total_dist = 0.0
+    
+    # Process all tokens from executor's logprobs
+    for token_id, inf_logprob in inf_lp.items():
+        if token_id in val_lp:
+            val_logprob = val_lp[token_id]
+        else:
+            # Estimate missing token as minimum of validator's values minus offset
+            if val_lp:
+                val_logprob = min(val_lp.values()) - 5.0
+            else:
+                val_logprob = inf_logprob
+        
+        # Distance formula: |a - b| / (eps + |a| + |b|) / 2
+        diff = abs(inf_logprob - val_logprob)
+        denom = EPSILON + abs(inf_logprob) + abs(val_logprob)
+        total_dist += diff / denom / 2.0
+    
+    return total_dist
+
+
+def compute_distance(
+    inf_logprobs: List[Dict[str, float]],
+    val_logprobs: List[Dict[str, float]],
+) -> float:
+    """
+    Calculate normalized distance between two logprob sequences.
+    
+    Args:
+        inf_logprobs: Executor's logprobs per position
+        val_logprobs: Validator's logprobs per position
+    
+    Returns:
+        Normalized distance (0.0 = identical, higher = more different)
+        Returns 10.0 (max fraud) if sequence lengths don't match
+    """
+    if len(inf_logprobs) != len(val_logprobs):
+        return 10.0  # Max fraud distance for length mismatch
+    
+    if not inf_logprobs:
+        return 0.0
+    
+    # Sum distances across all positions
+    total_dist = 0.0
+    total_tokens = 0
+    
+    for inf_lp, val_lp in zip(inf_logprobs, val_logprobs):
+        total_dist += position_distance(inf_lp, val_lp)
+        total_tokens += len(inf_lp)
+    
+    # Normalization matching Go implementation:
+    # (total_dist + 1.0) / (max(100, n_positions) * avg_tokens_per_pos + 1.0)
+    n_positions = len(inf_logprobs)
+    avg_tokens = total_tokens / n_positions if n_positions > 0 else 1
+    
+    normalized = (total_dist + 1.0) / (max(100, n_positions) * avg_tokens + 1.0)
+    
+    return normalized
+
+
+# =============================================================================
+# Weight Quantization and Recomputation
+# =============================================================================
+
+def quantize_to_weights(probs: Dict[str, float]) -> Dict[str, int]:
+    """
+    Quantize probabilities to integer weights at WEIGHT_SCALE.
+    
+    Args:
+        probs: Probability distribution {token_id: probability}
+    
+    Returns:
+        Integer weights {token_id: weight}
+    """
+    if not probs:
+        return {}
+    
+    return {
+        token_id: round(prob * WEIGHT_SCALE)
+        for token_id, prob in probs.items()
+    }
+
+
+def recompute_weights_from_logprobs(
+    logprobs: Dict[str, float],
+    temperature: float,
+) -> Dict[str, int]:
+    """
+    Recompute integer weights from logprobs using softmax with temperature.
+    
+    Args:
+        logprobs: Raw logprobs {token_id: logprob}
+        temperature: Temperature for softmax
+    
+    Returns:
+        Integer weights {token_id: weight}
+    """
+    if not logprobs:
+        return {}
+    
+    if len(logprobs) == 1:
+        # Single token gets all weight
+        token_id = list(logprobs.keys())[0]
+        return {token_id: WEIGHT_SCALE}
+    
+    # Apply temperature and compute softmax
+    # logprob = log(prob), so prob = exp(logprob)
+    # With temperature: prob = exp(logprob / temperature)
+    
+    # For numerical stability, subtract max
+    values = list(logprobs.values())
+    max_lp = max(values)
+    
+    exp_values = {}
+    for token_id, lp in logprobs.items():
+        # Scale by temperature
+        scaled = (lp - max_lp) / temperature
+        exp_values[token_id] = math.exp(scaled)
+    
+    total = sum(exp_values.values())
+    
+    if total <= 0:
+        # Fallback: uniform weights
+        n = len(logprobs)
+        return {token_id: WEIGHT_SCALE // n for token_id in logprobs}
+    
+    # Normalize to probabilities and quantize to weights
+    weights = {}
+    for token_id, exp_val in exp_values.items():
+        prob = exp_val / total
+        weights[token_id] = round(prob * WEIGHT_SCALE)
+    
+    return weights
+
+
+# =============================================================================
+# Sampling Verification (Stage 1b)
+# =============================================================================
+
+def verify_sampling_sequence(
+    tokens: List["EnforcedToken"],
+    seed_str: str,
+) -> Tuple[bool, int]:
+    """
+    Verify that tokens were sampled correctly from their weights.
+    
+    Uses the deterministic Sha256CounterRNG to replay sampling and verify
+    each token matches what would have been sampled.
+    
+    Args:
+        tokens: List of EnforcedToken with sampling_weights
+        seed_str: Seed string for the RNG
+    
+    Returns:
+        Tuple of (success, failed_position)
+        If success is True, failed_position is -1
+        If success is False, failed_position is the first failing position
+    """
+    from vllm.v1.sample.deterministic_utils import (
+        Sha256CounterRNG,
+        sample_categorical_weights,
+    )
+    
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    
+    for pos, token in enumerate(tokens):
+        # Skip tokens without sampling weights
+        if token.sampling_weights is None:
+            continue
+        
+        # Sort by token-ID string, not numeric: contract §3 order. A numeric key
+        # would disagree ("10" < "2" as strings) and false-reject. (§8 U12)
+        sorted_items = sorted(token.sampling_weights.items(), key=lambda x: x[0])
+        weight_list = [w for _, w in sorted_items]
+        token_list = [t for t, _ in sorted_items]
+        
+        # Sample using RNG
+        idx = sample_categorical_weights(weight_list, rng)
+        expected_token = token_list[idx]
+        
+        # Compare
+        if token.token != expected_token:
+            return False, pos
+    
+    return True, -1
+
+
+# =============================================================================
+# Weight Consistency Verification (Stage 1a)
+# =============================================================================
+
+def verify_weights_consistency(
+    tokens: List["EnforcedToken"],
+    temperature: float,
+    tolerance: float = 0.05,
+) -> Tuple[bool, int]:
+    """
+    Verify that sampling_weights are consistent with logprobs.
+    
+    Recomputes weights from logprobs and compares against claimed weights.
+    
+    Args:
+        tokens: List of EnforcedToken with logprobs and sampling_weights
+        temperature: Temperature used for weight computation
+        tolerance: Relative tolerance for weight comparison (default 5%)
+    
+    Returns:
+        Tuple of (success, failed_position)
+        If success is True, failed_position is -1
+        If success is False, failed_position is the first failing position
+    """
+    for pos, token in enumerate(tokens):
+        # Skip if missing either logprobs or weights
+        if token.logprobs is None or token.sampling_weights is None:
+            continue
+        
+        # Recompute weights from logprobs
+        expected_weights = recompute_weights_from_logprobs(
+            token.logprobs, temperature
+        )
+        
+        # Compare weights
+        for token_id, claimed_weight in token.sampling_weights.items():
+            if token_id not in expected_weights:
+                return False, pos
+            
+            expected = expected_weights[token_id]
+            
+            # Allow tolerance for rounding differences
+            if expected == 0 and claimed_weight == 0:
+                continue
+            
+            if expected == 0:
+                # Expected zero but got non-zero
+                if claimed_weight > 10:  # Small tolerance
+                    return False, pos
+                continue
+            
+            relative_diff = abs(claimed_weight - expected) / max(expected, 1)
+            if relative_diff > tolerance:
+                return False, pos
+    
+    return True, -1
+
+
+# =============================================================================
+# High-Level Validation Functions
+# =============================================================================
+
+def validate_before_model(
+    artifact: "EnforcedTokens",
+    seed_str: str,
+    temperature: float,
+) -> "ValidationResult":
+    """
+    Stage 1 validation (before running model).
+    
+    Verifies:
+    1a. Weight consistency: sampling_weights match logprobs
+    1b. Sampling verification: tokens were sampled correctly from weights
+    
+    Args:
+        artifact: EnforcedTokens containing tokens with weights and logprobs
+        seed_str: Seed string for deterministic sampling
+        temperature: Temperature used for weight computation
+    
+    Returns:
+        ValidationResult with fraud indicators set
+    """
+    from vllm.entrypoints.openai.protocol import ValidationResult
+    
+    result = ValidationResult()
+    
+    # Stage 1a: Verify weight consistency
+    weights_ok, failed_pos = verify_weights_consistency(
+        artifact.tokens, temperature
+    )
+    
+    if not weights_ok:
+        result.fraud = True
+        result.correct_processed_logprobs = False
+        result.distance = 10.0
+        return result
+    
+    # Stage 1b: Verify sampling
+    sampling_ok, failed_pos = verify_sampling_sequence(
+        artifact.tokens, seed_str
+    )
+    
+    if not sampling_ok:
+        result.fraud = True
+        result.correct_sampling = False
+        result.distance = 10.0
+        return result
+    
+    return result
+
+
+def validate_after_model(
+    executor_logprobs: List[Dict[str, float]],
+    validator_logprobs: List[Dict[str, float]],
+) -> "ValidationResult":
+    """
+    Stage 2 validation (after running model).
+    
+    Compares logprob distributions between executor and validator.
+    
+    Args:
+        executor_logprobs: Logprobs from the executor's artifact
+        validator_logprobs: Logprobs from validator's model run
+    
+    Returns:
+        ValidationResult with distance and fraud indicators
+    """
+    from vllm.entrypoints.openai.protocol import ValidationResult
+    
+    result = ValidationResult()
+    
+    distance = compute_distance(executor_logprobs, validator_logprobs)
+    result.distance = distance
+    
+    if distance > DEFAULT_FRAUD_DISTANCE_THRESHOLD:
+        result.fraud = True
+        result.correct_raw_logprobs = False
+    
+    return result
+
+
+def validate_full(
+    artifact: "EnforcedTokens",
+    validator_logprobs: List[Dict[str, float]],
+    seed_str: str,
+    temperature: float,
+) -> "ValidationResult":
+    """
+    Full two-stage validation.
+    
+    Runs both Stage 1 (pre-model) and Stage 2 (post-model) validation.
+    
+    Args:
+        artifact: EnforcedTokens from executor
+        validator_logprobs: Logprobs from validator's model run
+        seed_str: Seed string for deterministic sampling
+        temperature: Temperature used for weight computation
+    
+    Returns:
+        ValidationResult with all fraud indicators
+    """
+    from vllm.entrypoints.openai.protocol import ValidationResult
+    
+    # Stage 1: Pre-model validation
+    result = validate_before_model(artifact, seed_str, temperature)
+    
+    if result.fraud:
+        return result
+    
+    # Stage 2: Post-model validation
+    executor_logprobs = [
+        t.logprobs for t in artifact.tokens
+        if t.logprobs is not None
+    ]
+    
+    stage2_result = validate_after_model(executor_logprobs, validator_logprobs)
+    
+    # Merge results
+    result.distance = stage2_result.distance
+    result.correct_raw_logprobs = stage2_result.correct_raw_logprobs
+    
+    if stage2_result.fraud:
+        result.fraud = True
+    
+    return result

--- a/vllm/validation_sampling.py
+++ b/vllm/validation_sampling.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Check 2 -- Sampling Replay (pure CPU, no torch).
+
+The validator replays the executor's per-position sampling from the reported
+logprobs and compares against the reported token. Zero tolerance: any mismatch
+is fraud. Background and contract: gonka-ai/gonka#1199.
+
+Scope:
+- This module implements Check 2 only. Full honesty also requires Check 1
+  (logprob distance), which re-runs the model on GPU and is out of scope here.
+- ``verify_sampling_from_logprobs`` verifies a *single* position and returns a
+  bool. The sequence-level loop belongs to the serving-layer orchestrator, not
+  here.
+- The seed is passed in already-composed as ``seed_str``; this module does not
+  derive it. Seed hardening is a separate concern.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+from vllm.v1.sample.deterministic_utils import (
+    Sha256CounterRNG,
+    logprobs_to_weights,
+    sample_categorical_weights,
+)
+
+# The contract version this validator can faithfully replay. An artifact
+# declaring anything else is Inconclusive (version-unsupported), not Fraud.
+# Mirrors detsample.SupportedContractVersion (contract §0).
+SUPPORTED_CONTRACT_VERSION = "1.0.0"
+
+
+def verify_sampling_from_logprobs(
+    logprobs: Dict[str, float],
+    seed_str: str,
+    temperature: str,
+    top_p: Optional[str],
+    top_k: Optional[int],
+    min_p: Optional[str],
+    reported_token: str,
+) -> bool:
+    """Replay Check 2 for a single token position.
+
+    Args:
+        logprobs: {token_id_str: float} -- the executor's post-penalty logprobs
+            for this position (matches ``EnforcedToken.logprobs``). Converted to
+            canonical decimal strings via ``repr(f)`` before entering the
+            pipeline (the single float->string conversion point).
+            ``Decimal(repr(f))`` is the documented canonicalization.
+        seed_str: The already-composed RNG seed string (this function does not
+            derive it).
+        temperature: Temperature as string (e.g. "0.7"). Must be > 0.
+        top_p: Optional nucleus sampling threshold as string.
+        top_k: Optional top-k filter count.
+        min_p: Optional min-p threshold as string.
+        reported_token: The token ID string the executor claims it sampled.
+
+    Returns:
+        True if the replayed token matches ``reported_token`` (honest), else
+        False (fraud). Zero tolerance.
+
+    Note:
+        A True result means the sampling step is consistent with *these*
+        logprobs -- it does not prove the logprobs themselves are what the model
+        produced (that is Check 1, §8 U8), nor that the executor's production
+        weight path is reproducible (§8 U11/U12).
+    """
+    # Single float->string conversion point (§4). repr() is CPython's
+    # shortest round-tripping representation.
+    logprob_strings = {tid: repr(f) for tid, f in logprobs.items()}
+
+    weights = logprobs_to_weights(
+        logprob_strings, temperature,
+        top_p=top_p, top_k=top_k, min_p=min_p,
+    )
+
+    # Weight list built in lexicographic token-ID-string order; the returned
+    # index maps back through the same order (§8 U12).
+    sorted_tids = sorted(weights.keys())
+    weight_list = [weights[tid] for tid in sorted_tids]
+
+    rng = Sha256CounterRNG.from_seed_string(seed_str)
+    idx = sample_categorical_weights(weight_list, rng)
+    replayed_token = sorted_tids[idx]
+
+    return replayed_token == reported_token
+
+
+class Verdict(str, Enum):
+    """Classified outcome of a single-position replay.
+
+    Mirrors detsample.Verdict (verify.go). A replay mismatch is only FRAUD when
+    the validator could faithfully reproduce the executor's computation; an
+    unsupported version, a greedy position, or a validator-side replay error is
+    INCONCLUSIVE, never FRAUD.
+    """
+
+    HONEST = "honest"
+    FRAUD = "fraud"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass
+class PositionResult:
+    """A verdict plus a human-readable reason (empty for HONEST)."""
+
+    verdict: Verdict
+    reason: str = ""
+
+
+def _inconclusive(reason: str) -> PositionResult:
+    return PositionResult(verdict=Verdict.INCONCLUSIVE, reason=reason)
+
+
+def verify_position(
+    logprobs: Dict[str, float],
+    seed_str: str,
+    temperature: str,
+    top_p: Optional[str],
+    top_k: Optional[int],
+    min_p: Optional[str],
+    reported_token: str,
+    *,
+    contract_version: str = SUPPORTED_CONTRACT_VERSION,
+    greedy: bool = False,
+) -> PositionResult:
+    """Replay one artifact position and classify it (Honest/Fraud/Inconclusive).
+
+    Version gating and the greedy/temperature exemptions run *before* any fraud
+    verdict, clause-for-clause with detsample.VerifyPosition (verify.go):
+
+    1. contract-version mismatch -> Inconclusive (version-unsupported, §0)
+    2. greedy (temperature 0)    -> Inconclusive (§7: argmax bypasses the RNG,
+       so the sequence check carries no signal)
+    3. non-positive/unparseable temperature with greedy unset -> Inconclusive
+       (an inconsistent artifact, not fraud)
+    4. replay error              -> Inconclusive (validator-side inability)
+    5. replay ok, token differs  -> Fraud (zero tolerance)
+    6. token matches             -> Honest
+
+    Scope: single position. Sequence/response-level aggregation is out of scope
+    (not defined on the Go side yet).
+    """
+    if contract_version != SUPPORTED_CONTRACT_VERSION:
+        return _inconclusive(
+            f"unsupported contract version {contract_version!r} "
+            f"(validator supports {SUPPORTED_CONTRACT_VERSION!r})")
+
+    if greedy:
+        return _inconclusive(
+            "greedy position (temperature 0): sequence check not applicable")
+
+    try:
+        temp_val = float(temperature)
+    except (TypeError, ValueError):
+        return _inconclusive(
+            f"unparseable temperature {temperature!r} with greedy flag unset")
+    if temp_val <= 0:
+        return _inconclusive(
+            f"non-positive temperature {temperature!r} with greedy flag unset")
+
+    try:
+        honest = verify_sampling_from_logprobs(
+            logprobs, seed_str, temperature,
+            top_p=top_p, top_k=top_k, min_p=min_p,
+            reported_token=reported_token,
+        )
+    except Exception as e:  # noqa: BLE001 — any replay error is validator-side
+        return _inconclusive(f"replay error: {e}")
+
+    if not honest:
+        return PositionResult(
+            verdict=Verdict.FRAUD,
+            reason=f"replayed token differs from reported {reported_token!r}")
+    return PositionResult(verdict=Verdict.HONEST)
+
+
+def result_for_validator_error(error: BaseException) -> None:
+    """A validator-side error yields no verdict (None), never a silent
+    honest/fraud judgement about the executor. Mirrors detsample.VerifyPosition
+    treating a validator-side problem as inconclusive. Always None; `error` is
+    for the caller to log."""
+    return None

--- a/vllm/validation_sampling.py
+++ b/vllm/validation_sampling.py
@@ -332,9 +332,11 @@ def mae_distance(
     for exec_lp, val_lp in zip(executor_logprobs, validator_logprobs):
         if not exec_lp:
             continue
+        # Sum over sorted token IDs so the float accumulation order is identical
+        # to the Go validator's (byte-exact cross-language distance).
         diffs = [
-            abs(e - val_lp[tid]) if tid in val_lp else penalty
-            for tid, e in exec_lp.items()
+            abs(exec_lp[tid] - val_lp[tid]) if tid in val_lp else penalty
+            for tid in sorted(exec_lp)
         ]
         if diffs:
             per_position.append(sum(diffs) / len(diffs))

--- a/vllm/validation_sampling.py
+++ b/vllm/validation_sampling.py
@@ -32,6 +32,12 @@ from vllm.v1.sample.deterministic_utils import (
 # Mirrors detsample.SupportedContractVersion (contract §0).
 SUPPORTED_CONTRACT_VERSION = "1.0.0"
 
+# The seed-derivation domain this validator can replay. An artifact declaring a
+# different domain is Inconclusive (version-unsupported), not Fraud. Must match
+# deterministic_utils._SEED_DOMAIN_TAG and detsample.SupportedSeedDomain (Go);
+# the conformance vectors' seed_derivation.domain_tag pins it, so drift is caught.
+SUPPORTED_SEED_DOMAIN = "gonka-deterministic-sampling-v1"
+
 
 def verify_sampling_from_logprobs(
     logprobs: Dict[str, float],
@@ -125,6 +131,7 @@ def verify_position(
     reported_token: str,
     *,
     contract_version: str = SUPPORTED_CONTRACT_VERSION,
+    seed_domain: str = SUPPORTED_SEED_DOMAIN,
     greedy: bool = False,
 ) -> PositionResult:
     """Replay one artifact position and classify it (Honest/Fraud/Inconclusive).
@@ -133,13 +140,14 @@ def verify_position(
     verdict, clause-for-clause with detsample.VerifyPosition (verify.go):
 
     1. contract-version mismatch -> Inconclusive (version-unsupported, §0)
-    2. greedy (temperature 0)    -> Inconclusive (§7: argmax bypasses the RNG,
+    2. seed-domain mismatch      -> Inconclusive (version-unsupported, §8)
+    3. greedy (temperature 0)    -> Inconclusive (§7: argmax bypasses the RNG,
        so the sequence check carries no signal)
-    3. non-positive/unparseable temperature with greedy unset -> Inconclusive
+    4. non-positive/unparseable temperature with greedy unset -> Inconclusive
        (an inconsistent artifact, not fraud)
-    4. replay error              -> Inconclusive (validator-side inability)
-    5. replay ok, token differs  -> Fraud (zero tolerance)
-    6. token matches             -> Honest
+    5. replay error              -> Inconclusive (validator-side inability)
+    6. replay ok, token differs  -> Fraud (zero tolerance)
+    7. token matches             -> Honest
 
     Scope: single position. Sequence/response-level aggregation is out of scope
     (not defined on the Go side yet).
@@ -148,6 +156,11 @@ def verify_position(
         return _inconclusive(
             f"unsupported contract version {contract_version!r} "
             f"(validator supports {SUPPORTED_CONTRACT_VERSION!r})")
+
+    if seed_domain != SUPPORTED_SEED_DOMAIN:
+        return _inconclusive(
+            f"unsupported seed domain {seed_domain!r} "
+            f"(validator supports {SUPPORTED_SEED_DOMAIN!r})")
 
     if greedy:
         return _inconclusive(
@@ -250,6 +263,7 @@ def verify_sequence(
     min_p: Optional[str],
     *,
     contract_version: str = SUPPORTED_CONTRACT_VERSION,
+    seed_domain: str = SUPPORTED_SEED_DOMAIN,
     greedy: bool = False,
 ) -> SequenceResult:
     """Replay a whole response position-by-position and aggregate the verdict.
@@ -269,6 +283,10 @@ def verify_sequence(
         return SequenceResult(
             Verdict.INCONCLUSIVE,
             reason=f"unsupported contract version {contract_version!r}")
+    if seed_domain != SUPPORTED_SEED_DOMAIN:
+        return SequenceResult(
+            Verdict.INCONCLUSIVE,
+            reason=f"unsupported seed domain {seed_domain!r}")
     if greedy:
         return SequenceResult(
             Verdict.INCONCLUSIVE,
@@ -290,6 +308,7 @@ def verify_sequence(
             top_p=top_p, top_k=top_k, min_p=min_p,
             reported_token=token.token,
             contract_version=contract_version,
+            seed_domain=seed_domain,
         )
         if pr.verdict is Verdict.FRAUD:
             return SequenceResult(

--- a/vllm/validation_sampling.py
+++ b/vllm/validation_sampling.py
@@ -19,7 +19,7 @@ Scope:
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from vllm.v1.sample.deterministic_utils import (
     Sha256CounterRNG,
@@ -184,3 +184,161 @@ def result_for_validator_error(error: BaseException) -> None:
     treating a validator-side problem as inconclusive. Always None; `error` is
     for the caller to log."""
     return None
+
+
+# =============================================================================
+# Sequence-level orchestration (Stage-1 replay) + Stage-2 distance
+#
+# Converges the end-to-end validation onto this contract-faithful path, retiring
+# the legacy recompute path in ``validation_logic.py`` (gonka-ai/gonka#1199
+# follow-up items #1/#2/#3):
+#   - Stage-1 replays the SIGNED logprobs per position through the decimal
+#     pipeline (it never recomputes weights with an unfiltered float softmax).
+#   - RNG semantics: one seed per position (Decision B = per-position), so the
+#     variable draw-count of rejection sampling at one position cannot desync the
+#     replay of the rest of the sequence.
+#   - Stage-2 distance is MAE over the signed top-K support (Experiment 4), not
+#     the legacy relative-diff ratio.
+#   - Unbounded-support requests (no top_k and no min_p) carry no cheap Stage-1
+#     signal and are Inconclusive, deferred to Stage-2 (Experiment 2).
+# =============================================================================
+
+# Stage-2 fraud threshold on ``mae_distance``. PLACEHOLDER pending Decision D
+# (#1199): Experiments 4/5 put the honest floor near ~0.01 MAE and a clearly
+# different model near ~0.4-0.8, with int8 quantization a gray zone around
+# ~0.1-0.2. 0.25 accepts int8 as "the model" while still catching int4 and
+# cheaper models. The final value — and whether int8 counts as the model — is a
+# policy decision, NOT a measurement. Do not treat this as final/enforcing.
+STAGE2_MAE_FRAUD_THRESHOLD = 0.25
+
+
+@dataclass
+class SequenceResult:
+    """Aggregate verdict over a whole response."""
+
+    verdict: Verdict
+    fraud_position: int = -1
+    n_honest: int = 0
+    n_inconclusive: int = 0
+    reason: str = ""
+
+
+def _support_is_bounded(top_k: Optional[int], min_p: Optional[str]) -> bool:
+    """A request has bounded support iff ``top_k`` or ``min_p`` is active.
+
+    ``top_p`` alone (especially at high temperature) and pure-temperature
+    sampling have unbounded support — the nucleus can exceed the signed top-K, so
+    the reported set cannot faithfully reproduce the filter (Experiment 2). Such
+    requests get no cheap Stage-1 signal and are deferred to Stage-2.
+    """
+    if top_k is not None and top_k > 0:
+        return True
+    if min_p is not None:
+        try:
+            return float(min_p) > 0.0
+        except (TypeError, ValueError):
+            return False
+    return False
+
+
+def verify_sequence(
+    tokens: List["EnforcedToken"],  # noqa: F821 — avoid importing torch-side model
+    base_seed_str: str,
+    temperature: str,
+    top_p: Optional[str],
+    top_k: Optional[int],
+    min_p: Optional[str],
+    *,
+    contract_version: str = SUPPORTED_CONTRACT_VERSION,
+    greedy: bool = False,
+) -> SequenceResult:
+    """Replay a whole response position-by-position and aggregate the verdict.
+
+    Aggregation (zero tolerance):
+      - any position FRAUD  -> FRAUD (reports the first such position)
+      - else >= 1 HONEST    -> HONEST (Inconclusive positions defer to Stage-2)
+      - else all Inconclusive -> INCONCLUSIVE (Stage-1 carries no signal)
+
+    The per-position seed is ``f"{base_seed_str}|{pos}"`` (Decision B resolved to
+    per-position: independent, O(1) replay, and immune to rejection-sampling
+    draw-count desync across positions). Each ``token`` is an ``EnforcedToken``
+    with ``.logprobs`` (signed) and ``.token`` (reported); ``top_p/top_k/min_p``
+    are the resolved request-level params.
+    """
+    if contract_version != SUPPORTED_CONTRACT_VERSION:
+        return SequenceResult(
+            Verdict.INCONCLUSIVE,
+            reason=f"unsupported contract version {contract_version!r}")
+    if greedy:
+        return SequenceResult(
+            Verdict.INCONCLUSIVE,
+            reason="greedy (temperature 0): sequence check not applicable")
+    if not _support_is_bounded(top_k, min_p):
+        return SequenceResult(
+            Verdict.INCONCLUSIVE,
+            reason="unbounded support (no top_k/min_p): deferred to distance check")
+
+    n_honest = 0
+    n_inconclusive = 0
+    for pos, token in enumerate(tokens):
+        if token.logprobs is None:
+            n_inconclusive += 1
+            continue
+        seed_pos = f"{base_seed_str}|{pos}"
+        pr = verify_position(
+            token.logprobs, seed_pos, temperature,
+            top_p=top_p, top_k=top_k, min_p=min_p,
+            reported_token=token.token,
+            contract_version=contract_version,
+        )
+        if pr.verdict is Verdict.FRAUD:
+            return SequenceResult(
+                Verdict.FRAUD, fraud_position=pos,
+                n_honest=n_honest, n_inconclusive=n_inconclusive,
+                reason=pr.reason)
+        if pr.verdict is Verdict.HONEST:
+            n_honest += 1
+        else:
+            n_inconclusive += 1
+
+    if n_honest > 0:
+        return SequenceResult(
+            Verdict.HONEST, n_honest=n_honest, n_inconclusive=n_inconclusive)
+    return SequenceResult(
+        Verdict.INCONCLUSIVE, n_inconclusive=n_inconclusive,
+        reason="no replayable position (all inconclusive)")
+
+
+def mae_distance(
+    executor_logprobs: List[Dict[str, float]],
+    validator_logprobs: List[Dict[str, float]],
+) -> float:
+    """Stage-2 distance: mean over positions of the mean absolute logprob
+    difference over the executor's reported top-K support.
+
+    Replaces the legacy relative-diff ratio (``validation_logic.compute_distance``).
+    Experiment 4 (#1199 follow-up) showed MAE over the top-K support separates
+    honest from a wrong model by ~40-65x, while the sampled-token delta overlaps
+    and cannot gate. A token missing on the validator side is charged a large
+    penalty so a truncated/mismatched distribution reads as distant.
+    """
+    if not executor_logprobs:
+        return 0.0
+    if len(executor_logprobs) != len(validator_logprobs):
+        return 10.0  # length mismatch -> maximally distant
+
+    penalty = 10.0
+    per_position = []
+    for exec_lp, val_lp in zip(executor_logprobs, validator_logprobs):
+        if not exec_lp:
+            continue
+        diffs = [
+            abs(e - val_lp[tid]) if tid in val_lp else penalty
+            for tid, e in exec_lp.items()
+        ]
+        if diffs:
+            per_position.append(sum(diffs) / len(diffs))
+
+    if not per_position:
+        return 0.0
+    return sum(per_position) / len(per_position)


### PR DESCRIPTION
## What this is

The vLLM half of the two-stage inference-validation design in gonka-ai/gonka#1199: reproducible deterministic sampling on the executor, plus a validator-side replay/verification path.

This PR is:

* Draft
* Non-enforcing
* Disabled by default behind `VLLM_DETERMINISTIC_SAMPLING`
* Limited to code and tests, with no dev notes or design docs

## How it works

The design has two stages:

1. **Stage 1 — sampling replay:** Re-derives each position's token from the signed logprobs and seed, then checks that it matches the reported token.
2. **Stage 2 — distance:** Recomputes logprobs and checks the distribution distance.

For Stage 1 to accept honest artifacts, the executor and validators—Python here and Go on-chain—must reduce the same logprobs to the same token, bit for bit, in both languages.

**Scope of this PR.** Stage 1 (sampling replay) is complete and verified end to end. Stage 2 contributes the **distance metric only** (`mae_distance` / Go `MAEDistance`); its threshold and any enforcement are policy and out of scope (see Still open, Decision D). Signature verification of the artifact (Decision A) is also out of scope. In short: this makes honest executor output *replayable and provably consistent*, not yet *enforceable*.

## What changed

### Executor sampling

`v1/sample/ops/topk_topp_sampler.deterministic_sample`

* Computes weights through the decimal pipeline over the raw logprobs, with an exact `2^16` total.
* Samples in canonical token-ID string order.
* Uses a per-position seed in the form `base|pos`.
* Replaces the previous float-based `(probs * 2^16).round()` pipeline, numeric token order, and single-stream sampling path.
* Uses the same computation that the validator replays.

### Python validator

`validation_sampling.py`

* Adds `verify_sequence`, which performs sequence-level replay and returns a three-valued verdict: `Honest`, `Fraud`, or `Inconclusive`.
* Adds `mae_distance`, which calculates Stage 2 distance as MAE over the signed top-K support.
* Returns `Inconclusive` for unbounded support, seed-domain mismatch, and temperature `0` / greedy sampling.
* Updates `serving_chat._perform_validation` to use the new validator.
* Retires the legacy recompute path in `validation_logic.py` from serving.

### Primitives

`v1/sample/deterministic_utils.py`

* Updates `sample_categorical_weights` to raise on zero-weight input instead of silently falling back to the last index, matching the behavior of the Go validator.

### Cross-language parity

* Extends `tests/v1/validation/conformance_vectors.json` to cover the sequence layer and distance metric, not only the primitives.
* The companion gonka `detsample` Go validator consumes the same file and asserts byte-identical results.

## Evidence

GPU experiments were run with GPT-2 and Qwen2.5 on an RTX 4090 (isolated environment, SDPA backend).

| Question | Result |
| --- | --- |
| Float executor vs. decimal validator false-reject rate | 14–77%; decimal pipeline: 0/128 |
| E1 live in a real vLLM engine, rather than an HF proxy | 70% divergence (float weights + numeric order combined; higher than the offline 14–77% because the live path also samples in numeric token order) |
| Which executor fix is sufficient? | E1 only: 39–59%; order only: 32–57%; both together: 0% |
| Full flow in real vLLM: inference → record → validate | Current artifact: `FRAUD`; after the fix: `HONEST` in 24/24 positions |
| Can the validator recompute logprobs instead of replaying? | No; batch composition alone causes 0–8% flips |
| Signed support size | Fixed top-256 distorts 7–33%; sign the filter's retained set |
| Stage 2 metric | MAE/KL over top-K separates honest and wrong-model outputs by approximately 40–65×; sampled-token delta overlaps |
| Quantized same model | Precision ladder: int4 is caught; int8 remains a gray zone |

**Headline:** The executor fix reduces executor-versus-validator divergence from approximately 70% to 0%, verified end to end in a real vLLM engine. An honest deterministic inference now produces an artifact that the contract validator confirms as `HONEST`. (Measured on GPT-2, one sampling config; not yet a whole-fleet guarantee — see Still open.)

## Testing

`pytest tests/v1/validation tests/v1/sample` passes with 45 tests on a CUDA GPU. Coverage includes the replay flow, three-valued verdicts, MAE distance, token-order convergence, chain-bound seed domain, and the sequence and distance conformance vectors. The end-to-end inference → validate loop was also run in a real vLLM engine, as described in the Evidence section.

## Still open — do not merge for enforcement

1. **Decision A — signed-artifact contract and signature check.** Replay currently trusts the supplied logprobs; there is no `responseHash` binding or signature verification.
2. **Chain-bound seed wiring.** `derive_chain_bound_seed` exists and is tested, but the executor and validator still build the seed from `request.seed`. This requires transporting `inference_id` into vLLM (Decision D10) and having the validator derive the seed instead of trusting the payload.
3. **Signed support size.** `DETERMINISTIC_SUPPORT_K=64` is a placeholder under Decision D2; the executor and validator must agree on a pinned value.
4. **Stage 2 threshold.** The metric is settled as MAE over the support; the threshold value, number of epochs, and cross-architecture CI gate remain policy decisions under Decision D.
5. **Untested areas.** Cross-architecture determinism (current evidence is a single RTX 4090 architecture), real production model and backend (current testing uses GPT-2 with SDPA/eager), tokenizer drift across MLNode versions, and production batch-size performance.

## Branch base / rebase

This branch was cut from an earlier `main` snapshot and has not yet been rebased onto the current `main`, so GitHub currently reports conflicts. Rebasing is a ready-for-review step and has been deferred while the PR remains a draft.

## Companion PR

The gonka-side implementation—the Go `detsample` validator and shared conformance vectors—is tracked separately in gonka-ai/gonka#1448.

Refs: gonka-ai/gonka#1199
