### PR TITLE
fix(poc): enforced-tokens ingestion + shm broadcast ring size (2/2)

### DIFF
--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -1,0 +1,46 @@
+# Composes the full Gonka "S2" image = vLLM 0.25.1 + PoC-v2 thin residual
+# (this repo) + the out-of-tree gonka-poc plugin (pip). PoC compute logic
+# lives in the PLUGIN, not in-tree; only the irreducible sampler residual
+# ships inside vllm/.
+#
+#   docker build -f docker/Dockerfile.gonka-poc -t vllm-poc:0.25.1 .
+#
+# Reproduces ghcr.io/kaitakuai/vllm-poc@sha256:72423e85... (our reference S2).
+
+ARG BASE_IMAGE=vllm/vllm-openai:v0.25.1
+FROM ${BASE_IMAGE}
+
+# --- Gonka PoC-v2 runtime env -------------------------------------------------
+ENV VLLM_ALLOW_INSECURE_SERIALIZATION=1
+# NVFP4 / FP8 fast paths on Blackwell (B200/B300/RTX PRO 6000); harmless elsewhere.
+ENV VLLM_USE_FLASHINFER_MOE_FP4=1
+ENV VLLM_USE_FLASHINFER_MOE_FP8=1
+
+RUN pip install --no-cache-dir scipy
+
+# --- S1: overlay the in-tree sampler residual (.py only, no CUDA rebuild) ------
+# The 14 residual files live in this repo's vllm/ tree; we merge only .py into
+# the pre-built package, preserving compiled .so.
+COPY ./vllm /tmp/vllm-src
+RUN VLLM_DIR=$(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))") \
+    && [ -d "$VLLM_DIR" ] || (echo "ERROR: vllm not importable"; exit 1) \
+    && cd /tmp/vllm-src \
+    && find . -name "*.py" | tar -cf - -T - | tar -xf - -C "$VLLM_DIR/" \
+    && rm -rf /tmp/vllm-src
+
+# Pin the V1 model runner: vLLM 0.25 ships a parallel V2 GPU runner with its own
+# sampler/InputBatch that bypasses the residual. Off = PoC validation surface intact.
+ENV VLLM_USE_V2_MODEL_RUNNER=0
+
+# --- S2: add the out-of-tree PoC plugin (pip) ---------------------------------
+# All PoC compute (nonce gen, RNG, Householder scoring, L2/fraud validation,
+# DeepSeek-V4 support) is in the plugin — NOT in this repo.
+# Pinned to a tag rather than a branch: the plugin repository is being handed
+# over to the gonka-ai organisation, and a branch would resolve to whatever
+# HEAD it has at build time. v0.1.0a0 is the first tagged release and is
+# immutable across the ownership change.
+ARG GONKA_POC_REPO=kaitakuai/gonka-poc
+ARG GONKA_POC_REF=v0.1.0a0
+RUN pip install --no-cache-dir --no-deps \
+      "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \
+    && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10" "fastapi<0.137" "pydantic>=2"

--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -18,6 +18,17 @@ ENV VLLM_ALLOW_INSECURE_SERIALIZATION=1
 # NVFP4 / FP8 fast paths on Blackwell (B200/B300/RTX PRO 6000); harmless elsewhere.
 ENV VLLM_USE_FLASHINFER_MOE_FP4=1
 ENV VLLM_USE_FLASHINFER_MOE_FP8=1
+# Enlarged shm broadcast rings. Kimi-K2.6 died repeatedly under production load
+# on a 4xB300 fleet until these were raised; engine deaths went from roughly
+# every 35 minutes to every 2-3 hours. The knob defaults to upstream sizes so
+# that unrelated deployments do not pay the /dev/shm cost, which means an image
+# for this workload has to opt in explicitly -- here.
+#
+# Budget accordingly: each ring costs max_chunks x (max_chunk_bytes + metadata),
+# so at the 16 MiB default a ring of 64 is ~1 GiB, and an engine has several.
+# Plan on ~1.3 GiB of extra /dev/shm per engine; an undersized tmpfs fails as
+# SIGBUS under load rather than at startup.
+ENV VLLM_MQ_MAX_CHUNKS=64
 
 # --- S1: overlay the in-tree sampler residual (.py only, no CUDA rebuild) ------
 # Merges this tree's .py files over the pre-built package, keeping compiled .so.

--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -4,32 +4,42 @@
 # ships inside vllm/.
 #
 #   docker build -f docker/Dockerfile.gonka-poc -t vllm-poc:0.25.1 .
-#
-# Reproduces ghcr.io/kaitakuai/vllm-poc@sha256:72423e85... (our reference S2).
 
 ARG BASE_IMAGE=vllm/vllm-openai:v0.25.1
 FROM ${BASE_IMAGE}
 
 # --- Gonka PoC-v2 runtime env -------------------------------------------------
+# The plugin reaches workers through collective_rpc, whose payloads are not
+# msgpack-encodable, so the engine's message bus has to allow pickle. Set here
+# because the image is built for that workload; a general-purpose deployment
+# should not carry it, and unsetting it disables the PoC path rather than
+# degrading it.
 ENV VLLM_ALLOW_INSECURE_SERIALIZATION=1
 # NVFP4 / FP8 fast paths on Blackwell (B200/B300/RTX PRO 6000); harmless elsewhere.
 ENV VLLM_USE_FLASHINFER_MOE_FP4=1
 ENV VLLM_USE_FLASHINFER_MOE_FP8=1
 
-RUN pip install --no-cache-dir scipy
-
 # --- S1: overlay the in-tree sampler residual (.py only, no CUDA rebuild) ------
-# The 14 residual files live in this repo's vllm/ tree; we merge only .py into
-# the pre-built package, preserving compiled .so.
+# Merges this tree's .py files over the pre-built package, keeping compiled .so.
+# The version guard matters: .py from one minor over .so from another either
+# fails at import or, worse, half-works.
+ARG EXPECTED_VLLM_VERSION=0.25.1
 COPY ./vllm /tmp/vllm-src
-RUN VLLM_DIR=$(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))") \
+RUN INSTALLED=$(python3 -c "import vllm; print(vllm.__version__)") \
+    && case "$INSTALLED" in "${EXPECTED_VLLM_VERSION}"*) ;; \
+         *) echo "ERROR: base image ships vllm $INSTALLED, residual targets ${EXPECTED_VLLM_VERSION}"; exit 1 ;; \
+       esac \
+    && VLLM_DIR=$(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))") \
     && [ -d "$VLLM_DIR" ] || (echo "ERROR: vllm not importable"; exit 1) \
     && cd /tmp/vllm-src \
     && find . -name "*.py" | tar -cf - -T - | tar -xf - -C "$VLLM_DIR/" \
     && rm -rf /tmp/vllm-src
 
-# Pin the V1 model runner: vLLM 0.25 ships a parallel V2 GPU runner with its own
-# sampler/InputBatch that bypasses the residual. Off = PoC validation surface intact.
+# Select the V1 model runner. vLLM 0.25 ships a parallel V2 runner with its own
+# sampler, which does not implement enforced tokens or per-request logprobs
+# mode. This is a convenience default, not the safety net: the V2 sampler now
+# rejects such requests outright, so overriding this variable produces an error
+# rather than a reply that silently enforced nothing.
 ENV VLLM_USE_V2_MODEL_RUNNER=0
 
 # --- S2: add the out-of-tree PoC plugin (pip) ---------------------------------
@@ -43,4 +53,4 @@ ARG GONKA_POC_REPO=kaitakuai/gonka-poc
 ARG GONKA_POC_REF=v0.1.0a0
 RUN pip install --no-cache-dir --no-deps \
       "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \
-    && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10" "fastapi<0.137" "pydantic>=2"
+    && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10"

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/contract/test_mq_ring_surface.py
+++ b/tests/contract/test_mq_ring_surface.py
@@ -1,0 +1,55 @@
+"""Drift detector: pin the shm MessageQueue ring-size surface (REBASE.md row 8).
+
+Row 8 enlarges the shm broadcast rings from their defaults (6 GroupCoordinator
+chunks / 10 executor chunks) to 64: a briefly-slow TP reader starves the writer
+under burst load -> "No available shared memory broadcast block" engine stalls.
+Ported from the 0.20 fat-fork (kaitakuai/vllm#15).
+
+Two modes (see ``test_sampler_surface.py`` header + REBASE.md):
+    * in-fork job — runs against the residual wheel; ALL assertions MUST pass.
+    * upstream-drift job — ring values fail on upstream (expected rebase ALERT);
+      the signature test failing means upstream removed the knob entirely.
+
+Scope: read-only source inspection; NO GPU, NO engine startup.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+
+def test_message_queue_accepts_max_chunks() -> None:
+    """``MessageQueue.__init__`` must still expose ``max_chunks``."""
+    from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
+
+    params = inspect.signature(MessageQueue.__init__).parameters
+    assert "max_chunks" in params, (
+        "MessageQueue.__init__ lost the max_chunks parameter — the row 8 "
+        "ring enlargement has no surface to apply to"
+    )
+
+
+def test_group_coordinator_rings_enlarged() -> None:
+    """All three GroupCoordinator ring sites carry max_chunks=64."""
+    from vllm.distributed import parallel_state
+
+    sites = re.findall(r"1 << 22,\s*(\d+)", inspect.getsource(parallel_state))
+    assert sites == ["64", "64", "64"], (
+        f"expected three '1 << 22, 64' ring sites in parallel_state, got {sites} "
+        "— row 8 patch missing or upstream moved the call sites"
+    )
+
+
+def test_rpc_broadcast_mq_ring_enlarged() -> None:
+    """The per-step executor ring (the primary stall site) carries max_chunks=64."""
+    from vllm.v1.executor import multiproc_executor
+
+    src = inspect.getsource(multiproc_executor)
+    assert "rpc_broadcast_mq = MessageQueue(" in src, (
+        "rpc_broadcast_mq construction moved — re-anchor the row 8 executor hunk"
+    )
+    assert "max_chunks=64" in src, (
+        "rpc_broadcast_mq no longer passes max_chunks=64 (default 10) — row 8 "
+        "executor hunk missing"
+    )

--- a/tests/contract/test_mq_ring_surface.py
+++ b/tests/contract/test_mq_ring_surface.py
@@ -1,22 +1,20 @@
-"""Drift detector: pin the shm MessageQueue ring-size surface (REBASE.md row 8).
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pin the surface the VLLM_MQ_MAX_CHUNKS override depends on.
 
-Row 8 enlarges the shm broadcast rings from their defaults (6 GroupCoordinator
-chunks / 10 executor chunks) to 64: a briefly-slow TP reader starves the writer
-under burst load -> "No available shared memory broadcast block" engine stalls.
-Ported from the 0.20 fat-fork (kaitakuai/vllm#15).
+A briefly-slow TP reader can starve the shm broadcast writer under burst
+load, surfacing as "No available shared memory broadcast block" stalls. The
+override raises the ring count to buy slack; these tests pin the two things
+it needs — the ``max_chunks`` parameter and the env knob itself — plus the
+default-preserving behaviour, so that neither an upstream refactor nor a
+careless edit turns the override into a silent no-op.
 
-Two modes (see ``test_sampler_surface.py`` header + REBASE.md):
-    * in-fork job — runs against the residual wheel; ALL assertions MUST pass.
-    * upstream-drift job — ring values fail on upstream (expected rebase ALERT);
-      the signature test failing means upstream removed the knob entirely.
-
-Scope: read-only source inspection; NO GPU, NO engine startup.
+Read-only: no GPU, no engine startup, no queue is constructed.
 """
 
 from __future__ import annotations
 
 import inspect
-import re
 
 
 def test_message_queue_accepts_max_chunks() -> None:
@@ -25,31 +23,51 @@ def test_message_queue_accepts_max_chunks() -> None:
 
     params = inspect.signature(MessageQueue.__init__).parameters
     assert "max_chunks" in params, (
-        "MessageQueue.__init__ lost the max_chunks parameter — the row 8 "
-        "ring enlargement has no surface to apply to"
+        "MessageQueue.__init__ lost the max_chunks parameter — the ring-size "
+        "override has nothing to apply to"
     )
 
 
-def test_group_coordinator_rings_enlarged() -> None:
-    """All three GroupCoordinator ring sites carry max_chunks=64."""
+def test_env_knob_exists_and_defaults_to_none() -> None:
+    """The knob must exist and must not change ring sizes when unset.
+
+    ``None`` is what keeps every call site on its own upstream default; a
+    concrete default here would raise /dev/shm requirements for every
+    deployment, including those that never hit the starvation case.
+    """
+    import vllm.envs as envs
+
+    assert hasattr(envs, "VLLM_MQ_MAX_CHUNKS"), (
+        "VLLM_MQ_MAX_CHUNKS is gone — the ring-size override is unreachable"
+    )
+    value = envs.VLLM_MQ_MAX_CHUNKS
+    assert value is None or isinstance(value, int), (
+        f"VLLM_MQ_MAX_CHUNKS should be None or int, got {value!r}"
+    )
+
+
+def test_ring_sites_honour_the_knob() -> None:
+    """Every ring that shares the starvation failure mode reads the knob.
+
+    Asserted per module rather than by counting literals: a site that keeps a
+    hardcoded ring size stays vulnerable while the tests pass, which is how
+    the Ray executor was missed the first time.
+    """
     from vllm.distributed import parallel_state
-
-    sites = re.findall(r"1 << 22,\s*(\d+)", inspect.getsource(parallel_state))
-    assert sites == ["64", "64", "64"], (
-        f"expected three '1 << 22, 64' ring sites in parallel_state, got {sites} "
-        "— row 8 patch missing or upstream moved the call sites"
-    )
-
-
-def test_rpc_broadcast_mq_ring_enlarged() -> None:
-    """The per-step executor ring (the primary stall site) carries max_chunks=64."""
     from vllm.v1.executor import multiproc_executor
 
-    src = inspect.getsource(multiproc_executor)
-    assert "rpc_broadcast_mq = MessageQueue(" in src, (
-        "rpc_broadcast_mq construction moved — re-anchor the row 8 executor hunk"
-    )
-    assert "max_chunks=64" in src, (
-        "rpc_broadcast_mq no longer passes max_chunks=64 (default 10) — row 8 "
-        "executor hunk missing"
+    for module in (parallel_state, multiproc_executor):
+        assert "VLLM_MQ_MAX_CHUNKS" in inspect.getsource(module), (
+            f"{module.__name__} no longer reads VLLM_MQ_MAX_CHUNKS — its rings "
+            f"are pinned to the default and the override cannot reach them"
+        )
+
+    # Optional dependency: absent unless vLLM was installed with Ray.
+    try:
+        from vllm.v1.executor import ray_executor_v2
+    except ImportError:
+        return
+    assert "VLLM_MQ_MAX_CHUNKS" in inspect.getsource(ray_executor_v2), (
+        "the Ray executor's broadcast ring ignores VLLM_MQ_MAX_CHUNKS, so the "
+        "stall it shares with the multiproc executor stays unfixable there"
     )

--- a/tests/contract/test_request_validation_surface.py
+++ b/tests/contract/test_request_validation_surface.py
@@ -1,129 +1,121 @@
-"""Drift detector: pin the enforced_tokens / inference-validation REQUEST surface.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pin the HTTP -> SamplingParams path for enforced-token replay.
 
-The SAMPLER half of enforced-token replay is pinned in ``test_sampler_surface.py``
-(commits 1c5368212 / c2db96992 / f2bbeaac8). THIS file pins the REQUEST-INGESTION
-half that bridges HTTP -> SamplingParams: the ``vllm.validation.EnforcedTokens``
-helper and the ``ChatCompletionRequest.{enforced_tokens, enforced_str,
-logprobs_mode}`` fields, plus the ``OpenAIServingChat`` glue that writes
-``sampling_params.enforced_token_ids``.
+The sampler half of replay is pinned in ``test_sampler_surface.py``. This
+file pins the ingestion half: the request fields, the helper that decodes
+them, and the validation that keeps a replay id out of the embedding lookup
+unless the model can embed it.
 
-Originating commit: the enforced_tokens request-ingestion patch (REBASE.md row 7) —
-``feat(validation): add enforced_tokens request ingestion`` (validation.py + chat
-protocol.py + chat serving.py + engine/serving.py).
+Both halves have to be present for replay to work, and the failure mode when
+the ingestion half is missing is silent — the payload is dropped by the
+request model and validation degrades into an ordinary generate, with no
+error anywhere. That is what these tests exist to make loud.
 
-Without this layer the sampler enforcement IS present but NEVER fires: a validator's
-``enforced_tokens`` payload is silently dropped by Pydantic, so inference validation
-does not work. A future upstream rebase that drops these hunks would reintroduce that
-bug with GREEN CI unless this contract fails loudly.
-
-Two modes (see ``test_sampler_surface.py`` header + REBASE.md):
-    * in-fork job — runs against the residual wheel; ALL assertions MUST pass.
-    * upstream-drift job — runs against unmodified upstream; these fail (expected),
-      which is the rebase ALERT signal.
-
-Scope: read-only module/class inspection; NO GPU, NO engine startup, NO forward pass.
+Read-only: no GPU, no engine startup, no forward pass.
 """
 
 from __future__ import annotations
 
 import importlib
-import inspect
 
 import pytest
 
-# ---------------------------------------------------------------------------- #
-# vllm.validation.EnforcedTokens helper (new module)
-# ---------------------------------------------------------------------------- #
-
 
 def test_validation_module_has_enforced_tokens() -> None:
-    """Pin the ``vllm.validation`` helper classes added by the ingestion commit.
-
-    What breaks if this assertion fails:
-        - In-fork: the enforced_tokens ingestion commit (REBASE.md row 7) did not
-          apply — re-add ``vllm/validation.py``.
-        - Upstream-drift: upstream still has no ``vllm.validation`` module
-          (expected on the drift job).
-    """
+    """The helper that turns a replay payload into token ids must exist."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.validation")
     for name in ("EnforcedToken", "EnforcedTokens"):
         assert getattr(mod, name, None) is not None, (
-            f"vllm.validation.{name} missing — the enforced_tokens ingestion "
-            f"commit (REBASE.md row 7) did not apply. Inference validation replay "
-            f"is dropped at the HTTP layer (Pasha's bug)."
+            f"vllm.validation.{name} is missing, so a replay payload cannot be "
+            f"decoded and inference validation silently degrades to a plain "
+            f"generate"
         )
