### PR TITLE
fix(poc): stop enforcing once the replay is exhausted

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -849,9 +849,11 @@ class InputBatch:
             if etids:
                 out = self.req_output_token_ids[i]
                 out_len = len(out) if out else 0
-                enforced_list.append(
-                    etids[out_len] if out_len < len(etids) else etids[-1]
-                )
+                # Past the end of the replay, stop enforcing rather than
+                # repeating the final id: the sequence has been reproduced, and
+                # pinning every later step to one token prevents the request
+                # from ever finishing on its own.
+                enforced_list.append(etids[out_len] if out_len < len(etids) else -1)
                 has_any = True
             else:
                 enforced_list.append(-1)


### PR DESCRIPTION
Part 5/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

Once the request has produced every id in enforced_token_ids, the index
runs past the end and the code pinned each further step to etids[-1] --
the same token forever. Generation cannot reach a stop condition on its
own, so the request runs to max_tokens emitting one repeated token.

Sampling normally past the end is what the sentinel already means
everywhere else in this function: -1 is "nothing enforced at this
position".

Worth a second opinion: if the intent was that the last id is always EOS,
so repeating it terminates immediately, then this only matters when the
caller omits EOS -- but that is a caller-supplied payload, and the failure
is silent.
