### PR TITLE
fix(poc): reject replay requests on a V2 engine in the frontend

### DIFF
--- a/tests/contract/test_v2_runner_containment.py
+++ b/tests/contract/test_v2_runner_containment.py
@@ -53,3 +53,34 @@ def test_v2_runner_still_separate_sampler() -> None:
         "re-evaluate the containment pin and whether the residual hooks now "
         "cover both runners."
     )
+
+
+def test_v2_runner_rejects_replay_requests_in_the_frontend() -> None:
+    """A replay request must be refused, and refused before it reaches a worker.
+
+    The env pin is a default, not a guarantee: an operator can flip it, and
+    upstream can change what it defaults to. If a replay request does reach a
+    V2 engine, the only safe answer is a rejected request.
+
+    Where the rejection happens matters as much as that it happens. Raising
+    from inside the worker's sampler would surface during execute_model, which
+    the engine treats as a dead engine: it shuts down and takes every other
+    request with it. One bad request would become an outage. So this asserts
+    the check sits in the frontend validation path, where it is a 400.
+    """
+    pytest.importorskip("vllm")
+    from vllm.sampling_params import SamplingParams
+    from vllm.v1.engine.input_processor import InputProcessor
+
+    class _Config:
+        use_v2_model_runner = True
+
+    processor = object.__new__(InputProcessor)
+    processor.vllm_config = _Config()
+
+    for params in (
+        SamplingParams(enforced_token_ids=[1, 2, 3]),
+        SamplingParams(logprobs_mode="raw_logprobs"),
+    ):
+        with pytest.raises(ValueError, match="V2 model runner"):
+            processor._validate_params(params, ("generate",))

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -91,6 +91,27 @@ class InputProcessor:
             ]
             if not supported_generation_tasks:
                 raise ValueError("This model does not support generation")
+            # The V2 model runner has its own sampler, which does not read
+            # enforced_token_ids or a per-request logprobs_mode. A request
+            # carrying either would be sampled without them and come back
+            # looking ordinary -- a validator would read that reply as a
+            # verified replay when nothing was enforced. Reject it here, in
+            # the frontend, where it is a 400. The same check inside the
+            # worker would kill the engine and every request on it.
+            if self.vllm_config.use_v2_model_runner:
+                if params.enforced_token_ids is not None:
+                    raise ValueError(
+                        "enforced_token_ids is not supported by the V2 model "
+                        "runner. Start the server with "
+                        "VLLM_USE_V2_MODEL_RUNNER=0, or drop the parameter."
+                    )
+                if params.logprobs_mode is not None:
+                    raise ValueError(
+                        "Per-request logprobs_mode is not supported by the V2 "
+                        "model runner. Start the server with "
+                        "VLLM_USE_V2_MODEL_RUNNER=0, or use the engine-level "
+                        "--logprobs-mode."
+                    )
 
             params.verify(
                 self.model_config,


### PR DESCRIPTION
Part 3/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

The V2 model runner has its own sampler and does not read
enforced_token_ids or a per-request logprobs_mode. A replay request
reaching it was sampled without either and came back looking like an
ordinary completion, so a validator would read the reply as a verified
replay when nothing had been enforced.

Containment was an env pin alone (VLLM_USE_V2_MODEL_RUNNER=0), which an
operator can flip and upstream can redefine. This adds the check itself.

It goes in _validate_params, in the frontend, where a ValueError becomes a
400 for that one request. Putting the same check in the worker's sampler --
the obvious place -- is what an earlier revision of this did, and it is
worse than the bug: add_request runs inside execute_model, the engine reads
an exception there as a dead engine, and one malformed request becomes a
node outage.
