### PR TITLE
fix(poc): stop a disabled grammar from leaking another request's mask

### DIFF
--- a/tests/contract/test_grammar_failure_isolation.py
+++ b/tests/contract/test_grammar_failure_isolation.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""What a request sees after its own grammar has been disabled.
+
+When ``XgrammarGrammar`` gives up on a request it sets ``_grammar_failed`` and
+stops constraining it. The two methods below are what the rest of the engine
+calls afterwards, and both are shared with other requests: the bitmask is one
+tensor with a row per request, reused across steps.
+
+Neither test needs a GPU or a running engine -- ``_grammar_failed`` short-
+circuits before the matcher is touched, so the grammar object is constructed
+without one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("xgrammar")
+
+from vllm.v1.structured_output.backend_xgrammar import (  # noqa: E402
+    XgrammarGrammar,
+)
+
+
+def _failed_grammar() -> XgrammarGrammar:
+    """A grammar in the failed state, with no matcher behind it."""
+    grammar = object.__new__(XgrammarGrammar)
+    grammar._grammar_failed = True
+    return grammar
+
+
+def test_failed_grammar_does_not_inherit_the_previous_row() -> None:
+    """A disabled grammar must clear its row, not leave the last mask in it.
+
+    Rows are reused between steps and between requests. Returning without
+    writing leaves whatever occupied the row before -- in a shared batch,
+    another request's grammar -- silently constraining this request to an
+    unrelated set of tokens.
+    """
+    vocab_bits = 4
+    bitmask = torch.zeros((2, vocab_bits), dtype=torch.int32)
+    # Row 1 carries a leftover mask admitting a single token.
+    bitmask[1].fill_(0)
+    bitmask[1][0] = 0b0010
+
+    _failed_grammar().fill_bitmask(bitmask, 1)
+
+    assert torch.equal(bitmask[1], torch.full((vocab_bits,), -1, dtype=torch.int32)), (
+        "a disabled grammar left a stale mask in its row"
+    )
+    assert torch.equal(bitmask[0], torch.zeros(vocab_bits, dtype=torch.int32)), (
+        "filling one row must not disturb another request's row"
+    )
+
+
+def test_failed_grammar_accepts_draft_tokens() -> None:
+    """A disabled grammar must not reject the speculative tokens it is given.
+
+    ``validate_tokens`` returns the accepted prefix. A failed matcher's
+    verdicts are meaningless, and rejecting on them takes speculative
+    acceptance to zero -- a silent throughput collapse rather than an error.
+    """
+    tokens = [11, 22, 33]
+
+    assert _failed_grammar().validate_tokens(tokens) == tokens