-    enforced_tokens = mod.EnforcedTokens
-    for meth in (
-        "encode",
-        "from_content",
-        "get_enforced_token_ids",
-        "detect_logprobs_mode",
-    ):
-        assert hasattr(enforced_tokens, meth), (
-            f"EnforcedTokens.{meth} missing — re-port the ingestion commit "
-            f"(REBASE.md row 7)."
+    for meth in ("encode", "get_enforced_token_ids"):
+        assert hasattr(mod.EnforcedTokens, meth), (
+            f"EnforcedTokens.{meth} is missing — the ingestion path cannot "
+            f"produce token ids"
         )
 
 
-# ---------------------------------------------------------------------------- #
-# ChatCompletionRequest enforced_tokens / enforced_str / logprobs_mode fields
-# ---------------------------------------------------------------------------- #
+def test_replay_ids_are_range_checked() -> None:
+    """Out-of-range replay ids must be rejected before they reach the engine.
+
+    This is the difference between a 400 and a dead worker: an id outside the
+    vocabulary reaches an embedding lookup, where it is a device-side assert
+    that takes down the process and every other request on it.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    validate = getattr(mod, "validate_enforced_token_ids", None)
+    assert validate is not None, (
+        "vllm.validation.validate_enforced_token_ids is missing — replay ids "
+        "would reach the embedding lookup unchecked"
+    )
+
+    vocab_size = 32000
+    validate([0, 1, vocab_size - 1], vocab_size)  # in range: must not raise
+
+    for bad in ([vocab_size], [-1], [-5]):
+        with pytest.raises(ValueError):
+            validate(bad, vocab_size)
 
 
-def test_chat_request_has_enforced_token_fields() -> None:
-    """Pin the request fields that carry a validator's enforced-token payload.
+def test_replay_payload_is_size_bounded() -> None:
+    """The payload must have ceilings, so a large body cannot exhaust memory."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("MAX_ENFORCED_TOKENS", "MAX_TOP_TOKENS_PER_POSITION"):
+        limit = getattr(mod, name, None)
+        assert isinstance(limit, int) and limit > 0, (
+            f"vllm.validation.{name} is missing or not a positive int — the "
+            f"replay payload is unbounded"
+        )
 
-    What breaks if this assertion fails:
-        - In-fork: the request-protocol hunk did not apply; Pydantic SILENTLY
-          DROPS the validator's ``enforced_tokens`` payload (the exact bug the
-          ingestion commit fixes).
-        - Upstream-drift: upstream ChatCompletionRequest lacks these (expected).
+    with pytest.raises(ValueError):
+        mod.EnforcedTokens(
+            tokens=[{"token": "1"}] * (mod.MAX_ENFORCED_TOKENS + 1),
+        )
+
+
+def test_chat_request_carries_replay_fields() -> None:
+    """The request model must accept the replay fields.
+
+    If it does not, the payload is dropped during request parsing and the
+    validator gets an ordinary completion back while believing it verified
+    something.
     """
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.protocol")
     cls = getattr(mod, "ChatCompletionRequest", None)
     assert cls is not None, (
-        "vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionRequest "
-        "missing — module restructured; re-port the ingestion commit."
+        "ChatCompletionRequest is missing — the request protocol module was "
+        "restructured"
     )
-    # Pydantic v2 model field set.
     fields = set(getattr(cls, "model_fields", {}) or {})
-    if not fields:  # extreme-fallback for non-pydantic shape
+    if not fields:
         fields = set(getattr(cls, "__annotations__", {}) or {})
     for name in ("enforced_tokens", "enforced_str", "logprobs_mode"):
         assert name in fields, (
-            f"ChatCompletionRequest.{name} missing from model_fields — the "
-            f"enforced_tokens ingestion commit (REBASE.md row 7) did not apply. "
-            f"A validator's payload is silently dropped -> inference validation "
-            f"broken."
+            f"ChatCompletionRequest.{name} is missing, so that part of a "
+            f"replay request is silently discarded"
         )
 
 
-# ---------------------------------------------------------------------------- #
-# OpenAIServingChat bridges request fields -> sampling_params.enforced_token_ids
-# ---------------------------------------------------------------------------- #
+def test_sampling_params_carries_replay_ids() -> None:
+    """The field the ingestion path writes into must exist on SamplingParams.
 
-
-def test_chat_serving_writes_enforced_token_ids() -> None:
-    """Pin that the chat serving path converts the request fields into
-    ``sampling_params.enforced_token_ids``.
-
-    What breaks if this assertion fails:
-        - The serving glue (serving.py enforced block) did not apply; the request
-          fields exist but never reach the sampler — enforced_tokens parsed yet
-          never enforced. Re-port the ingestion commit (REBASE.md row 7).
+    Checked on the destination type rather than by reading the serving source,
+    so the test tracks the contract instead of a particular implementation.
     """
     pytest.importorskip("vllm")
-    mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.serving")
-    cls = getattr(mod, "OpenAIServingChat", None)
-    assert cls is not None, (
-        "OpenAIServingChat missing — module restructured; re-port the ingestion commit."
+    mod = importlib.import_module("vllm.sampling_params")
+    cls = mod.SamplingParams
+    fields = set(getattr(cls, "__struct_fields__", ()) or ()) or set(
+        getattr(cls, "__annotations__", {}) or {}
     )
-    src = inspect.getsource(cls)
-    assert "enforced_token_ids" in src, (
-        "OpenAIServingChat no longer writes sampling_params.enforced_token_ids — "
-        "the serving bridge from the ingestion commit was lost. enforced_tokens "
-        "would be parsed but never enforced. Re-port the ingestion commit "
-        "(REBASE.md row 7)."
+    assert "enforced_token_ids" in fields, (
+        "SamplingParams.enforced_token_ids is missing — the ingestion path has "
+        "nowhere to write decoded replay ids, so enforcement never fires"
     )

--- a/tests/contract/test_request_validation_surface.py
+++ b/tests/contract/test_request_validation_surface.py
@@ -1,0 +1,129 @@
+"""Drift detector: pin the enforced_tokens / inference-validation REQUEST surface.
+
+The SAMPLER half of enforced-token replay is pinned in ``test_sampler_surface.py``
+(commits 1c5368212 / c2db96992 / f2bbeaac8). THIS file pins the REQUEST-INGESTION
+half that bridges HTTP -> SamplingParams: the ``vllm.validation.EnforcedTokens``
+helper and the ``ChatCompletionRequest.{enforced_tokens, enforced_str,
+logprobs_mode}`` fields, plus the ``OpenAIServingChat`` glue that writes
+``sampling_params.enforced_token_ids``.
+
+Originating commit: the enforced_tokens request-ingestion patch (REBASE.md row 7) —
+``feat(validation): add enforced_tokens request ingestion`` (validation.py + chat
+protocol.py + chat serving.py + engine/serving.py).
+
+Without this layer the sampler enforcement IS present but NEVER fires: a validator's
+``enforced_tokens`` payload is silently dropped by Pydantic, so inference validation
+does not work. A future upstream rebase that drops these hunks would reintroduce that
+bug with GREEN CI unless this contract fails loudly.
+
+Two modes (see ``test_sampler_surface.py`` header + REBASE.md):
+    * in-fork job — runs against the residual wheel; ALL assertions MUST pass.
+    * upstream-drift job — runs against unmodified upstream; these fail (expected),
+      which is the rebase ALERT signal.
+
+Scope: read-only module/class inspection; NO GPU, NO engine startup, NO forward pass.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+# ---------------------------------------------------------------------------- #
+# vllm.validation.EnforcedTokens helper (new module)
+# ---------------------------------------------------------------------------- #
+
+
+def test_validation_module_has_enforced_tokens() -> None:
+    """Pin the ``vllm.validation`` helper classes added by the ingestion commit.
+
+    What breaks if this assertion fails:
+        - In-fork: the enforced_tokens ingestion commit (REBASE.md row 7) did not
+          apply — re-add ``vllm/validation.py``.
+        - Upstream-drift: upstream still has no ``vllm.validation`` module
+          (expected on the drift job).
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("EnforcedToken", "EnforcedTokens"):
+        assert getattr(mod, name, None) is not None, (
+            f"vllm.validation.{name} missing — the enforced_tokens ingestion "
+            f"commit (REBASE.md row 7) did not apply. Inference validation replay "
+            f"is dropped at the HTTP layer (Pasha's bug)."
+        )
+    enforced_tokens = mod.EnforcedTokens
+    for meth in (
+        "encode",
+        "from_content",
+        "get_enforced_token_ids",
+        "detect_logprobs_mode",
+    ):
+        assert hasattr(enforced_tokens, meth), (
+            f"EnforcedTokens.{meth} missing — re-port the ingestion commit "
+            f"(REBASE.md row 7)."
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# ChatCompletionRequest enforced_tokens / enforced_str / logprobs_mode fields
+# ---------------------------------------------------------------------------- #
+
+
+def test_chat_request_has_enforced_token_fields() -> None:
+    """Pin the request fields that carry a validator's enforced-token payload.
+
+    What breaks if this assertion fails:
+        - In-fork: the request-protocol hunk did not apply; Pydantic SILENTLY
+          DROPS the validator's ``enforced_tokens`` payload (the exact bug the
+          ingestion commit fixes).
+        - Upstream-drift: upstream ChatCompletionRequest lacks these (expected).
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.protocol")
+    cls = getattr(mod, "ChatCompletionRequest", None)
+    assert cls is not None, (
+        "vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionRequest "
+        "missing — module restructured; re-port the ingestion commit."
+    )
+    # Pydantic v2 model field set.
+    fields = set(getattr(cls, "model_fields", {}) or {})
+    if not fields:  # extreme-fallback for non-pydantic shape
+        fields = set(getattr(cls, "__annotations__", {}) or {})
+    for name in ("enforced_tokens", "enforced_str", "logprobs_mode"):
+        assert name in fields, (
+            f"ChatCompletionRequest.{name} missing from model_fields — the "
+            f"enforced_tokens ingestion commit (REBASE.md row 7) did not apply. "
+            f"A validator's payload is silently dropped -> inference validation "
+            f"broken."
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# OpenAIServingChat bridges request fields -> sampling_params.enforced_token_ids
+# ---------------------------------------------------------------------------- #
+
+
+def test_chat_serving_writes_enforced_token_ids() -> None:
+    """Pin that the chat serving path converts the request fields into
+    ``sampling_params.enforced_token_ids``.
+
+    What breaks if this assertion fails:
+        - The serving glue (serving.py enforced block) did not apply; the request
+          fields exist but never reach the sampler — enforced_tokens parsed yet
+          never enforced. Re-port the ingestion commit (REBASE.md row 7).
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.serving")
+    cls = getattr(mod, "OpenAIServingChat", None)
+    assert cls is not None, (
+        "OpenAIServingChat missing — module restructured; re-port the ingestion commit."
+    )
+    src = inspect.getsource(cls)
+    assert "enforced_token_ids" in src, (
+        "OpenAIServingChat no longer writes sampling_params.enforced_token_ids — "
+        "the serving bridge from the ingestion commit was lost. enforced_tokens "
+        "would be parsed but never enforced. Re-port the ingestion commit "
+        "(REBASE.md row 7)."
+    )

--- a/tests/contract/test_sampler_surface.py
+++ b/tests/contract/test_sampler_surface.py
@@ -1,27 +1,22 @@
-"""Drift detector: pin the vLLM sampler private surface that the residual fork patches.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Contract tests for the sampler surfaces the PoC residual depends on.
 
-This contract pin lives in the residual fork — its purpose is to catch upstream
-sampler / SamplingParams refactor BEFORE the manual rebase on the next vLLM
-minor. The residual is treated as permanent infrastructure (ADR-0014 in
-mlnode-foundry), so Layer 3 (merging upstream) is off the table; we instead
-keep a daily "is upstream still shaped the way we expect?" signal.
+The residual in this tree adds a few hooks to the V1 sampling stack that an
+out-of-tree plugin consumes: per-request ``logprobs_mode`` and
+``enforced_token_ids``, ``need_processed_logprobs`` threading through the
+top-k/top-p sampler, the matching ``InputBatch`` bookkeeping, and
+structured-output graceful degradation. All of them live on private classes,
+so a refactor can move them without producing an import error: the plugin
+keeps loading and silently stops enforcing tokens or stops returning the
+requested logprobs.
 
-Each test references the originating commit SHA on poc-sampler-residual-v0.23
-and documents what breaks if the assertion fails. The tests are intentionally
-brittle: an upstream rename / refactor MUST surface here so the rebase author
-can re-port the patches before merging the next minor.
+These tests pin the shape of each touched surface. A failure means the
+surface moved and the corresponding residual patch must be re-applied at its
+new location; every assertion message names the file to look at.
 
-Two modes:
-    * "in-fork" job — runs against the residual wheel itself. All assertions
-      MUST pass (otherwise our 6 patches did not apply correctly).
-    * "upstream-drift" job — runs against the unmodified upstream wheel. The
-      patch-added fields (logprobs_mode, enforced_token_ids, etc.) will be
-      MISSING on upstream and these tests will fail. That failure is the
-      ALERT signal — see .github/workflows/contract-tests-residual.yml and
-      REBASE.md for the rebase procedure.
-
-Scope: read-only inspection of vllm modules; NO GPU, NO engine startup, NO
-forward pass. Safe to run in a vanilla ``pip install vllm`` environment.
+Scope: read-only inspection of vllm modules. No GPU, no engine startup, no
+forward pass.
 """
 
 from __future__ import annotations
@@ -31,346 +26,279 @@ import inspect
 
 import pytest
 
-# ---------------------------------------------------------------------------- #
-# SamplingParams public dataclass fields (commit 1c5368212)
-# ---------------------------------------------------------------------------- #
-
 
 def test_sampling_params_has_poc_fields() -> None:
-    """Pin per-request SamplingParams fields added by 1c5368212.
-
-    Originating commit: 1c5368212 — feat(sampling): add per-request logprobs_mode
-    and enforced_token_ids fields.
-
-    What breaks if this assertion fails:
-        - On the in-fork job: our patch did not apply to this branch (rebase
-          regression) — fix by re-cherry-picking 1c5368212.
-        - On the upstream-drift job: upstream adopted (good — Layer 3 path
-          reopens) or renamed (bad — rebase author must rename our fields to
-          avoid collision before next-minor cherry-pick).
-    """
+    """Pin the per-request SamplingParams fields the plugin sets."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.sampling_params")
     cls = getattr(mod, "SamplingParams", None)
     assert cls is not None, "vllm.sampling_params.SamplingParams missing"
 
-    annotations = getattr(cls, "__annotations__", {}) or {}
-    # logprobs_mode: per-request override added by 1c5368212.
-    assert "logprobs_mode" in annotations, (
-        "SamplingParams.logprobs_mode missing — commit 1c5368212 did not "
-        "apply (in-fork failure) OR upstream lacks this field (drift "
-        "alert; expected on the upstream-drift job)."
-    )
-    # enforced_token_ids: validation-replay sequence added by 1c5368212.
-    assert "enforced_token_ids" in annotations, (
-        "SamplingParams.enforced_token_ids missing — commit 1c5368212 did "
-        "not apply (in-fork failure) OR upstream lacks this field (drift "
-        "alert; expected on the upstream-drift job)."
-    )
-
-    # Pin the field is wired into the actual constructor surface, not just
-    # carried as a type annotation. msgspec.Struct (current shape of
-    # SamplingParams in vllm 0.23) auto-generates __init__ from
-    # __struct_fields__ but does NOT expose those names via
-    # inspect.signature(cls.__init__) — that returns (self, *args, **kwargs).
-    # Dataclasses use __dataclass_fields__. Try msgspec → dataclass → init
-    # signature in that order so the assertion survives future class-type
-    # flips upstream.
-    field_names = set(getattr(cls, "__struct_fields__", None) or [])
+    # SamplingParams is a msgspec.Struct, whose declared field set is
+    # __struct_fields__; msgspec generates __init__ dynamically, so
+    # inspect.signature(cls.__init__) only reports (*args, **kwargs). Fall
+    # back to the dataclass and signature views so the assertion survives a
+    # future change of class machinery.
+    field_names = set(getattr(cls, "__struct_fields__", None) or ())
     if not field_names:
-        field_names = set((getattr(cls, "__dataclass_fields__", None) or {}).keys())
+        field_names = set(getattr(cls, "__dataclass_fields__", None) or ())
     if not field_names:
         field_names = set(inspect.signature(cls.__init__).parameters)
     for name in ("logprobs_mode", "enforced_token_ids"):
         assert name in field_names, (
-            f"SamplingParams: {name!r} not in constructor field set "
-            f"(__struct_fields__/__dataclass_fields__/__init__ signature). "
-            f"Annotation present but wiring lost — re-check commit 1c5368212."
+            f"SamplingParams.{name} is not a declared field — re-apply the "
+            f"residual patch to vllm/sampling_params.py."
         )
 
+    # from_optional is the path the API entrypoints take: a field that is
+    # declared but not forwarded here never reaches the sampler.
+    from_optional_params = set(inspect.signature(cls.from_optional).parameters)
+    for name in ("logprobs_mode", "enforced_token_ids"):
+        assert name in from_optional_params, (
+            f"SamplingParams.from_optional no longer forwards {name} — "
+            f"requests carrying it would be silently dropped before the "
+            f"sampler sees it."
+        )
 
-# ---------------------------------------------------------------------------- #
-# SamplingMetadata sampler-side fields (commit 1c5368212)
-# ---------------------------------------------------------------------------- #
+    # Both fields must be opt-in: requests that do not set them must behave
+    # exactly like unpatched vLLM.
+    defaults = cls()
+    assert defaults.logprobs_mode is None
+    assert defaults.enforced_token_ids is None
+
+    params = cls(
+        logprobs=1,
+        logprobs_mode="processed_logprobs",
+        enforced_token_ids=[7, 11],
+    )
+    assert params.logprobs_mode == "processed_logprobs"
+    assert params.enforced_token_ids == [7, 11]
+
+    # The value check runs from __post_init__; without it an unusable mode
+    # reaches the sampler and is resolved to the deployment default.
+    with pytest.raises(ValueError):
+        cls(logprobs_mode="not_a_mode")
 
 
 def test_sampling_metadata_has_poc_fields() -> None:
-    """Pin sampler-side bookkeeping fields on SamplingMetadata.
-
-    Originating commit: 1c5368212. Note that ``thinking_budget_state_holder``
-    is an upstream field (added in 0.23 by vllm-project) and coexists with
-    our fields; we do not assert on it here.
-
-    What breaks if this assertion fails:
-        - In-fork: 1c5368212 did not apply (or only partially applied).
-        - Upstream-drift: upstream lacks these fields (expected); when
-          upstream eventually relocates SamplingMetadata into a different
-          module / makes it non-dataclass, this test fires.
-    """
+    """Pin the sampler-side SamplingMetadata fields the residual populates."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.v1.sample.metadata")
     cls = getattr(mod, "SamplingMetadata", None)
     assert cls is not None, "vllm.v1.sample.metadata.SamplingMetadata missing"
 
-    annotations = getattr(cls, "__annotations__", {}) or {}
-    # batch_logprobs_mode carries the per-request mode resolution; the
-    # Sampler.forward() priority chain depends on this field name verbatim.
-    assert "batch_logprobs_mode" in annotations, (
-        "SamplingMetadata.batch_logprobs_mode missing — commit 1c5368212 "
-        "did not apply. Sampler.forward() priority resolution will silently "
-        "fall back to deployment default — PoC logprobs requests will be "
-        "wrong."
-    )
-    # enforced_next_token_ids drives the post-sampling override in
-    # Sampler.forward(); without it, validation replay is silently no-op.
-    assert "enforced_next_token_ids" in annotations, (
-        "SamplingMetadata.enforced_next_token_ids missing — commit 1c5368212 "
-        "did not apply. PoC v2 validation replay will silently no-op."
+    dc_fields = getattr(cls, "__dataclass_fields__", None)
+    assert dc_fields is not None, (
+        "SamplingMetadata is no longer a dataclass — re-check how "
+        "vllm/v1/worker/gpu_input_batch.py constructs it."
     )
 
-
-# ---------------------------------------------------------------------------- #
-# Sampler.forward signature accepts sampling_metadata (commits c2db96992 + 1c5368212)
-# ---------------------------------------------------------------------------- #
+    # batch_logprobs_mode drives the mode resolution in Sampler.forward, and
+    # logprobs_is_processed selects raw vs processed per row of a mixed
+    # batch; enforced_next_token_ids drives the post-sampling override.
+    for name in (
+        "batch_logprobs_mode",
+        "logprobs_is_processed",
+        "enforced_next_token_ids",
+    ):
+        assert name in dc_fields, (
+            f"SamplingMetadata.{name} missing — Sampler.forward would fall "
+            f"back to the deployment-wide logprobs mode and skip the "
+            f"enforced-token override without failing. Re-apply the residual "
+            f"patch to vllm/v1/sample/metadata.py."
+        )
+        assert dc_fields[name].default is None, (
+            f"SamplingMetadata.{name} no longer defaults to None — every "
+            f"other construction site of SamplingMetadata must keep working "
+            f"without the residual fields."
+        )
 
 
 def test_sampler_call_accepts_enforced_tokens() -> None:
-    """Pin that Sampler.forward accepts a SamplingMetadata kwarg that carries
-    enforced_next_token_ids.
-
-    Originating commits: 1c5368212 (field) + c2db96992 (forward() consumption).
-
-    Brittle by design: signature inspection is sensitive to upstream
-    refactors. We want this to fail loudly when upstream renames
-    sampling_metadata or splits Sampler.forward into a multi-stage call;
-    that is the entire point of this contract pin.
-
-    What breaks if this assertion fails:
-        - Sampler.forward signature drifted (upstream renamed
-          sampling_metadata, split forward into multiple methods, etc.).
-        - The rebase author MUST re-validate that c2db96992 still applies
-          and that enforced_next_token_ids is still threaded through.
-    """
+    """Pin the Sampler entry points that carry the residual state."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.v1.sample.sampler")
     cls = getattr(mod, "Sampler", None)
     assert cls is not None, "vllm.v1.sample.sampler.Sampler missing"
     assert hasattr(cls, "forward"), (
-        "Sampler.forward missing — upstream may have renamed to __call__ or "
-        "split the method; commit c2db96992 needs re-port."
+        "Sampler.forward missing — the method may have been renamed to "
+        "__call__ or split; the residual hooks in it need re-porting."
     )
 
-    sig = inspect.signature(cls.forward)
-    params = set(sig.parameters)
-    assert "sampling_metadata" in params, (
-        f"Sampler.forward no longer accepts sampling_metadata; "
-        f"present params = {sorted(params)!r}. "
-        f"Re-port commit c2db96992."
+    forward_params = set(inspect.signature(cls.forward).parameters)
+    assert "sampling_metadata" in forward_params, (
+        f"Sampler.forward no longer takes sampling_metadata; present params "
+        f"= {sorted(forward_params)!r}. The residual reads the per-request "
+        f"mode and the enforced tokens off it."
     )
 
-    # Verify the SamplingMetadata type itself still carries
-    # enforced_next_token_ids — the Sampler reads it via attribute access.
+    sample_params = set(inspect.signature(cls.sample).parameters)
+    assert "need_processed_logprobs" in sample_params, (
+        f"Sampler.sample no longer takes need_processed_logprobs; present "
+        f"params = {sorted(sample_params)!r}. Without it a per-request "
+        f"processed-logprobs override cannot reach the top-k/top-p sampler."
+    )
+
     meta_mod = importlib.import_module("vllm.v1.sample.metadata")
     meta_cls = getattr(meta_mod, "SamplingMetadata", None)
-    assert meta_cls is not None
-    meta_annotations = getattr(meta_cls, "__annotations__", {}) or {}
-    assert "enforced_next_token_ids" in meta_annotations, (
-        "Sampler.forward accepts sampling_metadata but SamplingMetadata "
-        "lacks enforced_next_token_ids — the field was removed or renamed. "
-        "Re-port commits 1c5368212 and c2db96992."
+    assert meta_cls is not None, "vllm.v1.sample.metadata.SamplingMetadata missing"
+    meta_fields = getattr(meta_cls, "__dataclass_fields__", None) or {}
+    assert "enforced_next_token_ids" in meta_fields, (
+        "Sampler.forward takes sampling_metadata but SamplingMetadata lacks "
+        "enforced_next_token_ids — validation replay would be a no-op."
     )
 
-
-# ---------------------------------------------------------------------------- #
-# TopKTopPSampler.forward_* accept need_processed_logprobs
-# (commits 3176a941c + 8d4e322e0)
-# ---------------------------------------------------------------------------- #
+    # The override is a tensor read inside forward(), observable only during
+    # a real forward pass on device tensors, which this contract test does
+    # not run; the source is the only place its removal shows up.
+    forward_src = inspect.getsource(cls.forward)
+    assert "enforced_next_token_ids" in forward_src, (
+        "Sampler.forward does not reference enforced_next_token_ids — the "
+        "post-sampling override was dropped; re-apply the residual patch to "
+        "vllm/v1/sample/sampler.py."
+    )
 
 
 def test_topk_topp_sampler_need_processed_logprobs() -> None:
-    """Pin that all forward_* paths on TopKTopPSampler accept
-    ``need_processed_logprobs`` as a kwarg.
-
-    Originating commits:
-        * 3176a941c — adds the kwarg + .sample() wrapper to forward_native /
-          forward_cuda / forward_cpu / forward_hip.
-        * 8d4e322e0 — extends the same threading to forward_xpu (added by
-          upstream in 0.23).
-
-    Brittle by design: a future upstream refactor that renames any of these
-    forward_* methods (e.g., splitting forward_cuda into forward_cuda_v1) or
-    drops them entirely (e.g., consolidating into a single dispatch fn) MUST
-    fail here.
-
-    What breaks if this assertion fails:
-        - One of the forward paths no longer threads need_processed_logprobs.
-        - On FlashInfer / aiter / XPU fast paths, mixed-mode batches will
-          silently NOT return processed logprobs → PoC v2 cross-validator
-          drift.
-    """
+    """Pin need_processed_logprobs on every TopKTopPSampler forward path."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.v1.sample.ops.topk_topp_sampler")
     cls = getattr(mod, "TopKTopPSampler", None)
     assert cls is not None, (
-        "vllm.v1.sample.ops.topk_topp_sampler.TopKTopPSampler missing — "
-        "module restructured; re-port commits 3176a941c and 8d4e322e0."
+        "vllm.v1.sample.ops.topk_topp_sampler.TopKTopPSampler missing — the "
+        "module was restructured and the residual threading needs re-porting."
     )
 
-    expected_methods = (
+    # Every backend path must accept the kwarg: the dispatch target depends
+    # on the platform, so one missing path is a runtime TypeError there and
+    # nowhere else.
+    for method_name in (
         "forward_native",
         "forward_cuda",
+        "forward_cpu",
         "forward_hip",
         "forward_xpu",
-    )
-    for method_name in expected_methods:
+    ):
         fn = getattr(cls, method_name, None)
         assert fn is not None, (
-            f"TopKTopPSampler.{method_name} missing — upstream may have "
-            f"renamed or consolidated this forward path. Re-port the "
-            f"need_processed_logprobs threading."
+            f"TopKTopPSampler.{method_name} missing — this forward path was "
+            f"renamed or consolidated; re-port the need_processed_logprobs "
+            f"threading to its replacement."
         )
-        sig = inspect.signature(fn)
-        params = set(sig.parameters)
+        params = set(inspect.signature(fn).parameters)
         assert "need_processed_logprobs" in params, (
-            f"TopKTopPSampler.{method_name} no longer accepts "
-            f"need_processed_logprobs kwarg; present params = "
-            f"{sorted(params)!r}. Re-port commits 3176a941c "
-            f"(forward_native/cuda/hip/cpu) and 8d4e322e0 (forward_xpu)."
+            f"TopKTopPSampler.{method_name} no longer takes "
+            f"need_processed_logprobs; present params = {sorted(params)!r}. "
+            f"On this path a mixed-mode batch would silently return raw "
+            f"logprobs where processed ones were requested."
         )
 
-    # Also pin the .sample() wrapper — c2db96992 routes the Sampler through it.
-    assert hasattr(cls, "sample"), (
-        "TopKTopPSampler.sample wrapper missing — Sampler.forward path will "
-        "crash with TypeError on FlashInfer when need_processed_logprobs=True. "
-        "Re-port commit 3176a941c."
+    # sample() is the wrapper Sampler.sample calls: it falls back to
+    # forward_native when the active fast path (FlashInfer, aiter) cannot
+    # produce processed logprobs.
+    sample = getattr(cls, "sample", None)
+    assert sample is not None, (
+        "TopKTopPSampler.sample missing — Sampler.sample would call the "
+        "platform forward directly and raise TypeError on the fast paths "
+        "when processed logprobs are requested."
     )
-
-
-# ---------------------------------------------------------------------------- #
-# InputBatch logprobs_modes dict (commit f2bbeaac8)
-# ---------------------------------------------------------------------------- #
+    sample_params = set(inspect.signature(sample).parameters)
+    assert "need_processed_logprobs" in sample_params, (
+        f"TopKTopPSampler.sample no longer takes need_processed_logprobs; "
+        f"present params = {sorted(sample_params)!r}."
+    )
 
 
 def test_input_batch_logprobs_modes_dict() -> None:
-    """Pin that InputBatch carries the per-request logprobs_modes dict.
-
-    Originating commit: f2bbeaac8 — feat(worker): port InputBatch
-    enforced-tokens and logprobs-mode bookkeeping.
-
-    The patch threads the dict via:
-        * constructor kwarg logprobs_mode_default
-        * instance attribute logprobs_modes (dict[str, str])
-        * instance attribute req_enforced_token_ids (dict[str, list[int] | None])
-        * property batch_logprobs_mode
-
-    We cannot instantiate InputBatch without a full vllm config (it requires
-    KV cache spec, vllm_config, etc.), so we inspect the class source AND
-    the __init__ signature instead.
-
-    What breaks if this assertion fails:
-        - InputBatch was restructured (likely candidate: a new
-          ``vllm.v1.worker.batch_state`` module).
-        - Without these structures, add_request / _make_sampling_metadata
-          cannot populate SamplingMetadata.batch_logprobs_mode /
-          enforced_next_token_ids — PoC v2 silently degrades.
-    """
+    """Pin the InputBatch bookkeeping that feeds SamplingMetadata."""
     pytest.importorskip("vllm")
     mod = importlib.import_module("vllm.v1.worker.gpu_input_batch")
     cls = getattr(mod, "InputBatch", None)
     assert cls is not None, (
-        "vllm.v1.worker.gpu_input_batch.InputBatch missing — module "
-        "restructured. Re-port commit f2bbeaac8 against the new location."
+        "vllm.v1.worker.gpu_input_batch.InputBatch missing — the module was "
+        "restructured; re-apply the residual bookkeeping at its new location."
     )
 
-    # The constructor accepts logprobs_mode_default after our patch.
-    sig = inspect.signature(cls.__init__)
-    init_params = set(sig.parameters)
+    init_params = set(inspect.signature(cls.__init__).parameters)
     assert "logprobs_mode_default" in init_params, (
-        "InputBatch.__init__ no longer accepts logprobs_mode_default kwarg; "
-        f"present params = {sorted(init_params)!r}. Re-port f2bbeaac8."
+        f"InputBatch.__init__ no longer takes logprobs_mode_default; present "
+        f"params = {sorted(init_params)!r}. The model runner passes the "
+        f"deployment-wide mode through it as the per-request fallback."
     )
 
-    # Inspect the class source for the attribute assignments and the
-    # batch_logprobs_mode property name; this catches drift even when
-    # __annotations__ is empty (instance-only attrs).
-    src = inspect.getsource(cls)
-    for needle in (
-        "self.logprobs_modes",
-        "self.req_enforced_token_ids",
-        "batch_logprobs_mode",
-    ):
-        assert needle in src, (
-            f"InputBatch source lacks {needle!r} — commit f2bbeaac8 did not "
-            f"apply (in-fork failure) OR upstream lacks our bookkeeping "
-            f"(drift alert — expected on the upstream-drift job)."
+    mode_attr = inspect.getattr_static(cls, "batch_logprobs_mode", None)
+    assert isinstance(mode_attr, property), (
+        "InputBatch.batch_logprobs_mode is not a property — the aggregation "
+        "of per-request modes into a batch-level mode (including 'mixed') "
+        "is gone; SamplingMetadata.batch_logprobs_mode cannot be filled."
+    )
+
+    assert hasattr(cls, "_build_enforced_tensor"), (
+        "InputBatch._build_enforced_tensor missing — the per-step enforced "
+        "token tensor is no longer built, so validation replay is a no-op."
+    )
+
+    # logprobs_modes and req_enforced_token_ids are instance attributes, and
+    # InputBatch cannot be constructed here (it needs a full VllmConfig, a KV
+    # cache spec and a device), so check the constructor source instead.
+    init_src = inspect.getsource(cls.__init__)
+    for needle in ("self.logprobs_modes", "self.req_enforced_token_ids"):
+        assert needle in init_src, (
+            f"InputBatch.__init__ no longer initializes {needle} — "
+            f"add_request cannot record per-request modes or enforced "
+            f"tokens; re-apply the residual patch to "
+            f"vllm/v1/worker/gpu_input_batch.py."
         )
 
 
-# ---------------------------------------------------------------------------- #
-# Structured-output graceful degradation hook (commit 4996d5af7)
-# ---------------------------------------------------------------------------- #
-
-
 def test_structured_output_graceful_degradation_hook() -> None:
-    """Pin the XgrammarGrammar.accept_tokens / _grammar_failed surface and the
-    StructuredOutputManager bitmask path our 4996d5af7 patch hooks.
-
-    Originating commit: 4996d5af7 — feat(structured-output): graceful
-    degradation on grammar token rejection.
-
-    The patch touches two surfaces:
-        * vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar
-          - adds ``_grammar_failed`` flag
-          - accept_tokens() returns True on rejection (instead of False)
-          - rollback() / fill_bitmask() early-return when _grammar_failed
-        * vllm.v1.structured_output.StructuredOutputManager
-          - replaces a hard assert with a soft warning + bitmask disable
-
-    What breaks if this assertion fails:
-        - The xgrammar backend was relocated (likely candidate:
-          ``vllm.v1.structured_output.xgrammar``) or renamed.
-        - OR the assert that 4996d5af7 softened was already removed upstream
-          (good — softer landing for the next rebase).
-    """
+    """Pin the grammar surfaces the graceful-degradation hook patches."""
     pytest.importorskip("vllm")
 
-    # Backend surface: XgrammarGrammar + _grammar_failed + accept_tokens.
     backend = importlib.import_module("vllm.v1.structured_output.backend_xgrammar")
     grammar_cls = getattr(backend, "XgrammarGrammar", None)
     assert grammar_cls is not None, (
-        "vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar missing — "
-        "backend was relocated or renamed. Re-port commit 4996d5af7."
-    )
-    assert hasattr(grammar_cls, "accept_tokens"), (
-        "XgrammarGrammar.accept_tokens missing — interface drifted. "
-        "Re-port commit 4996d5af7."
-    )
-    # _grammar_failed is the flag our patch adds; if the dataclass field
-    # vanished, the in-fork branch did not apply 4996d5af7.
-    grammar_src = inspect.getsource(grammar_cls)
-    assert "_grammar_failed" in grammar_src, (
-        "_grammar_failed flag missing in XgrammarGrammar — commit 4996d5af7 "
-        "did not apply (in-fork failure) OR upstream lacks the graceful "
-        "degradation hook (drift alert)."
+        "vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar missing "
+        "— the backend was relocated or renamed; re-apply the residual patch "
+        "at its new location."
     )
 
-    # Manager surface: StructuredOutputManager hosts the bitmask path our
-    # patch softened (was a hard assert before 4996d5af7).
+    # Enforced tokens can conflict with the grammar FSM. The hook turns that
+    # rejection into a per-request disable instead of a hard failure, using
+    # a _grammar_failed flag that rollback() and fill_bitmask() also honor.
+    grammar_fields = getattr(grammar_cls, "__dataclass_fields__", None) or {}
+    assert "_grammar_failed" in grammar_fields, (
+        "XgrammarGrammar._grammar_failed missing — a grammar rejection would "
+        "again abort the request instead of degrading gracefully."
+    )
+    assert grammar_fields["_grammar_failed"].default is False, (
+        "XgrammarGrammar._grammar_failed must default to False so grammar "
+        "enforcement stays on until a token is actually rejected."
+    )
+    for method_name in ("accept_tokens", "rollback", "fill_bitmask", "reset"):
+        assert hasattr(grammar_cls, method_name), (
+            f"XgrammarGrammar.{method_name} missing — the grammar interface "
+            f"drifted and the degradation hook no longer covers every entry "
+            f"point that touches the matcher."
+        )
+
     mgr_mod = importlib.import_module("vllm.v1.structured_output")
     mgr_cls = getattr(mgr_mod, "StructuredOutputManager", None)
     assert mgr_cls is not None, (
-        "vllm.v1.structured_output.StructuredOutputManager missing — "
-        "module restructured. Re-port commit 4996d5af7."
+        "vllm.v1.structured_output.StructuredOutputManager missing — the "
+        "module was restructured; re-apply the residual patch."
     )
-    # The patched code path lives inside grammar_bitmask construction; we
-    # don't pin the exact method name (likely internal) — instead pin that
-    # the module still imports the symbol we hook into.
-    mgr_src = inspect.getsource(mgr_cls)
-    # Either our patched code (logger.warning + apply_bitmask = False) OR
-    # the original assert must be present; if neither is, the call site
-    # moved and 4996d5af7 needs re-application.
-    assert "accept_tokens" in mgr_src, (
-        "StructuredOutputManager source no longer references "
-        "grammar.accept_tokens — the patched call site moved. "
-        "Re-port commit 4996d5af7 at the new location."
+    bitmask_fn = getattr(mgr_cls, "grammar_bitmask", None)
+    assert bitmask_fn is not None, (
+        "StructuredOutputManager.grammar_bitmask missing — the patched "
+        "bitmask path moved; find the new call site of accept_tokens."
+    )
+    # The patch replaces a raise at this call site with a warning plus a
+    # bitmask disable. There is no structural way to observe a call site, and
+    # exercising it needs a compiled grammar and a real speculative-decode
+    # batch, so pin it by source.
+    assert "accept_tokens" in inspect.getsource(bitmask_fn), (
+        "StructuredOutputManager.grammar_bitmask no longer calls "
+        "accept_tokens — the patched call site moved; re-apply the residual "
+        "patch to vllm/v1/structured_output/__init__.py at its new location."
     )

--- a/tests/contract/test_sampler_surface.py
+++ b/tests/contract/test_sampler_surface.py
@@ -1,0 +1,376 @@
+"""Drift detector: pin the vLLM sampler private surface that the residual fork patches.
+
+This contract pin lives in the residual fork — its purpose is to catch upstream
+sampler / SamplingParams refactor BEFORE the manual rebase on the next vLLM
+minor. The residual is treated as permanent infrastructure (ADR-0014 in
+mlnode-foundry), so Layer 3 (merging upstream) is off the table; we instead
+keep a daily "is upstream still shaped the way we expect?" signal.
+
+Each test references the originating commit SHA on poc-sampler-residual-v0.23
+and documents what breaks if the assertion fails. The tests are intentionally
+brittle: an upstream rename / refactor MUST surface here so the rebase author
+can re-port the patches before merging the next minor.
+
+Two modes:
+    * "in-fork" job — runs against the residual wheel itself. All assertions
+      MUST pass (otherwise our 6 patches did not apply correctly).
+    * "upstream-drift" job — runs against the unmodified upstream wheel. The
+      patch-added fields (logprobs_mode, enforced_token_ids, etc.) will be
+      MISSING on upstream and these tests will fail. That failure is the
+      ALERT signal — see .github/workflows/contract-tests-residual.yml and
+      REBASE.md for the rebase procedure.
+
+Scope: read-only inspection of vllm modules; NO GPU, NO engine startup, NO
+forward pass. Safe to run in a vanilla ``pip install vllm`` environment.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+# ---------------------------------------------------------------------------- #
+# SamplingParams public dataclass fields (commit 1c5368212)
+# ---------------------------------------------------------------------------- #
+
+
+def test_sampling_params_has_poc_fields() -> None:
+    """Pin per-request SamplingParams fields added by 1c5368212.
+
+    Originating commit: 1c5368212 — feat(sampling): add per-request logprobs_mode
+    and enforced_token_ids fields.
+
+    What breaks if this assertion fails:
+        - On the in-fork job: our patch did not apply to this branch (rebase
+          regression) — fix by re-cherry-picking 1c5368212.
+        - On the upstream-drift job: upstream adopted (good — Layer 3 path
+          reopens) or renamed (bad — rebase author must rename our fields to
+          avoid collision before next-minor cherry-pick).
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.sampling_params")
+    cls = getattr(mod, "SamplingParams", None)
+    assert cls is not None, "vllm.sampling_params.SamplingParams missing"
+
+    annotations = getattr(cls, "__annotations__", {}) or {}
+    # logprobs_mode: per-request override added by 1c5368212.
+    assert "logprobs_mode" in annotations, (
+        "SamplingParams.logprobs_mode missing — commit 1c5368212 did not "
+        "apply (in-fork failure) OR upstream lacks this field (drift "
+        "alert; expected on the upstream-drift job)."
+    )
+    # enforced_token_ids: validation-replay sequence added by 1c5368212.
+    assert "enforced_token_ids" in annotations, (
+        "SamplingParams.enforced_token_ids missing — commit 1c5368212 did "
+        "not apply (in-fork failure) OR upstream lacks this field (drift "
+        "alert; expected on the upstream-drift job)."
+    )
+
+    # Pin the field is wired into the actual constructor surface, not just
+    # carried as a type annotation. msgspec.Struct (current shape of
+    # SamplingParams in vllm 0.23) auto-generates __init__ from
+    # __struct_fields__ but does NOT expose those names via
+    # inspect.signature(cls.__init__) — that returns (self, *args, **kwargs).
+    # Dataclasses use __dataclass_fields__. Try msgspec → dataclass → init
+    # signature in that order so the assertion survives future class-type
+    # flips upstream.
+    field_names = set(getattr(cls, "__struct_fields__", None) or [])
+    if not field_names:
+        field_names = set((getattr(cls, "__dataclass_fields__", None) or {}).keys())
+    if not field_names:
+        field_names = set(inspect.signature(cls.__init__).parameters)
+    for name in ("logprobs_mode", "enforced_token_ids"):
+        assert name in field_names, (
+            f"SamplingParams: {name!r} not in constructor field set "
+            f"(__struct_fields__/__dataclass_fields__/__init__ signature). "
+            f"Annotation present but wiring lost — re-check commit 1c5368212."
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# SamplingMetadata sampler-side fields (commit 1c5368212)
+# ---------------------------------------------------------------------------- #
+
+
+def test_sampling_metadata_has_poc_fields() -> None:
+    """Pin sampler-side bookkeeping fields on SamplingMetadata.
+
+    Originating commit: 1c5368212. Note that ``thinking_budget_state_holder``
+    is an upstream field (added in 0.23 by vllm-project) and coexists with
+    our fields; we do not assert on it here.
+
+    What breaks if this assertion fails:
+        - In-fork: 1c5368212 did not apply (or only partially applied).
+        - Upstream-drift: upstream lacks these fields (expected); when
+          upstream eventually relocates SamplingMetadata into a different
+          module / makes it non-dataclass, this test fires.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.metadata")
+    cls = getattr(mod, "SamplingMetadata", None)
+    assert cls is not None, "vllm.v1.sample.metadata.SamplingMetadata missing"
+
+    annotations = getattr(cls, "__annotations__", {}) or {}
+    # batch_logprobs_mode carries the per-request mode resolution; the
+    # Sampler.forward() priority chain depends on this field name verbatim.
+    assert "batch_logprobs_mode" in annotations, (
+        "SamplingMetadata.batch_logprobs_mode missing — commit 1c5368212 "
+        "did not apply. Sampler.forward() priority resolution will silently "
+        "fall back to deployment default — PoC logprobs requests will be "
+        "wrong."
+    )
+    # enforced_next_token_ids drives the post-sampling override in
+    # Sampler.forward(); without it, validation replay is silently no-op.
+    assert "enforced_next_token_ids" in annotations, (
+        "SamplingMetadata.enforced_next_token_ids missing — commit 1c5368212 "
+        "did not apply. PoC v2 validation replay will silently no-op."
+    )
+
+
+# ---------------------------------------------------------------------------- #
+# Sampler.forward signature accepts sampling_metadata (commits c2db96992 + 1c5368212)
+# ---------------------------------------------------------------------------- #
+
+
+def test_sampler_call_accepts_enforced_tokens() -> None:
+    """Pin that Sampler.forward accepts a SamplingMetadata kwarg that carries
+    enforced_next_token_ids.
+
+    Originating commits: 1c5368212 (field) + c2db96992 (forward() consumption).
+
+    Brittle by design: signature inspection is sensitive to upstream
+    refactors. We want this to fail loudly when upstream renames
+    sampling_metadata or splits Sampler.forward into a multi-stage call;
+    that is the entire point of this contract pin.
+
+    What breaks if this assertion fails:
+        - Sampler.forward signature drifted (upstream renamed
+          sampling_metadata, split forward into multiple methods, etc.).
+        - The rebase author MUST re-validate that c2db96992 still applies
+          and that enforced_next_token_ids is still threaded through.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.sampler")
+    cls = getattr(mod, "Sampler", None)
+    assert cls is not None, "vllm.v1.sample.sampler.Sampler missing"
+    assert hasattr(cls, "forward"), (
+        "Sampler.forward missing — upstream may have renamed to __call__ or "
+        "split the method; commit c2db96992 needs re-port."
+    )
+
+    sig = inspect.signature(cls.forward)
+    params = set(sig.parameters)
+    assert "sampling_metadata" in params, (
+        f"Sampler.forward no longer accepts sampling_metadata; "
+        f"present params = {sorted(params)!r}. "
+        f"Re-port commit c2db96992."
+    )
+
+    # Verify the SamplingMetadata type itself still carries
+    # enforced_next_token_ids — the Sampler reads it via attribute access.
+    meta_mod = importlib.import_module("vllm.v1.sample.metadata")
+    meta_cls = getattr(meta_mod, "SamplingMetadata", None)
+    assert meta_cls is not None
+    meta_annotations = getattr(meta_cls, "__annotations__", {}) or {}
+    assert "enforced_next_token_ids" in meta_annotations, (
+        "Sampler.forward accepts sampling_metadata but SamplingMetadata "
+        "lacks enforced_next_token_ids — the field was removed or renamed. "
+        "Re-port commits 1c5368212 and c2db96992."
+    )
+
+
+# ---------------------------------------------------------------------------- #
+# TopKTopPSampler.forward_* accept need_processed_logprobs
+# (commits 3176a941c + 8d4e322e0)
+# ---------------------------------------------------------------------------- #
+
+
+def test_topk_topp_sampler_need_processed_logprobs() -> None:
+    """Pin that all forward_* paths on TopKTopPSampler accept
+    ``need_processed_logprobs`` as a kwarg.
+
+    Originating commits:
+        * 3176a941c — adds the kwarg + .sample() wrapper to forward_native /
+          forward_cuda / forward_cpu / forward_hip.
+        * 8d4e322e0 — extends the same threading to forward_xpu (added by
+          upstream in 0.23).
+
+    Brittle by design: a future upstream refactor that renames any of these
+    forward_* methods (e.g., splitting forward_cuda into forward_cuda_v1) or
+    drops them entirely (e.g., consolidating into a single dispatch fn) MUST
+    fail here.
+
+    What breaks if this assertion fails:
+        - One of the forward paths no longer threads need_processed_logprobs.
+        - On FlashInfer / aiter / XPU fast paths, mixed-mode batches will
+          silently NOT return processed logprobs → PoC v2 cross-validator
+          drift.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.ops.topk_topp_sampler")
+    cls = getattr(mod, "TopKTopPSampler", None)
+    assert cls is not None, (
+        "vllm.v1.sample.ops.topk_topp_sampler.TopKTopPSampler missing — "
+        "module restructured; re-port commits 3176a941c and 8d4e322e0."
+    )
+
+    expected_methods = (
+        "forward_native",
+        "forward_cuda",
+        "forward_hip",
+        "forward_xpu",
+    )
+    for method_name in expected_methods:
+        fn = getattr(cls, method_name, None)
+        assert fn is not None, (
+            f"TopKTopPSampler.{method_name} missing — upstream may have "
+            f"renamed or consolidated this forward path. Re-port the "
+            f"need_processed_logprobs threading."
+        )
+        sig = inspect.signature(fn)
+        params = set(sig.parameters)
+        assert "need_processed_logprobs" in params, (
+            f"TopKTopPSampler.{method_name} no longer accepts "
+            f"need_processed_logprobs kwarg; present params = "
+            f"{sorted(params)!r}. Re-port commits 3176a941c "
+            f"(forward_native/cuda/hip/cpu) and 8d4e322e0 (forward_xpu)."
+        )
+
+    # Also pin the .sample() wrapper — c2db96992 routes the Sampler through it.
+    assert hasattr(cls, "sample"), (
+        "TopKTopPSampler.sample wrapper missing — Sampler.forward path will "
+        "crash with TypeError on FlashInfer when need_processed_logprobs=True. "
+        "Re-port commit 3176a941c."
+    )
+
+
+# ---------------------------------------------------------------------------- #
+# InputBatch logprobs_modes dict (commit f2bbeaac8)
+# ---------------------------------------------------------------------------- #
+
+
+def test_input_batch_logprobs_modes_dict() -> None:
+    """Pin that InputBatch carries the per-request logprobs_modes dict.
+
+    Originating commit: f2bbeaac8 — feat(worker): port InputBatch
+    enforced-tokens and logprobs-mode bookkeeping.
+
+    The patch threads the dict via:
+        * constructor kwarg logprobs_mode_default
+        * instance attribute logprobs_modes (dict[str, str])
+        * instance attribute req_enforced_token_ids (dict[str, list[int] | None])
+        * property batch_logprobs_mode
+
+    We cannot instantiate InputBatch without a full vllm config (it requires
+    KV cache spec, vllm_config, etc.), so we inspect the class source AND
+    the __init__ signature instead.
+
+    What breaks if this assertion fails:
+        - InputBatch was restructured (likely candidate: a new
+          ``vllm.v1.worker.batch_state`` module).
+        - Without these structures, add_request / _make_sampling_metadata
+          cannot populate SamplingMetadata.batch_logprobs_mode /
+          enforced_next_token_ids — PoC v2 silently degrades.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.worker.gpu_input_batch")
+    cls = getattr(mod, "InputBatch", None)
+    assert cls is not None, (
+        "vllm.v1.worker.gpu_input_batch.InputBatch missing — module "
+        "restructured. Re-port commit f2bbeaac8 against the new location."
+    )
+
+    # The constructor accepts logprobs_mode_default after our patch.
+    sig = inspect.signature(cls.__init__)
+    init_params = set(sig.parameters)
+    assert "logprobs_mode_default" in init_params, (
+        "InputBatch.__init__ no longer accepts logprobs_mode_default kwarg; "
+        f"present params = {sorted(init_params)!r}. Re-port f2bbeaac8."
+    )
+
+    # Inspect the class source for the attribute assignments and the
+    # batch_logprobs_mode property name; this catches drift even when
+    # __annotations__ is empty (instance-only attrs).
+    src = inspect.getsource(cls)
+    for needle in (
+        "self.logprobs_modes",
+        "self.req_enforced_token_ids",
+        "batch_logprobs_mode",
+    ):
+        assert needle in src, (
+            f"InputBatch source lacks {needle!r} — commit f2bbeaac8 did not "
+            f"apply (in-fork failure) OR upstream lacks our bookkeeping "
+            f"(drift alert — expected on the upstream-drift job)."
+        )
+
+
+# ---------------------------------------------------------------------------- #
+# Structured-output graceful degradation hook (commit 4996d5af7)
+# ---------------------------------------------------------------------------- #
+
+
+def test_structured_output_graceful_degradation_hook() -> None:
+    """Pin the XgrammarGrammar.accept_tokens / _grammar_failed surface and the
+    StructuredOutputManager bitmask path our 4996d5af7 patch hooks.
+
+    Originating commit: 4996d5af7 — feat(structured-output): graceful
+    degradation on grammar token rejection.
+
+    The patch touches two surfaces:
+        * vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar
+          - adds ``_grammar_failed`` flag
+          - accept_tokens() returns True on rejection (instead of False)
+          - rollback() / fill_bitmask() early-return when _grammar_failed
+        * vllm.v1.structured_output.StructuredOutputManager
+          - replaces a hard assert with a soft warning + bitmask disable
+
+    What breaks if this assertion fails:
+        - The xgrammar backend was relocated (likely candidate:
+          ``vllm.v1.structured_output.xgrammar``) or renamed.
+        - OR the assert that 4996d5af7 softened was already removed upstream
+          (good — softer landing for the next rebase).
+    """
+    pytest.importorskip("vllm")
+
+    # Backend surface: XgrammarGrammar + _grammar_failed + accept_tokens.
+    backend = importlib.import_module("vllm.v1.structured_output.backend_xgrammar")
+    grammar_cls = getattr(backend, "XgrammarGrammar", None)
+    assert grammar_cls is not None, (
+        "vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar missing — "
+        "backend was relocated or renamed. Re-port commit 4996d5af7."
+    )
+    assert hasattr(grammar_cls, "accept_tokens"), (
+        "XgrammarGrammar.accept_tokens missing — interface drifted. "
+        "Re-port commit 4996d5af7."
+    )
+    # _grammar_failed is the flag our patch adds; if the dataclass field
+    # vanished, the in-fork branch did not apply 4996d5af7.
+    grammar_src = inspect.getsource(grammar_cls)
+    assert "_grammar_failed" in grammar_src, (
+        "_grammar_failed flag missing in XgrammarGrammar — commit 4996d5af7 "
+        "did not apply (in-fork failure) OR upstream lacks the graceful "
+        "degradation hook (drift alert)."
+    )
+
+    # Manager surface: StructuredOutputManager hosts the bitmask path our
+    # patch softened (was a hard assert before 4996d5af7).
+    mgr_mod = importlib.import_module("vllm.v1.structured_output")
+    mgr_cls = getattr(mgr_mod, "StructuredOutputManager", None)
+    assert mgr_cls is not None, (
+        "vllm.v1.structured_output.StructuredOutputManager missing — "
+        "module restructured. Re-port commit 4996d5af7."
+    )
+    # The patched code path lives inside grammar_bitmask construction; we
+    # don't pin the exact method name (likely internal) — instead pin that
+    # the module still imports the symbol we hook into.
+    mgr_src = inspect.getsource(mgr_cls)
+    # Either our patched code (logger.warning + apply_bitmask = False) OR
+    # the original assert must be present; if neither is, the call site
+    # moved and 4996d5af7 needs re-application.
+    assert "accept_tokens" in mgr_src, (
+        "StructuredOutputManager source no longer references "
+        "grammar.accept_tokens — the patched call site moved. "
+        "Re-port commit 4996d5af7 at the new location."
+    )

--- a/tests/contract/test_v2_runner_containment.py
+++ b/tests/contract/test_v2_runner_containment.py
@@ -1,22 +1,22 @@
-"""Drift detector: pin the V2-model-runner containment surface (row 9).
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Contract tests for the V2-model-runner containment the residual relies on.
 
-vLLM 0.25 ships a parallel V2 GPU model runner (``vllm/v1/worker/gpu/``) with
-its own InputBatch and sampler stack. It BYPASSES the residual sampler rows
+vLLM ships a second GPU model runner (``vllm/v1/worker/gpu/``) with its own
+InputBatch and sampler stack, which does not carry the residual sampler hooks
 (per-request ``logprobs_mode``, ``enforced_token_ids``,
-``need_processed_logprobs``): a request routed through V2 samples without any
-of the PoC validation surface, silently.
+``need_processed_logprobs``). A request routed through it samples without any
+of that, and without an error. Containment is therefore an env pin,
+``VLLM_USE_V2_MODEL_RUNNER=0``, baked into docker/Dockerfile.gonka-poc.
 
-Containment = the image bakes ``VLLM_USE_V2_MODEL_RUNNER=0``
-(Dockerfile.quick). This contract pins the two assumptions that make the pin
-effective:
+The pin only works while two assumptions hold:
 
-1. The env knob still exists upstream (renamed/removed => the pin is a silent
-   no-op and a future default flip re-exposes V2).
-2. The V2 runner still carries its own sampler module (if upstream unifies the
-   stacks, this contract alerts so the rows can be re-evaluated — possibly the
-   pin becomes unnecessary, possibly the rows need a V2 port).
+1. the env knob still exists — once renamed or dropped, the pin is a silent
+   no-op and a future flip of the default re-exposes the V2 runner;
+2. the V2 runner still has its own sampler stack — once the stacks are
+   unified, either the pin is unnecessary or the hooks need a V2 port.
 
-Scope: read-only inspection; NO GPU, NO engine startup.
+Scope: read-only inspection. No GPU, no engine startup.
 """
 
 from __future__ import annotations
@@ -27,28 +27,29 @@ import pytest
 
 
 def test_v2_runner_env_knob_exists() -> None:
-    """VLLM_USE_V2_MODEL_RUNNER must still be a recognized env knob."""
+    """Require VLLM_USE_V2_MODEL_RUNNER to still be a recognized env knob."""
     pytest.importorskip("vllm")
     envs = importlib.import_module("vllm.envs")
     assert "VLLM_USE_V2_MODEL_RUNNER" in getattr(envs, "environment_variables", {}), (
         "VLLM_USE_V2_MODEL_RUNNER is gone from vllm.envs — the baked "
-        "Dockerfile pin is a silent no-op. Find the new V2-runner switch and "
-        "re-pin (row 9), or confirm the V2 runner was removed/unified."
+        "container pin no longer selects anything. Find the current "
+        "V2-runner switch and re-pin, or confirm the V2 runner was removed."
     )
 
 
 def test_v2_runner_still_separate_sampler() -> None:
-    """The V2 runner keeps its own sampler stack (the reason the pin exists)."""
+    """Require the V2 runner to keep the separate sampler stack it is pinned for."""
     pytest.importorskip("vllm")
     try:
         v2_sampler = importlib.import_module("vllm.v1.worker.gpu.sample.sampler")
     except ModuleNotFoundError:
         pytest.skip(
-            "V2 runner sampler module gone — stacks may have been unified; "
-            "re-evaluate row 9 (pin may be droppable, or rows need a V2 port)."
+            "V2 runner sampler module is gone — the stacks may have been "
+            "unified; re-evaluate whether the env pin is still needed."
         )
     v1_sampler = importlib.import_module("vllm.v1.sample.sampler")
     assert v2_sampler.__name__ != v1_sampler.__name__, (
-        "V2 sampler resolves to the V1 module — unification happened; "
-        "re-evaluate row 9."
+        "The V2 sampler resolves to the V1 module — unification happened, so "
+        "re-evaluate the containment pin and whether the residual hooks now "
+        "cover both runners."
     )

--- a/tests/contract/test_v2_runner_containment.py
+++ b/tests/contract/test_v2_runner_containment.py
@@ -1,0 +1,54 @@
+"""Drift detector: pin the V2-model-runner containment surface (row 9).
+
+vLLM 0.25 ships a parallel V2 GPU model runner (``vllm/v1/worker/gpu/``) with
+its own InputBatch and sampler stack. It BYPASSES the residual sampler rows
+(per-request ``logprobs_mode``, ``enforced_token_ids``,
+``need_processed_logprobs``): a request routed through V2 samples without any
+of the PoC validation surface, silently.
+
+Containment = the image bakes ``VLLM_USE_V2_MODEL_RUNNER=0``
+(Dockerfile.quick). This contract pins the two assumptions that make the pin
+effective:
+
+1. The env knob still exists upstream (renamed/removed => the pin is a silent
+   no-op and a future default flip re-exposes V2).
+2. The V2 runner still carries its own sampler module (if upstream unifies the
+   stacks, this contract alerts so the rows can be re-evaluated — possibly the
+   pin becomes unnecessary, possibly the rows need a V2 port).
+
+Scope: read-only inspection; NO GPU, NO engine startup.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_v2_runner_env_knob_exists() -> None:
+    """VLLM_USE_V2_MODEL_RUNNER must still be a recognized env knob."""
+    pytest.importorskip("vllm")
+    envs = importlib.import_module("vllm.envs")
+    assert "VLLM_USE_V2_MODEL_RUNNER" in getattr(envs, "environment_variables", {}), (
+        "VLLM_USE_V2_MODEL_RUNNER is gone from vllm.envs — the baked "
+        "Dockerfile pin is a silent no-op. Find the new V2-runner switch and "
+        "re-pin (row 9), or confirm the V2 runner was removed/unified."
+    )
+
+
+def test_v2_runner_still_separate_sampler() -> None:
+    """The V2 runner keeps its own sampler stack (the reason the pin exists)."""
+    pytest.importorskip("vllm")
+    try:
+        v2_sampler = importlib.import_module("vllm.v1.worker.gpu.sample.sampler")
+    except ModuleNotFoundError:
+        pytest.skip(
+            "V2 runner sampler module gone — stacks may have been unified; "
+            "re-evaluate row 9 (pin may be droppable, or rows need a V2 port)."
+        )
+    v1_sampler = importlib.import_module("vllm.v1.sample.sampler")
+    assert v2_sampler.__name__ != v1_sampler.__name__, (
+        "V2 sampler resolves to the V1 module — unification happened; "
+        "re-evaluate row 9."
+    )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -496,7 +496,7 @@ class GroupCoordinator:
         self.mq_broadcaster: MessageQueue | None = None
         if use_message_queue_broadcaster and self.world_size > 1:
             self.mq_broadcaster = MessageQueue.create_from_process_group(
-                self.cpu_group, 1 << 22, 6
+                self.cpu_group, 1 << 22, 64
             )
 
         # TODO(#35915): Remove is_tpu() check once tpu_inference
@@ -541,7 +541,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             writer_rank=writer_rank,
             external_writer_handle=external_writer_handle,
             blocking=blocking,
@@ -555,7 +555,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group_single_reader(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             reader_rank=self.ranks[reader_rank_in_group],
             blocking=blocking,
         )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -496,7 +496,7 @@ class GroupCoordinator:
         self.mq_broadcaster: MessageQueue | None = None
         if use_message_queue_broadcaster and self.world_size > 1:
             self.mq_broadcaster = MessageQueue.create_from_process_group(
-                self.cpu_group, 1 << 22, 64
+                self.cpu_group, 1 << 22, envs.VLLM_MQ_MAX_CHUNKS or 6
             )
 
         # TODO(#35915): Remove is_tpu() check once tpu_inference
@@ -541,7 +541,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group(
             self.cpu_group,
             1 << 22,
-            64,
+            envs.VLLM_MQ_MAX_CHUNKS or 6,
             writer_rank=writer_rank,
             external_writer_handle=external_writer_handle,
             blocking=blocking,
@@ -555,7 +555,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group_single_reader(
             self.cpu_group,
             1 << 22,
-            64,
+            envs.VLLM_MQ_MAX_CHUNKS or 6,
             reader_rank=self.ranks[reader_rank_in_group],
             blocking=blocking,
         )

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -256,18 +256,7 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
         tokenizer: TokenizerLike | None,
         return_as_token_id: bool = False,
     ) -> str:
-        if return_as_token_id:
-            return format_token_id_placeholder(token_id)
-
-        if logprob.decoded_token is not None:
-            return logprob.decoded_token
-
-        if tokenizer is None:
-            raise ValueError(
-                "Unable to get tokenizer because `skip_tokenizer_init=True`"
-            )
-
-        return tokenizer.decode([token_id])
+        return str(token_id)
 
 
 def format_token_id_placeholder(token_id: int) -> str:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -47,6 +47,7 @@ from vllm.sampling_params import (
     ThinkingTokenBudget,
 )
 from vllm.utils import random_uuid
+from vllm.validation import EnforcedTokens
 
 logger = init_logger(__name__)
 
@@ -269,6 +270,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     prompt_logprobs: int | None = None
     allowed_token_ids: list[int] | None = None
     bad_words: list[str] = Field(default_factory=list)
+    logprobs_mode: Literal["raw_logprobs", "processed_logprobs"] | None = None
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]
@@ -437,6 +439,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",
+    )
+
+    enforced_tokens: EnforcedTokens | None = Field(
+        default=None,
+        description="Enforced token sequence for Gonka validation replay.",
+    )
+    enforced_str: str | None = Field(
+        default=None,
+        description="Enforced output string for Gonka validation replay.",
     )
 
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
@@ -679,6 +690,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             stop_token_ids=stop_token_ids,
             logprobs=self.top_logprobs if self.logprobs else None,
             prompt_logprobs=prompt_logprobs,
+            logprobs_mode=self.logprobs_mode,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens,
             min_tokens=self.min_tokens,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -66,6 +66,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
 from vllm.utils.mistral import is_mistral_tool_parser
+from vllm.validation import validate_enforced_token_ids
 
 logger = init_logger(__name__)
 
@@ -329,8 +330,15 @@ class OpenAIServingChat(GenerateBaseServing):
                     enforced_ids = request.enforced_tokens.get_enforced_token_ids()
 
                 if enforced_ids:
-                    if enforced_ids[-1] != tokenizer.eos_token_id:
-                        enforced_ids.append(tokenizer.eos_token_id)
+                    # Untrusted input: these ids go straight into an embedding
+                    # lookup, where an out-of-range value aborts the worker
+                    # instead of failing the request.
+                    validate_enforced_token_ids(
+                        enforced_ids, self.model_config.get_vocab_size()
+                    )
+                    eos_token_id = tokenizer.eos_token_id
+                    if eos_token_id is not None and enforced_ids[-1] != eos_token_id:
+                        enforced_ids.append(eos_token_id)
                     sampling_params.enforced_token_ids = enforced_ids
                     if (
                         sampling_params.logprobs_mode is None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -319,6 +319,26 @@ class OpenAIServingChat(GenerateBaseServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                enforced_ids: list[int] | None = None
+                if request.enforced_str:
+                    enforced_ids = tokenizer.encode(
+                        request.enforced_str, add_special_tokens=False
+                    )
+                elif request.enforced_tokens:
+                    request.enforced_tokens.encode(tokenizer)
+                    enforced_ids = request.enforced_tokens.get_enforced_token_ids()
+
+                if enforced_ids:
+                    if enforced_ids[-1] != tokenizer.eos_token_id:
+                        enforced_ids.append(tokenizer.eos_token_id)
+                    sampling_params.enforced_token_ids = enforced_ids
+                    if (
+                        sampling_params.logprobs_mode is None
+                        and request.enforced_tokens is not None
+                    ):
+                        detected = request.enforced_tokens.detect_logprobs_mode()
+                        if detected:
+                            sampling_params.logprobs_mode = detected
 
             self._log_inputs(
                 sub_request_id,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -211,6 +211,7 @@ if TYPE_CHECKING:
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_ENFORCE_STRICT_TOOL_CALLING: bool = True
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
+    VLLM_MQ_MAX_CHUNKS: int | None = None
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: int = 5
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
@@ -1624,6 +1625,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # processes via zmq.
     "VLLM_MQ_MAX_CHUNK_BYTES_MB": lambda: int(
         os.getenv("VLLM_MQ_MAX_CHUNK_BYTES_MB", "16")
+    ),
+    # Number of chunks in a shared-memory message-queue ring. None keeps each
+    # call site's own default. Raise it when a transiently slow reader starves
+    # the writer under burst load ("No available shared memory broadcast
+    # block"); the cost is linear in /dev/shm, per ring, per engine.
+    "VLLM_MQ_MAX_CHUNKS": lambda: (
+        int(os.environ["VLLM_MQ_MAX_CHUNKS"])
+        if "VLLM_MQ_MAX_CHUNKS" in os.environ
+        else None
     ),
     # Timeout in seconds for execute_model RPC calls in multiprocessing
     # executor (only applies when TP > 1).

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -281,6 +281,10 @@ class SamplingParams(
     When set, logprobs for exactly these token IDs will be returned,
     in addition to the sampled token. This is useful for scoring tasks
     where you want to compare probabilities of specific label tokens."""
+    logprobs_mode: str | None = None
+    """Per-request logprobs mode override for sampled-token logprobs.
+    Accepted values: 'raw_logprobs', 'processed_logprobs', or None
+    (use deployment-level --logprobs-mode default)."""
     flat_logprobs: bool = False
     """Whether to return logprobs in flatten format (i.e. FlatLogprob)
     for better performance.
@@ -340,6 +344,11 @@ class SamplingParams(
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
 
+    enforced_token_ids: list[int] | None = None
+    """Enforced next-token IDs for gonka-style validation replay. When set,
+    the sampler will force the generated token at each step to match this
+    sequence, regardless of the underlying logits."""
+
     skip_reading_prefix_cache: bool | None = None
     thinking_token_budget: int | None = None
     """Maximum number of tokens allowed for thinking operations."""
@@ -366,6 +375,7 @@ class SamplingParams(
         stop: str | list[str] | None = None,
         stop_token_ids: list[int] | None = None,
         bad_words: list[str] | None = None,
+        enforced_token_ids: list[int] | None = None,
         thinking_token_budget: int | None = None,
         include_stop_str_in_output: bool = False,
         ignore_eos: bool = False,
@@ -373,6 +383,7 @@ class SamplingParams(
         min_tokens: int = 0,
         logprobs: int | None = None,
         prompt_logprobs: int | None = None,
+        logprobs_mode: str | None = None,
         detokenize: bool = True,
         skip_special_tokens: bool = True,
         spaces_between_special_tokens: bool = True,
@@ -426,6 +437,7 @@ class SamplingParams(
             stop=stop,
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,
+            enforced_token_ids=enforced_token_ids,
             thinking_token_budget=thinking_token_budget,
             include_stop_str_in_output=include_stop_str_in_output,
             ignore_eos=ignore_eos,
@@ -433,6 +445,7 @@ class SamplingParams(
             min_tokens=min_tokens,
             logprobs=logprobs,
             prompt_logprobs=prompt_logprobs,
+            logprobs_mode=logprobs_mode,
             detokenize=detokenize,
             skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens,
@@ -599,6 +612,16 @@ class SamplingParams(
                 f"{self.prompt_logprobs}.",
                 parameter="prompt_logprobs",
                 value=self.prompt_logprobs,
+            )
+        if self.logprobs_mode is not None and self.logprobs_mode not in (
+            "raw_logprobs",
+            "processed_logprobs",
+        ):
+            raise VLLMValidationError(
+                "logprobs_mode must be 'raw_logprobs', 'processed_logprobs', "
+                f"or None, got {self.logprobs_mode!r}.",
+                parameter="logprobs_mode",
+                value=self.logprobs_mode,
             )
         assert isinstance(self.stop_token_ids, list)
         if not all(isinstance(st_id, int) for st_id in self.stop_token_ids):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -152,13 +152,19 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
-                # A briefly-slow TP reader starves the writer (EngineCore)
-                # under burst load, surfacing as "No available shared memory
-                # broadcast block" stalls. Raising the ring count buys slack.
-                # Off by default: each ring costs
-                # max_chunks x (max_chunk_bytes + metadata) of /dev/shm, so at
-                # the 16 MiB default a ring of 64 is ~1 GiB -- and this is one
-                # ring of several per engine. Opt in with VLLM_MQ_MAX_CHUNKS.
+                # Sized by VLLM_MQ_MAX_CHUNKS. Raising it is what stopped a
+                # large MoE model (Kimi-K2.6, TP=4) from dying under sustained
+                # production load: the writer here is EngineCore, and when a
+                # reader is briefly slow to drain, the writer blocks
+                # ("No available shared memory broadcast block"), the step
+                # stalls, and the engine is eventually declared dead. Deeper
+                # rings absorb the stall. Treat it as a mitigation rather than
+                # a cure -- stalls were still seen near idle afterwards.
+                #
+                # Off by default because each ring costs
+                # max_chunks x (max_chunk_bytes + metadata) of /dev/shm: at the
+                # 16 MiB default a ring of 64 is ~1 GiB, and an engine has
+                # several, so this cannot be imposed on every deployment.
                 max_chunks=envs.VLLM_MQ_MAX_CHUNKS or 10,
                 connect_ip=mq_connect_ip,
             )

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -152,10 +152,14 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
-                # 64 (default 10): a briefly-slow TP reader starves the writer
-                # (EngineCore) under burst load -> "No available shared memory
-                # broadcast block" engine stalls. Costs 64 x 16 MiB /dev/shm.
-                max_chunks=64,
+                # A briefly-slow TP reader starves the writer (EngineCore)
+                # under burst load, surfacing as "No available shared memory
+                # broadcast block" stalls. Raising the ring count buys slack.
+                # Off by default: each ring costs
+                # max_chunks x (max_chunk_bytes + metadata) of /dev/shm, so at
+                # the 16 MiB default a ring of 64 is ~1 GiB -- and this is one
+                # ring of several per engine. Opt in with VLLM_MQ_MAX_CHUNKS.
+                max_chunks=envs.VLLM_MQ_MAX_CHUNKS or 10,
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -152,6 +152,10 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
+                # 64 (default 10): a briefly-slow TP reader starves the writer
+                # (EngineCore) under burst load -> "No available shared memory
+                # broadcast block" engine stalls. Costs 64 x 16 MiB /dev/shm.
+                max_chunks=64,
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -343,6 +343,10 @@ class RayExecutorV2(MultiprocExecutor):
             self.world_size,
             n_local,
             max_chunk_bytes=max_chunk_bytes,
+            # Same knob as the multiproc executor: this ring has the same
+            # writer-starvation failure mode, so it must honour the same
+            # override rather than silently keeping the smaller default.
+            max_chunks=envs.VLLM_MQ_MAX_CHUNKS or 10,
             connect_ip=ray.util.get_node_ip_address(),
         )
         scheduler_output_handle = self.rpc_broadcast_mq.export_handle()

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -48,8 +48,20 @@ class SamplingMetadata:
     # req_index -> list of token IDs to get logprobs for
     logprob_token_ids: dict[int, list[int]] | None = None
 
+    # Per-request logprobs mode: "raw_logprobs", "processed_logprobs",
+    # "mixed", or None (no sampled-token logprobs requested).
+    batch_logprobs_mode: str | None = None
+
+    # Per-row bool mask: True = processed, False = raw.
+    # Only materialized when batch_logprobs_mode == "mixed".
+    logprobs_is_processed: torch.Tensor | None = None
+
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
     # thinking-token-budget logits (holder may exist with an empty tracking set).
     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
+
+    # Enforced next token ids for validation replay (gonka PoC).
+    # Shape [num_reqs], -1 means no enforcement for that request.
+    enforced_next_token_ids: torch.Tensor | None = None

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -120,12 +120,43 @@ class TopKTopPSampler(nn.Module):
         else:
             self.forward = self.forward_native
 
+    def sample(
+        self,
+        logits: torch.Tensor,
+        generators: dict[int, torch.Generator],
+        k: torch.Tensor | None,
+        p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Sample with optional processed logprobs.
+
+        When need_processed_logprobs is True and the active forward
+        implementation cannot produce them (FlashInfer / aiter fast
+        paths), this falls back to forward_native transparently.
+        """
+        if need_processed_logprobs and self.forward is not self.forward_native:
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=True,
+            )
+        return self.forward(
+            logits,
+            generators,
+            k,
+            p,
+            need_processed_logprobs=need_processed_logprobs,
+        )
+
     def forward_native(
         self,
         logits: torch.Tensor,
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling.
@@ -136,7 +167,7 @@ class TopKTopPSampler(nn.Module):
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
             logits_to_return = logits
-        elif self.logprobs_mode == "processed_logprobs":
+        elif self.logprobs_mode == "processed_logprobs" or need_processed_logprobs:
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         return (
@@ -150,21 +181,35 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """More optimized implementation for top-k and top-p sampling."""
         # Fall back to the PyTorch-native path when FlashInfer has nothing
-        # to do (no top-k / top-p filter) or when per-request generators
-        # are present (unsupported by FlashInfer 0.2.3+).
-        if (k is None and p is None) or generators:
+        # to do (no top-k / top-p filter), when per-request generators
+        # are present (unsupported by FlashInfer 0.2.3+), or when the
+        # caller requested processed logprobs (FlashInfer can't expose them).
+        if (k is None and p is None) or generators or need_processed_logprobs:
             if generators:
                 logger.debug_once(
                     "FlashInfer 0.2.3+ does not support "
                     "per-request generators. Falling back to "
                     "PyTorch-native implementation."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         if self.use_fp64_gumbel:
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         assert self.logprobs_mode not in ("processed_logits", "processed_logprobs"), (
             "FlashInfer does not support returning logits/logprobs"
         )
@@ -179,6 +224,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling for CPU.
@@ -189,7 +235,7 @@ class TopKTopPSampler(nn.Module):
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
             logits_to_return = logits
-        elif self.logprobs_mode == "processed_logprobs":
+        elif self.logprobs_mode == "processed_logprobs" or need_processed_logprobs:
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
 
         if len(generators) != logits.shape[0] and not self.use_fp64_gumbel:
@@ -225,17 +271,30 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Optimized ROCm/aiter path (same structure as forward_cuda)."""
-        if (k is None and p is None) or generators:
+        if (k is None and p is None) or generators or need_processed_logprobs:
             if generators:
                 logger.warning_once(
                     "aiter sampler does not support per-request generators; "
                     "falling back to PyTorch-native."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         if self.use_fp64_gumbel:
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         assert self.logprobs_mode not in (
             "processed_logits",
             "processed_logprobs",
@@ -288,14 +347,22 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if generators:
-            logger.warning_once(
-                "xpu kernel topk_topp_sampler does not support "
-                "per-request generators. Falling back to "
-                "PyTorch-native implementation."
+        if generators or need_processed_logprobs:
+            if generators:
+                logger.warning_once(
+                    "xpu kernel topk_topp_sampler does not support "
+                    "per-request generators. Falling back to "
+                    "PyTorch-native implementation."
+                )
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
             )
-            return self.forward_native(logits, generators, k, p)
         random_sampled = torch.empty(
             logits.shape[0], dtype=torch.int64, device=logits.device
         )

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -76,17 +76,32 @@ class Sampler(nn.Module):
         predict_bonus_token: bool = False,
         logprobs_mode_override: LogprobsMode | None = None,
     ) -> SamplerOutput:
-        logprobs_mode = logprobs_mode_override or self.logprobs_mode
+        num_logprobs = sampling_metadata.max_num_logprobs
+
+        # Determine effective logprobs mode.
+        # Priority: logprobs_mode_override (RejectionSampler) >
+        #           batch_logprobs_mode (per-request) > deployment default.
+        if logprobs_mode_override is not None:
+            effective_mode = logprobs_mode_override
+            is_mixed = False
+        else:
+            batch_mode = sampling_metadata.batch_logprobs_mode
+            if batch_mode is not None and batch_mode != self.logprobs_mode:
+                effective_mode = batch_mode
+                is_mixed = batch_mode == "mixed"
+            else:
+                effective_mode = self.logprobs_mode
+                is_mixed = False
+
         # NOTE(woosuk): Use the original logits (before any penalties or
         # temperature scaling) for the top-k logprobs.
         # This is different from the V0 sampler, which uses the logits that
         # is used for sampling (after penalties and temperature scaling).
-        num_logprobs = sampling_metadata.max_num_logprobs
         raw_logprobs: torch.Tensor | None = None
         if num_logprobs is not None or sampling_metadata.logprob_token_ids:
-            if logprobs_mode == "raw_logprobs":
+            if effective_mode in ("raw_logprobs", "mixed"):
                 raw_logprobs = self.compute_logprobs(logits)
-            elif logprobs_mode == "raw_logits":
+            elif effective_mode == "raw_logits":
                 if logits.dtype == torch.float32:
                     raw_logprobs = logits.clone()
                 else:
@@ -98,15 +113,45 @@ class Sampler(nn.Module):
         logits = self.apply_logits_processors(
             logits, sampling_metadata, predict_bonus_token
         )
+
+        need_processed = num_logprobs is not None and effective_mode in (
+            "processed_logprobs",
+            "processed_logits",
+            "mixed",
+        )
         # Sample the next token.
-        sampled, processed_logprobs = self.sample(logits, sampling_metadata)
-        if processed_logprobs is not None:
+        sampled, processed_logprobs = self.sample(
+            logits,
+            sampling_metadata,
+            logprobs_mode_override=logprobs_mode_override,
+            need_processed_logprobs=need_processed,
+        )
+
+        # For homogeneous batches, processed logprobs replace raw when the
+        # effective mode wants processed output. When a per-request override
+        # selects raw_logprobs (or raw_logits), keep the raw values computed
+        # earlier and discard the processed logprobs the sampler produced as
+        # a side-effect of the deployment default.
+        if (
+            not is_mixed
+            and processed_logprobs is not None
+            and effective_mode not in ("raw_logprobs", "raw_logits")
+        ):
             raw_logprobs = processed_logprobs
+
         # Convert sampled token ids to int64 (long) type to ensure compatibility
         # with subsequent operations that may use these values as indices.
-        # This conversion is necessary because FlashInfer sampling operations
-        # return int32 (while PyTorch argmax and topk return int64).
         sampled = sampled.long()
+
+        # Override with enforced token ids where specified (gonka PoC v2).
+        # NOTE: this is post-sampling so logprobs are still computed against
+        # the model's actual distribution, not the enforced token. That is
+        # exactly what PoC validation needs to compare against the origin.
+        if sampling_metadata.enforced_next_token_ids is not None:
+            enforced = sampling_metadata.enforced_next_token_ids
+            mask = enforced != -1
+            if mask.any():
+                sampled[mask] = enforced[mask]
 
         # Handle logprob_token_ids if specified (more efficient than full vocab)
         # This is used by generative_scoring API to get logprobs for specific tokens
@@ -119,16 +164,52 @@ class Sampler(nn.Module):
 
         if num_logprobs is None:
             logprobs_tensors = logprob_token_ids_tensors
-        elif num_logprobs == -1:
-            # Return the full unsorted and unranked logprobs.
-            logprobs_tensors = LogprobsTensors(
-                torch.empty(0), raw_logprobs, torch.empty(0)
-            )
+        elif not is_mixed:
+            if num_logprobs == -1:
+                # Return the full unsorted and unranked logprobs.
+                logprobs_tensors = LogprobsTensors(
+                    torch.empty(0), raw_logprobs, torch.empty(0)
+                )
+            else:
+                # Gather the logprobs and ranks of the topk and sampled token.
+                logprobs_tensors = self.gather_logprobs(
+                    raw_logprobs, num_logprobs, token_ids=sampled
+                )
         else:
-            # Gather the logprobs and ranks of the topk and sampled token.
-            logprobs_tensors = self.gather_logprobs(
-                raw_logprobs, num_logprobs, token_ids=sampled
-            )
+            # Mixed mode: gather from both raw and processed, merge per row.
+            lp_mask = sampling_metadata.logprobs_is_processed
+            if num_logprobs == -1:
+                lp = torch.where(
+                    lp_mask.unsqueeze(-1),
+                    processed_logprobs,
+                    raw_logprobs,
+                )
+                logprobs_tensors = LogprobsTensors(torch.empty(0), lp, torch.empty(0))
+            else:
+                raw_gathered = self.gather_logprobs(
+                    raw_logprobs, num_logprobs, token_ids=sampled
+                )
+                proc_gathered = self.gather_logprobs(
+                    processed_logprobs, num_logprobs, token_ids=sampled
+                )
+                mask_2d = lp_mask.unsqueeze(-1)
+                logprobs_tensors = LogprobsTensors(
+                    logprob_token_ids=torch.where(
+                        mask_2d,
+                        proc_gathered.logprob_token_ids,
+                        raw_gathered.logprob_token_ids,
+                    ),
+                    logprobs=torch.where(
+                        mask_2d,
+                        proc_gathered.logprobs,
+                        raw_gathered.logprobs,
+                    ),
+                    selected_token_ranks=torch.where(
+                        lp_mask,
+                        proc_gathered.selected_token_ranks,
+                        raw_gathered.selected_token_ranks,
+                    ),
+                )
 
         # If we have both num_logprobs and logprob_token_ids, prefer
         # logprob_token_ids as it's more specific
@@ -245,6 +326,7 @@ class Sampler(nn.Module):
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
         logprobs_mode_override: LogprobsMode | None = None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Sample logits based on sampling metadata.
 
@@ -266,7 +348,9 @@ class Sampler(nn.Module):
                 ):
                     if logprobs_mode == "processed_logits":
                         processed_logprobs = logits
-                    elif logprobs_mode == "processed_logprobs":
+                    elif (
+                        logprobs_mode == "processed_logprobs" or need_processed_logprobs
+                    ):
                         processed_logprobs = self.compute_logprobs(logits)
                 return greedy_sampled, processed_logprobs
 
@@ -283,11 +367,12 @@ class Sampler(nn.Module):
             logits = processor.apply(logits)
 
         # Apply top_k and/or top_p.
-        random_sampled, processed_logprobs = self.topk_topp_sampler(
+        random_sampled, processed_logprobs = self.topk_topp_sampler.sample(
             logits,
             sampling_metadata.generators,
             sampling_metadata.top_k,
             sampling_metadata.top_p,
+            need_processed_logprobs=need_processed_logprobs,
         )
 
         if greedy_sampled is None:

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -149,9 +149,11 @@ class Sampler(nn.Module):
         # exactly what PoC validation needs to compare against the origin.
         if sampling_metadata.enforced_next_token_ids is not None:
             enforced = sampling_metadata.enforced_next_token_ids
-            mask = enforced != -1
-            if mask.any():
-                sampled[mask] = enforced[mask]
+            # torch.where rather than a masked assignment guarded by
+            # mask.any(): both the guard and boolean-mask indexing force a
+            # device sync, and this runs on every decode step. -1 marks
+            # positions with nothing to enforce.
+            sampled = torch.where(enforced != -1, enforced, sampled)
 
         # Handle logprob_token_ids if specified (more efficient than full vocab)
         # This is used by generative_scoring API to get logprobs for specific tokens

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -283,6 +283,7 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
+                grammar_rejected = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for i, token in enumerate(req_tokens):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
@@ -316,9 +317,15 @@ class StructuredOutputManager:
                         if accepted:
                             state_advancements += 1
                         elif not post_reasoning_end_in_window:
-                            raise AssertionError(
-                                (token, req_id, scheduled_spec_decode_tokens)
+                            logger.warning(
+                                "Grammar rejected token %d for request %s "
+                                "during speculative decode bitmask fill. "
+                                "Disabling bitmask for this request.",
+                                token,
+                                req_id,
                             )
+                            apply_bitmask = False
+                            grammar_rejected = True
                     cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
@@ -333,7 +340,12 @@ class StructuredOutputManager:
                     #   should_fill_bitmask still returns False here because
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
-                    bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
+                    # A grammar rejection above disables the bonus row too:
+                    # the FSM is out of sync, so constraining with it would
+                    # corrupt output.
+                    bonus_apply = not grammar_rejected and (
+                        self.should_fill_bitmask(request) or apply_bitmask
+                    )
                     self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
                 if state_advancements > 0:

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -186,6 +186,12 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
         Returns the prefix list of tokens that are accepted by the FSM.
         """
+        if self._grammar_failed:
+            # The FSM is out of sync with the sequence, so its verdicts are
+            # meaningless: filtering against it would reject every draft token
+            # and drive speculative acceptance to zero. Treat all as accepted,
+            # consistent with grammar being disabled for this request.
+            return list(tokens)
         accepted_tokens = []
         for token in tokens:
             if self.matcher.accept_token(token):
@@ -206,6 +212,13 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
         if self._grammar_failed:
+            # Allow every token rather than returning early. The bitmask is
+            # reused across steps, so leaving this row untouched would apply
+            # whatever mask last occupied it -- in a shared batch, another
+            # request's grammar -- and constrain this request to an unrelated
+            # token set. -1 is all-bits-set, matching how the manager fills
+            # rows for requests that are not grammar-constrained.
+            bitmask[idx].fill_(-1)
             return
         self.matcher.fill_next_token_bitmask(bitmask, idx)
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -148,24 +148,34 @@ class XgrammarGrammar(StructuredOutputGrammar):
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
     _is_terminated: bool = field(default=False, repr=False, hash=False)
+    _grammar_failed: bool = field(default=False, repr=False, hash=False)
 
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
         Returns True if the FSM was advanced successfully.
         Returns False if the FSM failed to advance.
+
+        Grammar graceful degradation: when a token is rejected (e.g.
+        enforced tokens from validation replay that conflict with the
+        grammar FSM), grammar enforcement is disabled for the rest of
+        this request instead of causing a crash.
         """
         if self._is_terminated:
             return False
+        if self._grammar_failed:
+            return True
         for token in tokens:
             if not self.matcher.accept_token(token):
-                logger.error(
-                    "Failed to advance FSM for request %s "
-                    "for tokens %s. Please file an issue.",
-                    request_id,
+                logger.warning(
+                    "Grammar rejected token %d for request %s. "
+                    "Disabling grammar enforcement for this request "
+                    "(token may be from enforced replay).",
                     token,
+                    request_id,
                 )
-                return False
+                self._grammar_failed = True
+                return True
             self.num_processed_tokens += 1
         self._is_terminated = self.matcher.is_terminated()
         return True
@@ -188,11 +198,15 @@ class XgrammarGrammar(StructuredOutputGrammar):
         return accepted_tokens
 
     def rollback(self, num_tokens: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.rollback(num_tokens)
         self.num_processed_tokens -= num_tokens
         self._is_terminated = self.matcher.is_terminated()
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.fill_next_token_bitmask(bitmask, idx)
 
     def is_terminated(self) -> bool:
@@ -200,6 +214,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def reset(self):
         self.num_processed_tokens = 0
+        self._grammar_failed = False
         self.matcher.reset()
 
 

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -56,6 +56,22 @@ class Sampler:
     def add_request(
         self, req_idx: int, prompt_len: int, sampling_params: SamplingParams
     ) -> None:
+        # This sampler has its own sampling path and does not read
+        # enforced_token_ids or per-request logprobs_mode. Accepting such a
+        # request would return a plausible-looking completion that ignores
+        # both -- a validator would treat the reply as a verified replay when
+        # nothing was enforced. Fail loudly instead of degrading silently.
+        if sampling_params.enforced_token_ids is not None:
+            raise NotImplementedError(
+                "enforced_token_ids is not supported by the V2 model runner. "
+                "Run with VLLM_USE_V2_MODEL_RUNNER=0, or drop the parameter."
+            )
+        if sampling_params.logprobs_mode is not None:
+            raise NotImplementedError(
+                "Per-request logprobs_mode is not supported by the V2 model "
+                "runner. Run with VLLM_USE_V2_MODEL_RUNNER=0, or use the "
+                "engine-level --logprobs-mode instead."
+            )
         self.sampling_states.add_request(req_idx, sampling_params)
         self.penalties_state.add_request(req_idx, sampling_params)
         self.logit_bias_state.add_request(req_idx, prompt_len, sampling_params)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -106,6 +106,7 @@ class InputBatch:
         is_pooling_model: bool = False,
         cp_kv_cache_interleave_size: int = 1,
         reasoning_config: ReasoningConfig | None = None,
+        logprobs_mode_default: str = "raw_logprobs",
     ):
         self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
             reasoning_config,
@@ -253,6 +254,8 @@ class InputBatch:
         self.generators: dict[int, torch.Generator] = {}
 
         self.num_logprobs: dict[str, int] = {}
+        self.logprobs_mode_default = logprobs_mode_default
+        self.logprobs_modes: dict[str, str] = {}
 
         # req_id -> list of specific token IDs to compute logprobs for
         # More efficient than num_logprobs=-1 when only a few tokens are needed
@@ -276,6 +279,9 @@ class InputBatch:
         self.logits_processing_needs_token_ids = np.zeros(max_num_reqs, dtype=bool)
 
         self.req_output_token_ids: list[list[int] | None] = []
+
+        # Enforced next-token IDs keyed by req_id (gonka PoC v2 replay).
+        self.req_enforced_token_ids: dict[str, list[int] | None] = {}
 
         # Store provided logitsprocs. If none are provided, initialize empty
         # data structure
@@ -340,13 +346,23 @@ class InputBatch:
         req_index = self._register_add_request(request)
 
         req_id = request.req_id
+        enforced = (
+            getattr(request.sampling_params, "enforced_token_ids", None)
+            if request.sampling_params
+            else None
+        )
+
         if req_index == len(self._req_ids):
             self._req_ids.append(req_id)
             self.req_output_token_ids.append(request.output_token_ids)
+            if enforced:
+                self.req_enforced_token_ids[req_id] = enforced
             self.spec_token_ids.append([])
         else:
             self._req_ids[req_index] = req_id
             self.req_output_token_ids[req_index] = request.output_token_ids
+            if enforced:
+                self.req_enforced_token_ids[req_id] = enforced
             self.spec_token_ids[req_index].clear()
 
         self.req_id_to_index[req_id] = req_index
@@ -418,6 +434,9 @@ class InputBatch:
                     self.vocab_size
                     if sampling_params.logprobs == -1
                     else sampling_params.logprobs
+                )
+                self.logprobs_modes[req_id] = (
+                    sampling_params.logprobs_mode or self.logprobs_mode_default
                 )
 
             # Store specific token IDs to compute logprobs for (more efficient)
@@ -525,6 +544,7 @@ class InputBatch:
         self.batch_update_builder.removed_append(req_index)
         self._req_ids[req_index] = None
         self.req_output_token_ids[req_index] = None
+        self.req_enforced_token_ids.pop(req_id, None)
         self.spec_token_ids[req_index].clear()
         self.block_table.clear_row(req_index)
 
@@ -553,6 +573,7 @@ class InputBatch:
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
         self.logprob_token_ids.pop(req_id, None)
+        self.logprobs_modes.pop(req_id, None)
         if self.prev_req_id_to_index is not None:
             self.prev_req_id_to_index.pop(req_id, None)
 
@@ -809,6 +830,41 @@ class InputBatch:
         del self.req_output_token_ids[num_reqs:]
         del self.spec_token_ids[num_reqs:]
 
+    def _build_enforced_tensor(self) -> "torch.Tensor | None":
+        """Build enforced_next_token_ids tensor from current batch state.
+
+        Returns None if no requests have enforced tokens.
+        Shape [num_reqs], -1 means no enforcement for that request.
+        """
+        num_reqs = self.num_reqs
+        if num_reqs == 0 or not self.req_enforced_token_ids:
+            return None
+        enforced_list: list[int] = []
+        has_any = False
+        for i in range(num_reqs):
+            req_id = self._req_ids[i]
+            etids = (
+                self.req_enforced_token_ids.get(req_id) if req_id is not None else None
+            )
+            if etids:
+                out = self.req_output_token_ids[i]
+                out_len = len(out) if out else 0
+                enforced_list.append(
+                    etids[out_len] if out_len < len(etids) else etids[-1]
+                )
+                has_any = True
+            else:
+                enforced_list.append(-1)
+        if not has_any:
+            return None
+        return torch.tensor(enforced_list, dtype=torch.long, device=self.device)
+
+    def _update_enforced_tensor(self) -> None:
+        """Update enforced_next_token_ids on sampling_metadata each step."""
+        if self.sampling_metadata is None:
+            return
+        self.sampling_metadata.enforced_next_token_ids = self._build_enforced_tensor()
+
     def refresh_metadata(self):
         """Apply any batch updates to sampling metadata."""
 
@@ -828,6 +884,9 @@ class InputBatch:
             logit_proc.update_state(batch_update)
         if batch_update:
             self.sampling_metadata = self._make_sampling_metadata()
+        # Always update enforced tokens (they advance each step).
+        if self.req_enforced_token_ids:
+            self._update_enforced_tensor()
 
     def _make_sampling_metadata(self) -> SamplingMetadata:
         num_reqs = self.num_reqs
@@ -912,6 +971,19 @@ class InputBatch:
                     req_index = self.req_id_to_index[req_id]
                     logprob_token_ids_by_index[req_index] = token_ids
 
+        batch_mode = self.batch_logprobs_mode
+        logprobs_is_processed: torch.Tensor | None = None
+        if batch_mode == "mixed":
+            logprobs_is_processed = torch.zeros(
+                num_reqs, dtype=torch.bool, device=self.device
+            )
+            for i in range(num_reqs):
+                req_id = self._req_ids[i]
+                if req_id is not None:
+                    logprobs_is_processed[i] = (
+                        self.logprobs_modes.get(req_id) == "processed_logprobs"
+                    )
+
         return SamplingMetadata(
             temperature=temperature,
             all_greedy=self.all_greedy,
@@ -932,6 +1004,9 @@ class InputBatch:
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
             thinking_budget_state_holder=self.thinking_budget_state_holder,
+            batch_logprobs_mode=batch_mode,
+            logprobs_is_processed=logprobs_is_processed,
+            enforced_next_token_ids=self._build_enforced_tensor(),
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:
@@ -1121,6 +1196,21 @@ class InputBatch:
     @property
     def max_num_logprobs(self) -> int | None:
         return max(self.num_logprobs.values()) if self.num_logprobs else None
+
+    @property
+    def batch_logprobs_mode(self) -> str | None:
+        """Aggregate per-request logprobs modes into a batch-level mode.
+
+        Returns None when no request in the batch requested logprobs,
+        the single shared mode when all requests agree, or "mixed" when
+        the batch contains more than one distinct mode.
+        """
+        if not self.logprobs_modes:
+            return None
+        modes = set(self.logprobs_modes.values())
+        if len(modes) == 1:
+            return next(iter(modes))
+        return "mixed"
 
     @property
     def no_allowed_token_ids(self) -> bool:

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -974,15 +974,17 @@ class InputBatch:
         batch_mode = self.batch_logprobs_mode
         logprobs_is_processed: torch.Tensor | None = None
         if batch_mode == "mixed":
-            logprobs_is_processed = torch.zeros(
-                num_reqs, dtype=torch.bool, device=self.device
+            # Build on the host and transfer once. Assigning into a device
+            # tensor element by element costs a separate copy plus a sync per
+            # request, and this runs on every step.
+            is_processed = [
+                req_id is not None
+                and self.logprobs_modes.get(req_id) == "processed_logprobs"
+                for req_id in self._req_ids[:num_reqs]
+            ]
+            logprobs_is_processed = torch.tensor(
+                is_processed, dtype=torch.bool, device=self.device
             )
-            for i in range(num_reqs):
-                req_id = self._req_ids[i]
-                if req_id is not None:
-                    logprobs_is_processed[i] = (
-                        self.logprobs_modes.get(req_id) == "processed_logprobs"
-                    )
 
         return SamplingMetadata(
             temperature=temperature,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -710,6 +710,7 @@ class GPUModelRunner(
             is_pooling_model=self.is_pooling_model,
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             reasoning_config=self.vllm_config.reasoning_config,
+            logprobs_mode_default=self.model_config.logprobs_mode,
         )
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
@@ -7067,6 +7068,7 @@ class GPUModelRunner(
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
                 reasoning_config=self.vllm_config.reasoning_config,
+                logprobs_mode_default=self.model_config.logprobs_mode,
             )
 
         assert self._init_block_sizes == block_sizes, (

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,0 +1,75 @@
+"""EnforcedToken support for gonka-style inference validation."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EnforcedToken(BaseModel):
+    token: str
+    top_tokens: list[str] = Field(default_factory=list)
+    token_id: int | None = Field(default=None, exclude=True)
+    top_token_ids: list[int] = Field(default_factory=list, exclude=True)
+
+    def encode(self, tokenizer) -> None:
+        """Convert token strings to token IDs.
+        Tokens from gonka API are already numeric strings (token IDs)."""
+        try:
+            self.token_id = int(self.token)
+            self.top_token_ids = [int(t) for t in self.top_tokens]
+        except ValueError:
+            # Fallback: tokenize the string
+            ids = tokenizer.encode(self.token, add_special_tokens=False)
+            self.token_id = ids[0] if ids else 0
+            self.top_token_ids = []
+            for t in self.top_tokens:
+                t_ids = tokenizer.encode(t, add_special_tokens=False)
+                if t_ids:
+                    self.top_token_ids.append(t_ids[0])
+
+
+class EnforcedTokens(BaseModel):
+    tokens: list[EnforcedToken]
+
+    def encode(self, tokenizer) -> None:
+        for token in self.tokens:
+            token.encode(tokenizer)
+
+    @classmethod
+    def from_content(cls, content: list[dict[str, Any]]) -> "EnforcedTokens":
+        tokens = []
+        for position in content:
+            token = position["token"]
+            top_tokens = [x["token"] for x in position["top_logprobs"]]
+            tokens.append(EnforcedToken(token=token, top_tokens=top_tokens))
+        return cls(tokens=tokens)
+
+    def get_enforced_token_ids(self) -> list[int]:
+        if not self.tokens or self.tokens[0].token_id is None:
+            raise ValueError("Enforced tokens are not encoded")
+        return [token.token_id for token in self.tokens]
+
+    def detect_logprobs_mode(self, threshold: float = 0.10) -> str | None:
+        """Classify original inference logprobs mode from top_token_ids.
+
+        In processed-logprobs results, empty top-k slots are padded with the
+        lowest vocab IDs (0-3 for Qwen: ``!``, ``"``, ``#``, ``$``) at
+        logprob -9999. This makes ~75% of top_token_ids entries < 4.
+        In raw-logprobs results, only ~0.2% of entries are < 4.
+
+        Must be called after encode().
+
+        Returns ``'raw_logprobs'``, ``'processed_logprobs'``, or ``None``
+        if there is insufficient data (fewer than 10 top-token entries).
+        """
+        total = 0
+        low_id_count = 0
+        for t in self.tokens:
+            for tid in t.top_token_ids:
+                total += 1
+                if tid < 4:
+                    low_id_count += 1
+        if total < 10:
+            return None
+        ratio = low_id_count / total
+        return "processed_logprobs" if ratio > threshold else "raw_logprobs"

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,13 +1,31 @@
-"""EnforcedToken support for gonka-style inference validation."""
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Enforced-token support for replay-based inference validation.
+
+A validator replays a previously produced token sequence through this engine
+and compares the resulting logprobs against the originals. The ids arrive in
+the request body, so they are untrusted: they end up in an embedding lookup,
+where an out-of-range value is not a rejected request but a device-side
+assert that takes the worker process — and every other request on it — down.
+"""
 
 from typing import Any
 
 from pydantic import BaseModel, Field
 
+# Ceilings on the replay payload, applied before any of it reaches the engine.
+# They do not bound the request body (that belongs to the proxy), but they do
+# stop a large body from being materialised as a huge number of models, and
+# they keep the per-position fan-out finite.
+MAX_ENFORCED_TOKENS = 32768
+MAX_TOP_TOKENS_PER_POSITION = 64
+
 
 class EnforcedToken(BaseModel):
     token: str
-    top_tokens: list[str] = Field(default_factory=list)
+    top_tokens: list[str] = Field(
+        default_factory=list, max_length=MAX_TOP_TOKENS_PER_POSITION
+    )
     token_id: int | None = Field(default=None, exclude=True)
     top_token_ids: list[int] = Field(default_factory=list, exclude=True)
 
@@ -29,7 +47,7 @@ class EnforcedToken(BaseModel):
 
 
 class EnforcedTokens(BaseModel):
-    tokens: list[EnforcedToken]
+    tokens: list[EnforcedToken] = Field(max_length=MAX_ENFORCED_TOKENS)
 
     def encode(self, tokenizer) -> None:
         for token in self.tokens:
@@ -45,9 +63,12 @@ class EnforcedTokens(BaseModel):
         return cls(tokens=tokens)
 
     def get_enforced_token_ids(self) -> list[int]:
-        if not self.tokens or self.tokens[0].token_id is None:
+        if not self.tokens:
             raise ValueError("Enforced tokens are not encoded")
-        return [token.token_id for token in self.tokens]
+        ids = [token.token_id for token in self.tokens]
+        if any(tid is None for tid in ids):
+            raise ValueError("Enforced tokens are not encoded")
+        return [tid for tid in ids if tid is not None]
 
     def detect_logprobs_mode(self, threshold: float = 0.10) -> str | None:
         """Classify original inference logprobs mode from top_token_ids.
@@ -73,3 +94,25 @@ class EnforcedTokens(BaseModel):
             return None
         ratio = low_id_count / total
         return "processed_logprobs" if ratio > threshold else "raw_logprobs"
+
+
+def validate_enforced_token_ids(token_ids: list[int], vocab_size: int) -> None:
+    """Reject replay ids the model cannot embed.
+
+    Raises ``ValueError`` so the caller can return a 400. Without this an
+    out-of-range id reaches the embedding lookup and aborts the worker.
+
+    Negative values are rejected wholesale: the sampler reserves ``-1`` as the
+    "no enforcement at this position" sentinel, so accepting it from a client
+    would silently disable enforcement instead of replaying.
+    """
+    for position, token_id in enumerate(token_ids):
+        if not isinstance(token_id, int) or isinstance(token_id, bool):
+            raise ValueError(
+                f"enforced token at position {position} is not an integer: {token_id!r}"
+            )
+        if token_id < 0 or token_id >= vocab_size:
+            raise ValueError(
+                f"enforced token at position {position} is out of range for "
+                f"this model: {token_id} not in [0, {vocab_size})"
+            )


### PR DESCRIPTION
Second of two PRs splitting #66. **Stacked on #70** — review that one first; until it merges, GitHub shows this diff cumulatively. The eight files this PR actually adds are below.

## 1. Enforced-token HTTP ingestion

`vllm/validation.py`, chat-completion `protocol.py` / `serving.py`, `generate/base/serving.py`.

Without this bridge a validator's `enforced_tokens` payload is dropped during request parsing and never reaches `SamplingParams`. Inference validation then degrades into an ordinary generate — no error anywhere, the node simply stops proving what it claims to prove. This was reported on the GLM image.

**Self-review before asking for yours** turned up that the replay ids arrive over HTTP and go straight into an embedding lookup, where an out-of-range value is not a rejected request but a device-side assert that takes the worker down — and every other request on it. A single unvalidated field was effectively a remote kill switch. Fixed here:

- `validate_enforced_token_ids()` rejects non-integers and anything outside `[0, vocab_size)` before the ids reach the engine; the caller turns that into a 400. Negatives are rejected wholesale, because the sampler reserves `-1` as its "nothing to enforce here" sentinel — accepting `-1` from a client would silently disable replay rather than perform it.
- Ceilings on the payload (`MAX_ENFORCED_TOKENS`, `MAX_TOP_TOKENS_PER_POSITION`), so a large body cannot be materialised as an unbounded number of models.
- `eos_token_id` is appended only when the tokenizer actually has one. `TokenizerLike` types it as `int`, but it is `None` for some models, and a `None` in the id list crashes inside the worker instead of failing the request.
- `get_enforced_token_ids()` checks every element rather than only the first, and narrows the type so mypy is satisfied.

Still open, deliberately, because they change the API contract rather than harden it: `detect_logprobs_mode()` infers the logprobs mode heuristically from client-supplied data even though the request already carries an explicit field, and the numeric-id rendering in `generate/base/serving.py` changes `logprobs` output for every endpoint. Both are being handled separately — the second one needs a replacement in the plugin first, otherwise the GLM fix regresses.

## 2. shm broadcast ring size

`vllm/envs.py`, `distributed/parallel_state.py`, `v1/executor/multiproc_executor.py`, `v1/executor/ray_executor_v2.py`.

**What this fixes, concretely:** Kimi-K2.6 (TP=4) died repeatedly under sustained production load on a 4xB300 fleet. Raising these rings is what stopped it — engine deaths went from roughly every 35 minutes to every 2-3 hours. The mechanism, as far as we could establish it: the writer is EngineCore, a reader that is briefly slow to drain blocks it ("No available shared memory broadcast block"), the step stalls, and the engine is eventually declared dead and restarted, dropping in-flight requests.

Treat it as a **mitigation rather than a cure** — stalls were still observed near idle afterwards, so something deeper is likely involved. Same change as #58, carried to the 0.25.1 line.

The first version hardcoded 6/10 to 64 at four sites. Each ring costs `max_chunks x (max_chunk_bytes + metadata)`, so at the 16 MiB default a ring of 64 is about a gigabyte, and an engine has several — roughly 1.3 GiB of extra `/dev/shm` per engine. Imposing that on deployments that never hit this failure is not defensible, so it is now `VLLM_MQ_MAX_CHUNKS`, defaulting to `None` and leaving every site on its upstream default.

Our own image opts in explicitly (`ENV VLLM_MQ_MAX_CHUNKS=64` in `docker/Dockerfile.gonka-poc`), which is the right place for it: the workload is known there, and the default stays conservative for everyone else.

The Ray executor's ring shares the failure mode and was left out entirely, so the fix could not reach it while the contract test still passed. It reads the same knob now.

## Order

`enforced_token_ids` and `logprobs_mode` come from #70, and the ingestion bridge writes into them, so #70 must land first.

## Verification

`ruff check` and `ruff format` clean on every touched file. The range checker was exercised against in-range, out-of-range, negative, sentinel and boolean inputs; the env resolver returns `None` when unset and the integer when set. Contract tests assert behaviour — range checks reject, ceilings exist, the knob defaults to `None`, every ring site reads it — instead of grepping source text, which passed on comments and broke on reformatting. New files carry SPDX headers.
