### PR TITLE
Port PoC sampler residual to vLLM 0.25.1 (no behaviour change)

### DIFF
--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -1,0 +1,51 @@
+# Composes the image the Gonka network runs: stock vLLM + the in-tree sampler
+# residual from this repository + the out-of-tree gonka-poc plugin.
+#
+#   docker build -f docker/Dockerfile.gonka-poc -t vllm-poc:0.25.1 .
+#
+# PoC compute logic (nonce partitioning, seeded RNG, Householder scoring, L2 and
+# binomial validation, DeepSeek-V4 support) lives in the plugin. Only the sampler
+# surfaces that have no public extension point live in this repository.
+
+ARG BASE_IMAGE=vllm/vllm-openai:v0.25.1
+FROM ${BASE_IMAGE}
+
+# The plugin reaches workers over collective_rpc with payloads that are not
+# msgpack-encodable, so the engine's message bus has to allow pickle. Set here
+# because the image is built for that workload; a general-purpose deployment
+# should not carry it. Unsetting it disables the PoC path rather than degrading
+# it silently.
+ENV VLLM_ALLOW_INSECURE_SERIALIZATION=1
+# NVFP4 / FP8 fast paths on Blackwell (B200/B300/RTX PRO 6000); harmless elsewhere.
+ENV VLLM_USE_FLASHINFER_MOE_FP4=1
+ENV VLLM_USE_FLASHINFER_MOE_FP8=1
+
+# Overlay the residual .py files onto the pre-built package, keeping compiled
+# .so. The version guard matters: .py from one minor over .so from another
+# either fails at import or, worse, half-works.
+ARG EXPECTED_VLLM_VERSION=0.25.1
+COPY ./vllm /tmp/vllm-src
+RUN INSTALLED=$(python3 -c "import vllm; print(vllm.__version__)") \
+    && case "$INSTALLED" in "${EXPECTED_VLLM_VERSION}"*) ;; \
+         *) echo "ERROR: base image ships vllm $INSTALLED, residual targets ${EXPECTED_VLLM_VERSION}"; exit 1 ;; \
+       esac \
+    && VLLM_DIR=$(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))") \
+    && [ -d "$VLLM_DIR" ] || (echo "ERROR: vllm not importable"; exit 1) \
+    && cd /tmp/vllm-src \
+    && find . -name "*.py" | tar -cf - -T - | tar -xf - -C "$VLLM_DIR/" \
+    && rm -rf /tmp/vllm-src
+
+# Select the V1 model runner. vLLM 0.25 ships a parallel V2 runner with its own
+# sampler, which does not implement enforced tokens or per-request logprobs
+# mode, so a replay request served by it would return a plausible completion
+# that enforced nothing.
+ENV VLLM_USE_V2_MODEL_RUNNER=0
+
+# The out-of-tree plugin, pinned to a tag: the plugin repository is being handed
+# over to the gonka-ai organisation, and a branch would resolve to whatever HEAD
+# it has at build time.
+ARG GONKA_POC_REPO=kaitakuai/gonka-poc
+ARG GONKA_POC_REF=v0.1.0a0
+RUN pip install --no-cache-dir --no-deps \
+      "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \
+    && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10"

--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -41,10 +41,11 @@ RUN INSTALLED=$(python3 -c "import vllm; print(vllm.__version__)") \
 # that enforced nothing.
 ENV VLLM_USE_V2_MODEL_RUNNER=0
 
-# The out-of-tree plugin, pinned to a tag: the plugin repository is being handed
-# over to the gonka-ai organisation, and a branch would resolve to whatever HEAD
-# it has at build time.
-ARG GONKA_POC_REPO=kaitakuai/gonka-poc
+# The out-of-tree plugin, pinned to a tag rather than a branch, which would
+# resolve to whatever HEAD it has at build time. Lives in the gonka-ai
+# organisation as of 2026-07-28; the distribution is still named gonka-poc,
+# so only the source URL moved.
+ARG GONKA_POC_REPO=gonka-ai/gonka-vllm-plugins
 ARG GONKA_POC_REF=v0.1.0a0
 RUN pip install --no-cache-dir --no-deps \
       "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \

--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -48,5 +48,5 @@ ENV VLLM_USE_V2_MODEL_RUNNER=0
 ARG GONKA_POC_REPO=gonka-ai/gonka-vllm-plugins
 ARG GONKA_POC_REF=v0.1.1
 RUN pip install --no-cache-dir --no-deps \
-      "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \
+      "gonka-poc @ https://github.com/${GONKA_POC_REPO}/archive/refs/tags/${GONKA_POC_REF}.tar.gz" \
     && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10"

--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -46,7 +46,7 @@ ENV VLLM_USE_V2_MODEL_RUNNER=0
 # organisation as of 2026-07-28; the distribution is still named gonka-poc,
 # so only the source URL moved.
 ARG GONKA_POC_REPO=gonka-ai/gonka-vllm-plugins
-ARG GONKA_POC_REF=v0.1.0a0
+ARG GONKA_POC_REF=v0.1.1
 RUN pip install --no-cache-dir --no-deps \
       "gonka-poc @ git+https://github.com/${GONKA_POC_REPO}@${GONKA_POC_REF}" \
     && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10"

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/contract/test_sampler_surface.py
+++ b/tests/contract/test_sampler_surface.py
@@ -27,6 +27,14 @@ import inspect
 import pytest
 
 
+def test_completion_request_forwards_logprobs_mode() -> None:
+    mod = importlib.import_module("vllm.entrypoints.openai.completion.protocol")
+    request = mod.CompletionRequest(
+        model="test", prompt="test", logprobs_mode="processed_logprobs"
+    )
+    assert request.to_sampling_params(1).logprobs_mode == "processed_logprobs"
+
+
 def test_sampling_params_has_poc_fields() -> None:
     """Pin the per-request SamplingParams fields the plugin sets."""
     pytest.importorskip("vllm")