--- a/tests/contract/test_grammar_failure_isolation.py
+++ b/tests/contract/test_grammar_failure_isolation.py
@@ -1,17 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""What a request sees after its own grammar has been disabled.
-
-When ``XgrammarGrammar`` gives up on a request it sets ``_grammar_failed`` and
-stops constraining it. The two methods below are what the rest of the engine
-calls afterwards, and both are shared with other requests: the bitmask is one
-tensor with a row per request, reused across steps.
-
-Neither test needs a GPU or a running engine -- ``_grammar_failed`` short-
-circuits before the matcher is touched, so the grammar object is constructed
-without one.
-"""
-
 from __future__ import annotations
 
 import pytest
@@ -24,44 +12,14 @@ from vllm.v1.structured_output.backend_xgrammar import (  # noqa: E402
 )
 
 
-def _failed_grammar() -> XgrammarGrammar:
-    """A grammar in the failed state, with no matcher behind it."""
+def test_failed_grammar_is_unconstrained() -> None:
     grammar = object.__new__(XgrammarGrammar)
     grammar._grammar_failed = True
-    return grammar
 
-
-def test_failed_grammar_does_not_inherit_the_previous_row() -> None:
-    """A disabled grammar must clear its row, not leave the last mask in it.
-
-    Rows are reused between steps and between requests. Returning without
-    writing leaves whatever occupied the row before -- in a shared batch,
-    another request's grammar -- silently constraining this request to an
-    unrelated set of tokens.
-    """
-    vocab_bits = 4
-    bitmask = torch.zeros((2, vocab_bits), dtype=torch.int32)
-    # Row 1 carries a leftover mask admitting a single token.
-    bitmask[1].fill_(0)
+    bitmask = torch.zeros((2, 4), dtype=torch.int32)
     bitmask[1][0] = 0b0010
+    grammar.fill_bitmask(bitmask, 1)
 
-    _failed_grammar().fill_bitmask(bitmask, 1)
-
-    assert torch.equal(bitmask[1], torch.full((vocab_bits,), -1, dtype=torch.int32)), (
-        "a disabled grammar left a stale mask in its row"
-    )
-    assert torch.equal(bitmask[0], torch.zeros(vocab_bits, dtype=torch.int32)), (
-        "filling one row must not disturb another request's row"
-    )
-
-
-def test_failed_grammar_accepts_draft_tokens() -> None:
-    """A disabled grammar must not reject the speculative tokens it is given.
-
-    ``validate_tokens`` returns the accepted prefix. A failed matcher's
-    verdicts are meaningless, and rejecting on them takes speculative
-    acceptance to zero -- a silent throughput collapse rather than an error.
-    """
-    tokens = [11, 22, 33]
-
-    assert _failed_grammar().validate_tokens(tokens) == tokens
+    assert torch.equal(bitmask[1], torch.full((4,), -1, dtype=torch.int32))
+    assert torch.equal(bitmask[0], torch.zeros(4, dtype=torch.int32))
+    assert grammar.validate_tokens([11, 22, 33]) == [11, 22, 33]

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -187,10 +187,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
         Returns the prefix list of tokens that are accepted by the FSM.
         """
         if self._grammar_failed:
-            # The FSM is out of sync with the sequence, so its verdicts are
-            # meaningless: filtering against it would reject every draft token
-            # and drive speculative acceptance to zero. Treat all as accepted,
-            # consistent with grammar being disabled for this request.
+            # A failed matcher must not reject speculative tokens.
             return list(tokens)
         accepted_tokens = []
         for token in tokens:
@@ -212,12 +209,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
         if self._grammar_failed:
-            # Allow every token rather than returning early. The bitmask is
-            # reused across steps, so leaving this row untouched would apply
-            # whatever mask last occupied it -- in a shared batch, another
-            # request's grammar -- and constrain this request to an unrelated
-            # token set. -1 is all-bits-set, matching how the manager fills
-            # rows for requests that are not grammar-constrained.
+            # Clear the reused row; -1 allows every token.
             bitmask[idx].fill_(-1)
             return
         self.matcher.fill_next_token_bitmask(bitmask, idx)

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -186,6 +186,12 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
         Returns the prefix list of tokens that are accepted by the FSM.
         """
+        if self._grammar_failed:
+            # The FSM is out of sync with the sequence, so its verdicts are
+            # meaningless: filtering against it would reject every draft token
+            # and drive speculative acceptance to zero. Treat all as accepted,
+            # consistent with grammar being disabled for this request.
+            return list(tokens)
         accepted_tokens = []
         for token in tokens:
             if self.matcher.accept_token(token):
@@ -206,6 +212,13 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
     def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
         if self._grammar_failed:
+            # Allow every token rather than returning early. The bitmask is
+            # reused across steps, so leaving this row untouched would apply
+            # whatever mask last occupied it -- in a shared batch, another
+            # request's grammar -- and constrain this request to an unrelated
+            # token set. -1 is all-bits-set, matching how the manager fills
+            # rows for requests that are not grammar-constrained.
+            bitmask[idx].fill_(-1)
             return
         self.matcher.fill_next_token_bitmask(bitmask, idx)
 


### PR DESCRIPTION
Part 1/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

fill_bitmask returned without writing when the grammar had failed. The
bitmask is one tensor with a row per request, reused across steps, so the
row kept whatever last occupied it -- in a shared batch, another request's
grammar. The request was then constrained to an unrelated token set with
no error anywhere. Fill the row with -1 (all tokens allowed), which is how
the manager fills rows for unconstrained requests.

validate_tokens had the mirror problem: it kept consulting a matcher whose
verdicts are meaningless once the FSM is out of sync, rejecting every draft
token and taking speculative acceptance to zero.
