### PR TITLE
fix(poc): do not forward the logprobs-mode override into sample()

### DIFF
--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -120,10 +120,14 @@ class Sampler(nn.Module):
             "mixed",
         )
         # Sample the next token.
+        # The override is deliberately not forwarded to sample(): upstream does
+        # not forward it either, and doing so changes what the speculative
+        # decoding path returns. sample() keeps deciding by the deployment mode,
+        # while need_processed_logprobs only asks it to also produce processed
+        # values for the rows that want them.
         sampled, processed_logprobs = self.sample(
             logits,
             sampling_metadata,
-            logprobs_mode_override=logprobs_mode_override,
             need_processed_logprobs=need_processed,
         )
 


### PR DESCRIPTION
Part 6/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

sample() uses its mode argument to decide what the speculative decoding
path returns, not only what logprobs are reported. Passing a per-request
override into it therefore changes rejection-sampling behaviour for that
request as a side effect of asking for different logprobs.

need_processed_logprobs already carries what the caller actually wants:
also produce processed values for the rows that asked for them. That is
kept; the override is not forwarded, matching upstream.