--- a/tests/contract/test_sampler_surface.py
+++ b/tests/contract/test_sampler_surface.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Contract tests for the sampler surfaces the PoC residual depends on.
+
+The residual in this tree adds a few hooks to the V1 sampling stack that an
+out-of-tree plugin consumes: per-request ``logprobs_mode`` and
+``enforced_token_ids``, ``need_processed_logprobs`` threading through the
+top-k/top-p sampler, the matching ``InputBatch`` bookkeeping, and
+structured-output graceful degradation. All of them live on private classes,
+so a refactor can move them without producing an import error: the plugin
+keeps loading and silently stops enforcing tokens or stops returning the
+requested logprobs.
+
+These tests pin the shape of each touched surface. A failure means the
+surface moved and the corresponding residual patch must be re-applied at its
+new location; every assertion message names the file to look at.
+
+Scope: read-only inspection of vllm modules. No GPU, no engine startup, no
+forward pass.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+def test_sampling_params_has_poc_fields() -> None:
+    """Pin the per-request SamplingParams fields the plugin sets."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.sampling_params")
+    cls = getattr(mod, "SamplingParams", None)
+    assert cls is not None, "vllm.sampling_params.SamplingParams missing"
+
+    # SamplingParams is a msgspec.Struct, whose declared field set is
+    # __struct_fields__; msgspec generates __init__ dynamically, so
+    # inspect.signature(cls.__init__) only reports (*args, **kwargs). Fall
+    # back to the dataclass and signature views so the assertion survives a
+    # future change of class machinery.
+    field_names = set(getattr(cls, "__struct_fields__", None) or ())
+    if not field_names:
+        field_names = set(getattr(cls, "__dataclass_fields__", None) or ())
+    if not field_names:
+        field_names = set(inspect.signature(cls.__init__).parameters)
+    for name in ("logprobs_mode", "enforced_token_ids"):
+        assert name in field_names, (
+            f"SamplingParams.{name} is not a declared field — re-apply the "
+            f"residual patch to vllm/sampling_params.py."
+        )
+
+    # from_optional is the path the API entrypoints take: a field that is
+    # declared but not forwarded here never reaches the sampler.
+    from_optional_params = set(inspect.signature(cls.from_optional).parameters)
+    for name in ("logprobs_mode", "enforced_token_ids"):
+        assert name in from_optional_params, (
+            f"SamplingParams.from_optional no longer forwards {name} — "
+            f"requests carrying it would be silently dropped before the "
+            f"sampler sees it."
+        )
+
+    # Both fields must be opt-in: requests that do not set them must behave
+    # exactly like unpatched vLLM.
+    defaults = cls()
+    assert defaults.logprobs_mode is None
+    assert defaults.enforced_token_ids is None
+
+    params = cls(
+        logprobs=1,
+        logprobs_mode="processed_logprobs",
+        enforced_token_ids=[7, 11],
+    )
+    assert params.logprobs_mode == "processed_logprobs"
+    assert params.enforced_token_ids == [7, 11]
+
+    # The value check runs from __post_init__; without it an unusable mode
+    # reaches the sampler and is resolved to the deployment default.
+    with pytest.raises(ValueError):
+        cls(logprobs_mode="not_a_mode")
+
+
+def test_sampling_metadata_has_poc_fields() -> None:
+    """Pin the sampler-side SamplingMetadata fields the residual populates."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.metadata")
+    cls = getattr(mod, "SamplingMetadata", None)
+    assert cls is not None, "vllm.v1.sample.metadata.SamplingMetadata missing"
+
+    dc_fields = getattr(cls, "__dataclass_fields__", None)
+    assert dc_fields is not None, (
+        "SamplingMetadata is no longer a dataclass — re-check how "
+        "vllm/v1/worker/gpu_input_batch.py constructs it."
+    )
+
+    # batch_logprobs_mode drives the mode resolution in Sampler.forward, and
+    # logprobs_is_processed selects raw vs processed per row of a mixed
+    # batch; enforced_next_token_ids drives the post-sampling override.
+    for name in (
+        "batch_logprobs_mode",
+        "logprobs_is_processed",
+        "enforced_next_token_ids",
+    ):
+        assert name in dc_fields, (
+            f"SamplingMetadata.{name} missing — Sampler.forward would fall "
+            f"back to the deployment-wide logprobs mode and skip the "
+            f"enforced-token override without failing. Re-apply the residual "
+            f"patch to vllm/v1/sample/metadata.py."
+        )
+        assert dc_fields[name].default is None, (
+            f"SamplingMetadata.{name} no longer defaults to None — every "
+            f"other construction site of SamplingMetadata must keep working "
+            f"without the residual fields."
+        )
+
+
+def test_sampler_call_accepts_enforced_tokens() -> None:
+    """Pin the Sampler entry points that carry the residual state."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.sampler")
+    cls = getattr(mod, "Sampler", None)
+    assert cls is not None, "vllm.v1.sample.sampler.Sampler missing"
+    assert hasattr(cls, "forward"), (
+        "Sampler.forward missing — the method may have been renamed to "
+        "__call__ or split; the residual hooks in it need re-porting."
+    )
+
+    forward_params = set(inspect.signature(cls.forward).parameters)
+    assert "sampling_metadata" in forward_params, (
+        f"Sampler.forward no longer takes sampling_metadata; present params "
+        f"= {sorted(forward_params)!r}. The residual reads the per-request "
+        f"mode and the enforced tokens off it."
+    )
+
+    sample_params = set(inspect.signature(cls.sample).parameters)
+    assert "need_processed_logprobs" in sample_params, (
+        f"Sampler.sample no longer takes need_processed_logprobs; present "
+        f"params = {sorted(sample_params)!r}. Without it a per-request "
+        f"processed-logprobs override cannot reach the top-k/top-p sampler."
+    )
+
+    meta_mod = importlib.import_module("vllm.v1.sample.metadata")
+    meta_cls = getattr(meta_mod, "SamplingMetadata", None)
+    assert meta_cls is not None, "vllm.v1.sample.metadata.SamplingMetadata missing"
+    meta_fields = getattr(meta_cls, "__dataclass_fields__", None) or {}
+    assert "enforced_next_token_ids" in meta_fields, (
+        "Sampler.forward takes sampling_metadata but SamplingMetadata lacks "
+        "enforced_next_token_ids — validation replay would be a no-op."
+    )
+
+    # The override is a tensor read inside forward(), observable only during
+    # a real forward pass on device tensors, which this contract test does
+    # not run; the source is the only place its removal shows up.
+    forward_src = inspect.getsource(cls.forward)
+    assert "enforced_next_token_ids" in forward_src, (
+        "Sampler.forward does not reference enforced_next_token_ids — the "
+        "post-sampling override was dropped; re-apply the residual patch to "
+        "vllm/v1/sample/sampler.py."
+    )
+
+
+def test_topk_topp_sampler_need_processed_logprobs() -> None:
+    """Pin need_processed_logprobs on every TopKTopPSampler forward path."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.sample.ops.topk_topp_sampler")
+    cls = getattr(mod, "TopKTopPSampler", None)
+    assert cls is not None, (
+        "vllm.v1.sample.ops.topk_topp_sampler.TopKTopPSampler missing — the "
+        "module was restructured and the residual threading needs re-porting."
+    )
+
+    # Every backend path must accept the kwarg: the dispatch target depends
+    # on the platform, so one missing path is a runtime TypeError there and
+    # nowhere else.
+    for method_name in (
+        "forward_native",
+        "forward_cuda",
+        "forward_cpu",
+        "forward_hip",
+        "forward_xpu",
+    ):
+        fn = getattr(cls, method_name, None)
+        assert fn is not None, (
+            f"TopKTopPSampler.{method_name} missing — this forward path was "
+            f"renamed or consolidated; re-port the need_processed_logprobs "
+            f"threading to its replacement."
+        )
+        params = set(inspect.signature(fn).parameters)
+        assert "need_processed_logprobs" in params, (
+            f"TopKTopPSampler.{method_name} no longer takes "
+            f"need_processed_logprobs; present params = {sorted(params)!r}. "
+            f"On this path a mixed-mode batch would silently return raw "
+            f"logprobs where processed ones were requested."
+        )
+
+    # sample() is the wrapper Sampler.sample calls: it falls back to
+    # forward_native when the active fast path (FlashInfer, aiter) cannot
+    # produce processed logprobs.
+    sample = getattr(cls, "sample", None)
+    assert sample is not None, (
+        "TopKTopPSampler.sample missing — Sampler.sample would call the "
+        "platform forward directly and raise TypeError on the fast paths "
+        "when processed logprobs are requested."
+    )
+    sample_params = set(inspect.signature(sample).parameters)
+    assert "need_processed_logprobs" in sample_params, (
+        f"TopKTopPSampler.sample no longer takes need_processed_logprobs; "
+        f"present params = {sorted(sample_params)!r}."
+    )
+
+
+def test_input_batch_logprobs_modes_dict() -> None:
+    """Pin the InputBatch bookkeeping that feeds SamplingMetadata."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.v1.worker.gpu_input_batch")
+    cls = getattr(mod, "InputBatch", None)
+    assert cls is not None, (
+        "vllm.v1.worker.gpu_input_batch.InputBatch missing — the module was "
+        "restructured; re-apply the residual bookkeeping at its new location."
+    )
+
+    init_params = set(inspect.signature(cls.__init__).parameters)
+    assert "logprobs_mode_default" in init_params, (
+        f"InputBatch.__init__ no longer takes logprobs_mode_default; present "
+        f"params = {sorted(init_params)!r}. The model runner passes the "
+        f"deployment-wide mode through it as the per-request fallback."
+    )
+
+    mode_attr = inspect.getattr_static(cls, "batch_logprobs_mode", None)
+    assert isinstance(mode_attr, property), (
+        "InputBatch.batch_logprobs_mode is not a property — the aggregation "
+        "of per-request modes into a batch-level mode (including 'mixed') "
+        "is gone; SamplingMetadata.batch_logprobs_mode cannot be filled."
+    )
+
+    assert hasattr(cls, "_build_enforced_tensor"), (
+        "InputBatch._build_enforced_tensor missing — the per-step enforced "
+        "token tensor is no longer built, so validation replay is a no-op."
+    )
+
+    # logprobs_modes and req_enforced_token_ids are instance attributes, and
+    # InputBatch cannot be constructed here (it needs a full VllmConfig, a KV
+    # cache spec and a device), so check the constructor source instead.
+    init_src = inspect.getsource(cls.__init__)
+    for needle in ("self.logprobs_modes", "self.req_enforced_token_ids"):
+        assert needle in init_src, (
+            f"InputBatch.__init__ no longer initializes {needle} — "
+            f"add_request cannot record per-request modes or enforced "
+            f"tokens; re-apply the residual patch to "
+            f"vllm/v1/worker/gpu_input_batch.py."
+        )
+
+
+def test_structured_output_graceful_degradation_hook() -> None:
+    """Pin the grammar surfaces the graceful-degradation hook patches."""
+    pytest.importorskip("vllm")
+
+    backend = importlib.import_module("vllm.v1.structured_output.backend_xgrammar")
+    grammar_cls = getattr(backend, "XgrammarGrammar", None)
+    assert grammar_cls is not None, (
+        "vllm.v1.structured_output.backend_xgrammar.XgrammarGrammar missing "
+        "— the backend was relocated or renamed; re-apply the residual patch "
+        "at its new location."
+    )
+
+    # Enforced tokens can conflict with the grammar FSM. The hook turns that
+    # rejection into a per-request disable instead of a hard failure, using
+    # a _grammar_failed flag that rollback() and fill_bitmask() also honor.
+    grammar_fields = getattr(grammar_cls, "__dataclass_fields__", None) or {}
+    assert "_grammar_failed" in grammar_fields, (
+        "XgrammarGrammar._grammar_failed missing — a grammar rejection would "
+        "again abort the request instead of degrading gracefully."
+    )
+    assert grammar_fields["_grammar_failed"].default is False, (
+        "XgrammarGrammar._grammar_failed must default to False so grammar "
+        "enforcement stays on until a token is actually rejected."
+    )
+    for method_name in ("accept_tokens", "rollback", "fill_bitmask", "reset"):
+        assert hasattr(grammar_cls, method_name), (
+            f"XgrammarGrammar.{method_name} missing — the grammar interface "
+            f"drifted and the degradation hook no longer covers every entry "
+            f"point that touches the matcher."
+        )
+
+    mgr_mod = importlib.import_module("vllm.v1.structured_output")
+    mgr_cls = getattr(mgr_mod, "StructuredOutputManager", None)
+    assert mgr_cls is not None, (
+        "vllm.v1.structured_output.StructuredOutputManager missing — the "
+        "module was restructured; re-apply the residual patch."
+    )
+    bitmask_fn = getattr(mgr_cls, "grammar_bitmask", None)
+    assert bitmask_fn is not None, (
+        "StructuredOutputManager.grammar_bitmask missing — the patched "
+        "bitmask path moved; find the new call site of accept_tokens."
+    )
+    # The patch replaces a raise at this call site with a warning plus a
+    # bitmask disable. There is no structural way to observe a call site, and
+    # exercising it needs a compiled grammar and a real speculative-decode
+    # batch, so pin it by source.
+    assert "accept_tokens" in inspect.getsource(bitmask_fn), (
+        "StructuredOutputManager.grammar_bitmask no longer calls "
+        "accept_tokens — the patched call site moved; re-apply the residual "
+        "patch to vllm/v1/structured_output/__init__.py at its new location."
+    )

--- a/tests/contract/test_v2_runner_containment.py
+++ b/tests/contract/test_v2_runner_containment.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Contract tests for the V2-model-runner containment the residual relies on.
+
+vLLM ships a second GPU model runner (``vllm/v1/worker/gpu/``) with its own
+InputBatch and sampler stack, which does not carry the residual sampler hooks
+(per-request ``logprobs_mode``, ``enforced_token_ids``,
+``need_processed_logprobs``). A request routed through it samples without any
+of that, and without an error. Containment is therefore an env pin,
+``VLLM_USE_V2_MODEL_RUNNER=0``, baked into docker/Dockerfile.gonka-poc.
+
+The pin only works while two assumptions hold:
+
+1. the env knob still exists — once renamed or dropped, the pin is a silent
+   no-op and a future flip of the default re-exposes the V2 runner;
+2. the V2 runner still has its own sampler stack — once the stacks are
+   unified, either the pin is unnecessary or the hooks need a V2 port.
+
+Scope: read-only inspection. No GPU, no engine startup.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_v2_runner_env_knob_exists() -> None:
+    """Require VLLM_USE_V2_MODEL_RUNNER to still be a recognized env knob."""
+    pytest.importorskip("vllm")
+    envs = importlib.import_module("vllm.envs")
+    assert "VLLM_USE_V2_MODEL_RUNNER" in getattr(envs, "environment_variables", {}), (
+        "VLLM_USE_V2_MODEL_RUNNER is gone from vllm.envs — the baked "
+        "container pin no longer selects anything. Find the current "
+        "V2-runner switch and re-pin, or confirm the V2 runner was removed."
+    )
+
+
+def test_v2_runner_still_separate_sampler() -> None:
+    """Require the V2 runner to keep the separate sampler stack it is pinned for."""
+    pytest.importorskip("vllm")
+    try:
+        v2_sampler = importlib.import_module("vllm.v1.worker.gpu.sample.sampler")
+    except ModuleNotFoundError:
+        pytest.skip(
+            "V2 runner sampler module is gone — the stacks may have been "
+            "unified; re-evaluate whether the env pin is still needed."
+        )
+    v1_sampler = importlib.import_module("vllm.v1.sample.sampler")
+    assert v2_sampler.__name__ != v1_sampler.__name__, (
+        "The V2 sampler resolves to the V1 module — unification happened, so "
+        "re-evaluate the containment pin and whether the residual hooks now "
+        "cover both runners."
+    )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -496,7 +496,7 @@ class GroupCoordinator:
         self.mq_broadcaster: MessageQueue | None = None
         if use_message_queue_broadcaster and self.world_size > 1:
             self.mq_broadcaster = MessageQueue.create_from_process_group(
-                self.cpu_group, 1 << 22, 6
+                self.cpu_group, 1 << 22, 64
             )
 
         # TODO(#35915): Remove is_tpu() check once tpu_inference
@@ -541,7 +541,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             writer_rank=writer_rank,
             external_writer_handle=external_writer_handle,
             blocking=blocking,
@@ -555,7 +555,7 @@ class GroupCoordinator:
         return MessageQueue.create_from_process_group_single_reader(
             self.cpu_group,
             1 << 22,
-            6,
+            64,
             reader_rank=self.ranks[reader_rank_in_group],
             blocking=blocking,
         )

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -256,18 +256,7 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
         tokenizer: TokenizerLike | None,
         return_as_token_id: bool = False,
     ) -> str:
-        if return_as_token_id:
-            return format_token_id_placeholder(token_id)
-
-        if logprob.decoded_token is not None:
-            return logprob.decoded_token
-
-        if tokenizer is None:
-            raise ValueError(
-                "Unable to get tokenizer because `skip_tokenizer_init=True`"
-            )
-
-        return tokenizer.decode([token_id])
+        return str(token_id)
 
 
 def format_token_id_placeholder(token_id: int) -> str:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -47,6 +47,7 @@ from vllm.sampling_params import (
     ThinkingTokenBudget,
 )
 from vllm.utils import random_uuid
+from vllm.validation import EnforcedTokens
 
 logger = init_logger(__name__)
 
@@ -269,6 +270,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     prompt_logprobs: int | None = None
     allowed_token_ids: list[int] | None = None
     bad_words: list[str] = Field(default_factory=list)
+    logprobs_mode: Literal["raw_logprobs", "processed_logprobs"] | None = None
     # --8<-- [end:chat-completion-sampling-params]
 
     # --8<-- [start:chat-completion-extra-params]
@@ -437,6 +439,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",
+    )
+
+    enforced_tokens: EnforcedTokens | None = Field(
+        default=None,
+        description="Enforced token sequence for Gonka validation replay.",
+    )
+    enforced_str: str | None = Field(
+        default=None,
+        description="Enforced output string for Gonka validation replay.",
     )
 
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
@@ -679,6 +690,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             stop_token_ids=stop_token_ids,
             logprobs=self.top_logprobs if self.logprobs else None,
             prompt_logprobs=prompt_logprobs,
+            logprobs_mode=self.logprobs_mode,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens,
             min_tokens=self.min_tokens,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -319,6 +319,26 @@ class OpenAIServingChat(GenerateBaseServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                enforced_ids: list[int] | None = None
+                if request.enforced_str:
+                    enforced_ids = tokenizer.encode(
+                        request.enforced_str, add_special_tokens=False
+                    )
+                elif request.enforced_tokens:
+                    request.enforced_tokens.encode(tokenizer)
+                    enforced_ids = request.enforced_tokens.get_enforced_token_ids()
+
+                if enforced_ids:
+                    if enforced_ids[-1] != tokenizer.eos_token_id:
+                        enforced_ids.append(tokenizer.eos_token_id)
+                    sampling_params.enforced_token_ids = enforced_ids
+                    if (
+                        sampling_params.logprobs_mode is None
+                        and request.enforced_tokens is not None
+                    ):
+                        detected = request.enforced_tokens.detect_logprobs_mode()
+                        if detected:
+                            sampling_params.logprobs_mode = detected
 
             self._log_inputs(
                 sub_request_id,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -93,6 +93,7 @@ class CompletionRequest(OpenAIBaseModel):
     )
     allowed_token_ids: list[int] | None = None
     prompt_logprobs: int | None = None
+    logprobs_mode: Literal["raw_logprobs", "processed_logprobs"] | None = None
     # --8<-- [end:completion-sampling-params]
 
     # --8<-- [start:completion-extra-params]
@@ -356,6 +357,7 @@ class CompletionRequest(OpenAIBaseModel):
             stop=self.stop,
             stop_token_ids=stop_token_ids,
             logprobs=self.logprobs,
+            logprobs_mode=self.logprobs_mode,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens if not echo_without_generation else 1,
             min_tokens=self.min_tokens,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -281,6 +281,10 @@ class SamplingParams(
     When set, logprobs for exactly these token IDs will be returned,
     in addition to the sampled token. This is useful for scoring tasks
     where you want to compare probabilities of specific label tokens."""
+    logprobs_mode: str | None = None
+    """Per-request logprobs mode override for sampled-token logprobs.
+    Accepted values: 'raw_logprobs', 'processed_logprobs', or None
+    (use deployment-level --logprobs-mode default)."""
     flat_logprobs: bool = False
     """Whether to return logprobs in flatten format (i.e. FlatLogprob)
     for better performance.
@@ -340,6 +344,11 @@ class SamplingParams(
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
 
+    enforced_token_ids: list[int] | None = None
+    """Enforced next-token IDs for gonka-style validation replay. When set,
+    the sampler will force the generated token at each step to match this
+    sequence, regardless of the underlying logits."""
+
     skip_reading_prefix_cache: bool | None = None
     thinking_token_budget: int | None = None
     """Maximum number of tokens allowed for thinking operations."""
@@ -366,6 +375,7 @@ class SamplingParams(
         stop: str | list[str] | None = None,
         stop_token_ids: list[int] | None = None,
         bad_words: list[str] | None = None,
+        enforced_token_ids: list[int] | None = None,
         thinking_token_budget: int | None = None,
         include_stop_str_in_output: bool = False,
         ignore_eos: bool = False,
@@ -373,6 +383,7 @@ class SamplingParams(
         min_tokens: int = 0,
         logprobs: int | None = None,
         prompt_logprobs: int | None = None,
+        logprobs_mode: str | None = None,
         detokenize: bool = True,
         skip_special_tokens: bool = True,
         spaces_between_special_tokens: bool = True,
@@ -426,6 +437,7 @@ class SamplingParams(
             stop=stop,
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,
+            enforced_token_ids=enforced_token_ids,
             thinking_token_budget=thinking_token_budget,
             include_stop_str_in_output=include_stop_str_in_output,
             ignore_eos=ignore_eos,
@@ -433,6 +445,7 @@ class SamplingParams(
             min_tokens=min_tokens,
             logprobs=logprobs,
             prompt_logprobs=prompt_logprobs,
+            logprobs_mode=logprobs_mode,
             detokenize=detokenize,
             skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens,
@@ -599,6 +612,16 @@ class SamplingParams(
                 f"{self.prompt_logprobs}.",
                 parameter="prompt_logprobs",
                 value=self.prompt_logprobs,
+            )
+        if self.logprobs_mode is not None and self.logprobs_mode not in (
+            "raw_logprobs",
+            "processed_logprobs",
+        ):
+            raise VLLMValidationError(
+                "logprobs_mode must be 'raw_logprobs', 'processed_logprobs', "
+                f"or None, got {self.logprobs_mode!r}.",
+                parameter="logprobs_mode",
+                value=self.logprobs_mode,
             )
         assert isinstance(self.stop_token_ids, list)
         if not all(isinstance(st_id, int) for st_id in self.stop_token_ids):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -152,6 +152,10 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
+                # 64 (default 10): a briefly-slow TP reader starves the writer
+                # (EngineCore) under burst load -> "No available shared memory
+                # broadcast block" engine stalls. Costs 64 x 16 MiB /dev/shm.
+                max_chunks=64,
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -48,8 +48,20 @@ class SamplingMetadata:
     # req_index -> list of token IDs to get logprobs for
     logprob_token_ids: dict[int, list[int]] | None = None
 
+    # Per-request logprobs mode: "raw_logprobs", "processed_logprobs",
+    # "mixed", or None (no sampled-token logprobs requested).
+    batch_logprobs_mode: str | None = None
+
+    # Per-row bool mask: True = processed, False = raw.
+    # Only materialized when batch_logprobs_mode == "mixed".
+    logprobs_is_processed: torch.Tensor | None = None
+
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
     # thinking-token-budget logits (holder may exist with an empty tracking set).
     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
+
+    # Enforced next token ids for validation replay (gonka PoC).
+    # Shape [num_reqs], -1 means no enforcement for that request.
+    enforced_next_token_ids: torch.Tensor | None = None

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -120,12 +120,43 @@ class TopKTopPSampler(nn.Module):
         else:
             self.forward = self.forward_native
 
+    def sample(
+        self,
+        logits: torch.Tensor,
+        generators: dict[int, torch.Generator],
+        k: torch.Tensor | None,
+        p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Sample with optional processed logprobs.
+
+        When need_processed_logprobs is True and the active forward
+        implementation cannot produce them (FlashInfer / aiter fast
+        paths), this falls back to forward_native transparently.
+        """
+        if need_processed_logprobs and self.forward is not self.forward_native:
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=True,
+            )
+        return self.forward(
+            logits,
+            generators,
+            k,
+            p,
+            need_processed_logprobs=need_processed_logprobs,
+        )
+
     def forward_native(
         self,
         logits: torch.Tensor,
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling.
@@ -136,7 +167,7 @@ class TopKTopPSampler(nn.Module):
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
             logits_to_return = logits
-        elif self.logprobs_mode == "processed_logprobs":
+        elif self.logprobs_mode == "processed_logprobs" or need_processed_logprobs:
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
         probs = logits.softmax(dim=-1, dtype=torch.float32)
         return (
@@ -150,21 +181,35 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """More optimized implementation for top-k and top-p sampling."""
         # Fall back to the PyTorch-native path when FlashInfer has nothing
-        # to do (no top-k / top-p filter) or when per-request generators
-        # are present (unsupported by FlashInfer 0.2.3+).
-        if (k is None and p is None) or generators:
+        # to do (no top-k / top-p filter), when per-request generators
+        # are present (unsupported by FlashInfer 0.2.3+), or when the
+        # caller requested processed logprobs (FlashInfer can't expose them).
+        if (k is None and p is None) or generators or need_processed_logprobs:
             if generators:
                 logger.debug_once(
                     "FlashInfer 0.2.3+ does not support "
                     "per-request generators. Falling back to "
                     "PyTorch-native implementation."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         if self.use_fp64_gumbel:
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         assert self.logprobs_mode not in ("processed_logits", "processed_logprobs"), (
             "FlashInfer does not support returning logits/logprobs"
         )
@@ -179,6 +224,7 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         PyTorch-native implementation of top-k and top-p sampling for CPU.
@@ -189,7 +235,7 @@ class TopKTopPSampler(nn.Module):
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":
             logits_to_return = logits
-        elif self.logprobs_mode == "processed_logprobs":
+        elif self.logprobs_mode == "processed_logprobs" or need_processed_logprobs:
             logits_to_return = logits.log_softmax(dim=-1, dtype=torch.float32)
 
         if len(generators) != logits.shape[0] and not self.use_fp64_gumbel:
@@ -225,17 +271,30 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Optimized ROCm/aiter path (same structure as forward_cuda)."""
-        if (k is None and p is None) or generators:
+        if (k is None and p is None) or generators or need_processed_logprobs:
             if generators:
                 logger.warning_once(
                     "aiter sampler does not support per-request generators; "
                     "falling back to PyTorch-native."
                 )
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         if self.use_fp64_gumbel:
-            return self.forward_native(logits, generators, k, p)
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
+            )
         assert self.logprobs_mode not in (
             "processed_logits",
             "processed_logprobs",
@@ -288,14 +347,22 @@ class TopKTopPSampler(nn.Module):
         generators: dict[int, torch.Generator],
         k: torch.Tensor | None,
         p: torch.Tensor | None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if generators:
-            logger.warning_once(
-                "xpu kernel topk_topp_sampler does not support "
-                "per-request generators. Falling back to "
-                "PyTorch-native implementation."
+        if generators or need_processed_logprobs:
+            if generators:
+                logger.warning_once(
+                    "xpu kernel topk_topp_sampler does not support "
+                    "per-request generators. Falling back to "
+                    "PyTorch-native implementation."
+                )
+            return self.forward_native(
+                logits,
+                generators,
+                k,
+                p,
+                need_processed_logprobs=need_processed_logprobs,
             )
-            return self.forward_native(logits, generators, k, p)
         random_sampled = torch.empty(
             logits.shape[0], dtype=torch.int64, device=logits.device
         )

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -76,17 +76,32 @@ class Sampler(nn.Module):
         predict_bonus_token: bool = False,
         logprobs_mode_override: LogprobsMode | None = None,
     ) -> SamplerOutput:
-        logprobs_mode = logprobs_mode_override or self.logprobs_mode
+        num_logprobs = sampling_metadata.max_num_logprobs
+
+        # Determine effective logprobs mode.
+        # Priority: logprobs_mode_override (RejectionSampler) >
+        #           batch_logprobs_mode (per-request) > deployment default.
+        if logprobs_mode_override is not None:
+            effective_mode = logprobs_mode_override
+            is_mixed = False
+        else:
+            batch_mode = sampling_metadata.batch_logprobs_mode
+            if batch_mode is not None and batch_mode != self.logprobs_mode:
+                effective_mode = batch_mode
+                is_mixed = batch_mode == "mixed"
+            else:
+                effective_mode = self.logprobs_mode
+                is_mixed = False
+
         # NOTE(woosuk): Use the original logits (before any penalties or
         # temperature scaling) for the top-k logprobs.
         # This is different from the V0 sampler, which uses the logits that
         # is used for sampling (after penalties and temperature scaling).
-        num_logprobs = sampling_metadata.max_num_logprobs
         raw_logprobs: torch.Tensor | None = None
         if num_logprobs is not None or sampling_metadata.logprob_token_ids:
-            if logprobs_mode == "raw_logprobs":
+            if effective_mode in ("raw_logprobs", "mixed"):
                 raw_logprobs = self.compute_logprobs(logits)
-            elif logprobs_mode == "raw_logits":
+            elif effective_mode == "raw_logits":
                 if logits.dtype == torch.float32:
                     raw_logprobs = logits.clone()
                 else:
@@ -98,15 +113,45 @@ class Sampler(nn.Module):
         logits = self.apply_logits_processors(
             logits, sampling_metadata, predict_bonus_token
         )
+
+        need_processed = num_logprobs is not None and effective_mode in (
+            "processed_logprobs",
+            "processed_logits",
+            "mixed",
+        )
         # Sample the next token.
-        sampled, processed_logprobs = self.sample(logits, sampling_metadata)
-        if processed_logprobs is not None:
+        sampled, processed_logprobs = self.sample(
+            logits,
+            sampling_metadata,
+            logprobs_mode_override=logprobs_mode_override,
+            need_processed_logprobs=need_processed,
+        )
+
+        # For homogeneous batches, processed logprobs replace raw when the
+        # effective mode wants processed output. When a per-request override
+        # selects raw_logprobs (or raw_logits), keep the raw values computed
+        # earlier and discard the processed logprobs the sampler produced as
+        # a side-effect of the deployment default.
+        if (
+            not is_mixed
+            and processed_logprobs is not None
+            and effective_mode not in ("raw_logprobs", "raw_logits")
+        ):
             raw_logprobs = processed_logprobs
+
         # Convert sampled token ids to int64 (long) type to ensure compatibility
         # with subsequent operations that may use these values as indices.
-        # This conversion is necessary because FlashInfer sampling operations
-        # return int32 (while PyTorch argmax and topk return int64).
         sampled = sampled.long()
+
+        # Override with enforced token ids where specified (gonka PoC v2).
+        # NOTE: this is post-sampling so logprobs are still computed against
+        # the model's actual distribution, not the enforced token. That is
+        # exactly what PoC validation needs to compare against the origin.
+        if sampling_metadata.enforced_next_token_ids is not None:
+            enforced = sampling_metadata.enforced_next_token_ids
+            mask = enforced != -1
+            if mask.any():
+                sampled[mask] = enforced[mask]
 
         # Handle logprob_token_ids if specified (more efficient than full vocab)
         # This is used by generative_scoring API to get logprobs for specific tokens
@@ -119,16 +164,52 @@ class Sampler(nn.Module):
 
         if num_logprobs is None:
             logprobs_tensors = logprob_token_ids_tensors
-        elif num_logprobs == -1:
-            # Return the full unsorted and unranked logprobs.
-            logprobs_tensors = LogprobsTensors(
-                torch.empty(0), raw_logprobs, torch.empty(0)
-            )
+        elif not is_mixed:
+            if num_logprobs == -1:
+                # Return the full unsorted and unranked logprobs.
+                logprobs_tensors = LogprobsTensors(
+                    torch.empty(0), raw_logprobs, torch.empty(0)
+                )
+            else:
+                # Gather the logprobs and ranks of the topk and sampled token.
+                logprobs_tensors = self.gather_logprobs(
+                    raw_logprobs, num_logprobs, token_ids=sampled
+                )
         else:
-            # Gather the logprobs and ranks of the topk and sampled token.
-            logprobs_tensors = self.gather_logprobs(
-                raw_logprobs, num_logprobs, token_ids=sampled
-            )
+            # Mixed mode: gather from both raw and processed, merge per row.
+            lp_mask = sampling_metadata.logprobs_is_processed
+            if num_logprobs == -1:
+                lp = torch.where(
+                    lp_mask.unsqueeze(-1),
+                    processed_logprobs,
+                    raw_logprobs,
+                )
+                logprobs_tensors = LogprobsTensors(torch.empty(0), lp, torch.empty(0))
+            else:
+                raw_gathered = self.gather_logprobs(
+                    raw_logprobs, num_logprobs, token_ids=sampled
+                )
+                proc_gathered = self.gather_logprobs(
+                    processed_logprobs, num_logprobs, token_ids=sampled
+                )
+                mask_2d = lp_mask.unsqueeze(-1)
+                logprobs_tensors = LogprobsTensors(
+                    logprob_token_ids=torch.where(
+                        mask_2d,
+                        proc_gathered.logprob_token_ids,
+                        raw_gathered.logprob_token_ids,
+                    ),
+                    logprobs=torch.where(
+                        mask_2d,
+                        proc_gathered.logprobs,
+                        raw_gathered.logprobs,
+                    ),
+                    selected_token_ranks=torch.where(
+                        lp_mask,
+                        proc_gathered.selected_token_ranks,
+                        raw_gathered.selected_token_ranks,
+                    ),
+                )
 
         # If we have both num_logprobs and logprob_token_ids, prefer
         # logprob_token_ids as it's more specific
@@ -245,6 +326,7 @@ class Sampler(nn.Module):
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
         logprobs_mode_override: LogprobsMode | None = None,
+        need_processed_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Sample logits based on sampling metadata.
 
@@ -266,7 +348,9 @@ class Sampler(nn.Module):
                 ):
                     if logprobs_mode == "processed_logits":
                         processed_logprobs = logits
-                    elif logprobs_mode == "processed_logprobs":
+                    elif (
+                        logprobs_mode == "processed_logprobs" or need_processed_logprobs
+                    ):
                         processed_logprobs = self.compute_logprobs(logits)
                 return greedy_sampled, processed_logprobs
 
@@ -283,11 +367,12 @@ class Sampler(nn.Module):
             logits = processor.apply(logits)
 
         # Apply top_k and/or top_p.
-        random_sampled, processed_logprobs = self.topk_topp_sampler(
+        random_sampled, processed_logprobs = self.topk_topp_sampler.sample(
             logits,
             sampling_metadata.generators,
             sampling_metadata.top_k,
             sampling_metadata.top_p,
+            need_processed_logprobs=need_processed_logprobs,
         )
 
         if greedy_sampled is None:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -283,6 +283,7 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
+                grammar_rejected = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for i, token in enumerate(req_tokens):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
@@ -316,9 +317,15 @@ class StructuredOutputManager:
                         if accepted:
                             state_advancements += 1
                         elif not post_reasoning_end_in_window:
-                            raise AssertionError(
-                                (token, req_id, scheduled_spec_decode_tokens)
+                            logger.warning(
+                                "Grammar rejected token %d for request %s "
+                                "during speculative decode bitmask fill. "
+                                "Disabling bitmask for this request.",
+                                token,
+                                req_id,
                             )
+                            apply_bitmask = False
+                            grammar_rejected = True
                     cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
@@ -333,7 +340,12 @@ class StructuredOutputManager:
                     #   should_fill_bitmask still returns False here because
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
-                    bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
+                    # A grammar rejection above disables the bonus row too:
+                    # the FSM is out of sync, so constraining with it would
+                    # corrupt output.
+                    bonus_apply = not grammar_rejected and (
+                        self.should_fill_bitmask(request) or apply_bitmask
+                    )
                     self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
                 if state_advancements > 0:

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -148,24 +148,34 @@ class XgrammarGrammar(StructuredOutputGrammar):
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
     _is_terminated: bool = field(default=False, repr=False, hash=False)
+    _grammar_failed: bool = field(default=False, repr=False, hash=False)
 
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
         Returns True if the FSM was advanced successfully.
         Returns False if the FSM failed to advance.
+
+        Grammar graceful degradation: when a token is rejected (e.g.
+        enforced tokens from validation replay that conflict with the
+        grammar FSM), grammar enforcement is disabled for the rest of
+        this request instead of causing a crash.
         """
         if self._is_terminated:
             return False
+        if self._grammar_failed:
+            return True
         for token in tokens:
             if not self.matcher.accept_token(token):
-                logger.error(
-                    "Failed to advance FSM for request %s "
-                    "for tokens %s. Please file an issue.",
-                    request_id,
+                logger.warning(
+                    "Grammar rejected token %d for request %s. "
+                    "Disabling grammar enforcement for this request "
+                    "(token may be from enforced replay).",
                     token,
+                    request_id,
                 )
-                return False
+                self._grammar_failed = True
+                return True
             self.num_processed_tokens += 1
         self._is_terminated = self.matcher.is_terminated()
         return True
@@ -188,11 +198,15 @@ class XgrammarGrammar(StructuredOutputGrammar):
         return accepted_tokens
 
     def rollback(self, num_tokens: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.rollback(num_tokens)
         self.num_processed_tokens -= num_tokens
         self._is_terminated = self.matcher.is_terminated()
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
+        if self._grammar_failed:
+            return
         self.matcher.fill_next_token_bitmask(bitmask, idx)
 
     def is_terminated(self) -> bool:
@@ -200,6 +214,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def reset(self):
         self.num_processed_tokens = 0
+        self._grammar_failed = False
         self.matcher.reset()
 
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -106,6 +106,7 @@ class InputBatch:
         is_pooling_model: bool = False,
         cp_kv_cache_interleave_size: int = 1,
         reasoning_config: ReasoningConfig | None = None,
+        logprobs_mode_default: str = "raw_logprobs",
     ):
         self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
             reasoning_config,
@@ -253,6 +254,8 @@ class InputBatch:
         self.generators: dict[int, torch.Generator] = {}
 
         self.num_logprobs: dict[str, int] = {}
+        self.logprobs_mode_default = logprobs_mode_default
+        self.logprobs_modes: dict[str, str] = {}
 
         # req_id -> list of specific token IDs to compute logprobs for
         # More efficient than num_logprobs=-1 when only a few tokens are needed
@@ -276,6 +279,9 @@ class InputBatch:
         self.logits_processing_needs_token_ids = np.zeros(max_num_reqs, dtype=bool)
 
         self.req_output_token_ids: list[list[int] | None] = []
+
+        # Enforced next-token IDs keyed by req_id (gonka PoC v2 replay).
+        self.req_enforced_token_ids: dict[str, list[int] | None] = {}
 
         # Store provided logitsprocs. If none are provided, initialize empty
         # data structure
@@ -340,13 +346,23 @@ class InputBatch:
         req_index = self._register_add_request(request)
 
         req_id = request.req_id
+        enforced = (
+            getattr(request.sampling_params, "enforced_token_ids", None)
+            if request.sampling_params
+            else None
+        )
+
         if req_index == len(self._req_ids):
             self._req_ids.append(req_id)
             self.req_output_token_ids.append(request.output_token_ids)
+            if enforced:
+                self.req_enforced_token_ids[req_id] = enforced
             self.spec_token_ids.append([])
         else:
             self._req_ids[req_index] = req_id
             self.req_output_token_ids[req_index] = request.output_token_ids
+            if enforced:
+                self.req_enforced_token_ids[req_id] = enforced
             self.spec_token_ids[req_index].clear()
 
         self.req_id_to_index[req_id] = req_index
@@ -418,6 +434,9 @@ class InputBatch:
                     self.vocab_size
                     if sampling_params.logprobs == -1
                     else sampling_params.logprobs
+                )
+                self.logprobs_modes[req_id] = (
+                    sampling_params.logprobs_mode or self.logprobs_mode_default
                 )
 
             # Store specific token IDs to compute logprobs for (more efficient)
@@ -525,6 +544,7 @@ class InputBatch:
         self.batch_update_builder.removed_append(req_index)
         self._req_ids[req_index] = None
         self.req_output_token_ids[req_index] = None
+        self.req_enforced_token_ids.pop(req_id, None)
         self.spec_token_ids[req_index].clear()
         self.block_table.clear_row(req_index)
 
@@ -553,6 +573,7 @@ class InputBatch:
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
         self.logprob_token_ids.pop(req_id, None)
+        self.logprobs_modes.pop(req_id, None)
         if self.prev_req_id_to_index is not None:
             self.prev_req_id_to_index.pop(req_id, None)
 
@@ -809,6 +830,41 @@ class InputBatch:
         del self.req_output_token_ids[num_reqs:]
         del self.spec_token_ids[num_reqs:]
 
+    def _build_enforced_tensor(self) -> "torch.Tensor | None":
+        """Build enforced_next_token_ids tensor from current batch state.
+
+        Returns None if no requests have enforced tokens.
+        Shape [num_reqs], -1 means no enforcement for that request.
+        """
+        num_reqs = self.num_reqs
+        if num_reqs == 0 or not self.req_enforced_token_ids:
+            return None
+        enforced_list: list[int] = []
+        has_any = False
+        for i in range(num_reqs):
+            req_id = self._req_ids[i]
+            etids = (
+                self.req_enforced_token_ids.get(req_id) if req_id is not None else None
+            )
+            if etids:
+                out = self.req_output_token_ids[i]
+                out_len = len(out) if out else 0
+                enforced_list.append(
+                    etids[out_len] if out_len < len(etids) else etids[-1]
+                )
+                has_any = True
+            else:
+                enforced_list.append(-1)
+        if not has_any:
+            return None
+        return torch.tensor(enforced_list, dtype=torch.long, device=self.device)
+
+    def _update_enforced_tensor(self) -> None:
+        """Update enforced_next_token_ids on sampling_metadata each step."""
+        if self.sampling_metadata is None:
+            return
+        self.sampling_metadata.enforced_next_token_ids = self._build_enforced_tensor()
+
     def refresh_metadata(self):
         """Apply any batch updates to sampling metadata."""
 
@@ -828,6 +884,9 @@ class InputBatch:
             logit_proc.update_state(batch_update)
         if batch_update:
             self.sampling_metadata = self._make_sampling_metadata()
+        # Always update enforced tokens (they advance each step).
+        if self.req_enforced_token_ids:
+            self._update_enforced_tensor()
 
     def _make_sampling_metadata(self) -> SamplingMetadata:
         num_reqs = self.num_reqs
@@ -912,6 +971,19 @@ class InputBatch:
                     req_index = self.req_id_to_index[req_id]
                     logprob_token_ids_by_index[req_index] = token_ids
 
+        batch_mode = self.batch_logprobs_mode
+        logprobs_is_processed: torch.Tensor | None = None
+        if batch_mode == "mixed":
+            logprobs_is_processed = torch.zeros(
+                num_reqs, dtype=torch.bool, device=self.device
+            )
+            for i in range(num_reqs):
+                req_id = self._req_ids[i]
+                if req_id is not None:
+                    logprobs_is_processed[i] = (
+                        self.logprobs_modes.get(req_id) == "processed_logprobs"
+                    )
+
         return SamplingMetadata(
             temperature=temperature,
             all_greedy=self.all_greedy,
@@ -932,6 +1004,9 @@ class InputBatch:
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
             thinking_budget_state_holder=self.thinking_budget_state_holder,
+            batch_logprobs_mode=batch_mode,
+            logprobs_is_processed=logprobs_is_processed,
+            enforced_next_token_ids=self._build_enforced_tensor(),
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:
@@ -1121,6 +1196,21 @@ class InputBatch:
     @property
     def max_num_logprobs(self) -> int | None:
         return max(self.num_logprobs.values()) if self.num_logprobs else None
+
+    @property
+    def batch_logprobs_mode(self) -> str | None:
+        """Aggregate per-request logprobs modes into a batch-level mode.
+
+        Returns None when no request in the batch requested logprobs,
+        the single shared mode when all requests agree, or "mixed" when
+        the batch contains more than one distinct mode.
+        """
+        if not self.logprobs_modes:
+            return None
+        modes = set(self.logprobs_modes.values())
+        if len(modes) == 1:
+            return next(iter(modes))
+        return "mixed"
 
     @property
     def no_allowed_token_ids(self) -> bool:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -710,6 +710,7 @@ class GPUModelRunner(
             is_pooling_model=self.is_pooling_model,
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             reasoning_config=self.vllm_config.reasoning_config,
+            logprobs_mode_default=self.model_config.logprobs_mode,
         )
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
@@ -7067,6 +7068,7 @@ class GPUModelRunner(
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
                 reasoning_config=self.vllm_config.reasoning_config,
+                logprobs_mode_default=self.model_config.logprobs_mode,
             )
 
         assert self._init_block_sizes == block_sizes, (

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,0 +1,75 @@
+"""EnforcedToken support for gonka-style inference validation."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EnforcedToken(BaseModel):
+    token: str
+    top_tokens: list[str] = Field(default_factory=list)
+    token_id: int | None = Field(default=None, exclude=True)
+    top_token_ids: list[int] = Field(default_factory=list, exclude=True)
+
+    def encode(self, tokenizer) -> None:
+        """Convert token strings to token IDs.
+        Tokens from gonka API are already numeric strings (token IDs)."""
+        try:
+            self.token_id = int(self.token)
+            self.top_token_ids = [int(t) for t in self.top_tokens]
+        except ValueError:
+            # Fallback: tokenize the string
+            ids = tokenizer.encode(self.token, add_special_tokens=False)
+            self.token_id = ids[0] if ids else 0
+            self.top_token_ids = []
+            for t in self.top_tokens:
+                t_ids = tokenizer.encode(t, add_special_tokens=False)
+                if t_ids:
+                    self.top_token_ids.append(t_ids[0])
+
+
+class EnforcedTokens(BaseModel):
+    tokens: list[EnforcedToken]
+
+    def encode(self, tokenizer) -> None:
+        for token in self.tokens:
+            token.encode(tokenizer)
+
+    @classmethod
+    def from_content(cls, content: list[dict[str, Any]]) -> "EnforcedTokens":
+        tokens = []
+        for position in content:
+            token = position["token"]
+            top_tokens = [x["token"] for x in position["top_logprobs"]]
+            tokens.append(EnforcedToken(token=token, top_tokens=top_tokens))
+        return cls(tokens=tokens)
+
+    def get_enforced_token_ids(self) -> list[int]:
+        if not self.tokens or self.tokens[0].token_id is None:
+            raise ValueError("Enforced tokens are not encoded")
+        return [token.token_id for token in self.tokens]
+
+    def detect_logprobs_mode(self, threshold: float = 0.10) -> str | None:
+        """Classify original inference logprobs mode from top_token_ids.
+
+        In processed-logprobs results, empty top-k slots are padded with the
+        lowest vocab IDs (0-3 for Qwen: ``!``, ``"``, ``#``, ``$``) at
+        logprob -9999. This makes ~75% of top_token_ids entries < 4.
+        In raw-logprobs results, only ~0.2% of entries are < 4.
+
+        Must be called after encode().
+
+        Returns ``'raw_logprobs'``, ``'processed_logprobs'``, or ``None``
+        if there is insufficient data (fewer than 10 top-token entries).
+        """
+        total = 0
+        low_id_count = 0
+        for t in self.tokens:
+            for tid in t.top_token_ids:
+                total += 1
+                if tid < 4:
+                    low_id_count += 1
+        if total < 10:
+            return None
+        ratio = low_id_count / total
+        return "processed_logprobs" if ratio > threshold else "raw_logprobs"


### PR DESCRIPTION
**First PR of a series. This one changes no behaviour on purpose.**

The PoC sampler has been running in production on vLLM 0.20 as a fat fork of this repository. This carries that same logic to 0.25.1 in the thin-residual shape: the parts of the sampler with no public extension point stay in-tree, and everything else — nonce partitioning, seeded RNG, Householder scoring, L2 and binomial validation, DeepSeek-V4 support — lives in the out-of-tree `gonka-poc` plugin, loaded through the `vllm.general_plugins` entry point.

## Why this is a separate PR from the fixes

Porting turned up around ten things that look like defects. Rather than fold them into the port, this PR carries the production logic **as it is** and each finding gets its own follow-up PR with its own argument.

That way, if one of them is not a bug but a deliberate choice — and at least two probably are — rejecting it costs a single PR and leaves the port intact. It also means the diff below can be reviewed as a *port*: the question is "is this the same logic on the new base", not "is this code correct".

## What is in the diff

14 files under `vllm/`, plus the Dockerfile that composes the image and three contract tests.

The Python is the deployed source, reformatted by this repository's own ruff hooks (it did not pass `ruff check` as-is, so CI would have been red). The only change ruff made beyond formatting is `Optional[X]` → `X | None` in `validation.py`. **The AST is otherwise byte-identical to what runs in production** — worth checking if you want to bound the review:

```bash
# every file except validation.py parses to the same tree as the deployed source
python -c "import ast,sys; a,b=sys.argv[1:3]; print(ast.dump(ast.parse(open(a).read()))==ast.dump(ast.parse(open(b).read())))" \
  deployed/vllm/v1/sample/sampler.py vllm/v1/sample/sampler.py
```

Grouped by what they do:

| Area | Files |
| --- | --- |
| Enforced-token replay | `sampling_params.py`, `v1/sample/metadata.py`, `v1/sample/sampler.py`, `v1/worker/gpu_input_batch.py`, `v1/worker/gpu_model_runner.py` |
| Logprobs mode (raw vs processed) | `v1/sample/ops/topk_topp_sampler.py`, `v1/sample/sampler.py` |
| HTTP ingestion of both | `validation.py`, `entrypoints/openai/chat_completion/{protocol,serving}.py`, `entrypoints/generate/base/serving.py` |
| shm broadcast ring size | `distributed/parallel_state.py`, `v1/executor/multiproc_executor.py` |
| Structured output | `v1/structured_output/__init__.py`, `v1/structured_output/backend_xgrammar.py` |

Two of these carry production history worth stating plainly rather than leaving for you to find:

**shm ring size (`max_chunks` 6 → 64).** Not a tuning preference. Kimi-K2.6 at TP=4 died repeatedly under sustained load on a 4×B300 fleet; raising these rings moved engine deaths from roughly every 35 minutes to every 2–3 hours. It is a mitigation, not a cure — stalls were still seen near idle afterwards. The port keeps it hardcoded exactly as production has it; making it a knob is proposed separately, because ~1.3 GiB of extra `/dev/shm` per engine is not something to impose on deployments that never hit this.

**`_get_decoded_token` returning `str(token_id)`.** This changes `logprobs` output for every endpoint, not just the PoC path. It came from the fat fork, was marked as dropped during the original migration on the promise of a plugin-side serialiser that was never written, and so came back. Kept here because production depends on it; questioned separately.

## Verification

`ruff check` and `ruff format` clean across all 17 Python files. The three contract tests assert behaviour rather than grepping source text — the residual overlays `.py` onto a pre-built wheel, so an upstream rename does not break the build, it produces an image whose sampler silently skips the PoC path. That is the failure they exist to catch.

Image built from this branch and exercised on B300 hardware with DeepSeek-V4 and Kimi-K2.6.

## What follows

Roughly nine PRs, each one finding, each independently rejectable. Ordered so the ones most likely to be real defects come first — a request-scoped mask leak, unvalidated replay ids reaching an embedding lookup — and the ones most likely to be your deliberate design come last.
