### PR TITLE
fix(poc): use the engine's token-id format instead of rewriting logprobs

### DIFF
--- a/tests/contract/test_request_validation_surface.py
+++ b/tests/contract/test_request_validation_surface.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pin the HTTP -> SamplingParams path for enforced-token replay.
+
+The sampler half of replay is pinned in ``test_sampler_surface.py``. This
+file pins the ingestion half: the request fields, the helper that decodes
+them, and the validation that keeps a replay id out of the embedding lookup
+unless the model can embed it.
+
+Both halves have to be present for replay to work, and the failure mode when
+the ingestion half is missing is silent — the payload is dropped by the
+request model and validation degrades into an ordinary generate, with no
+error anywhere. That is what these tests exist to make loud.
+
+Read-only: no GPU, no engine startup, no forward pass.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_validation_module_has_enforced_tokens() -> None:
+    """The helper that turns a replay payload into token ids must exist."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("EnforcedToken", "EnforcedTokens"):
+        assert getattr(mod, name, None) is not None, (
+            f"vllm.validation.{name} is missing, so a replay payload cannot be "
+            f"decoded and inference validation silently degrades to a plain "
+            f"generate"
+        )
+    for meth in ("encode", "get_enforced_token_ids"):
+        assert hasattr(mod.EnforcedTokens, meth), (
+            f"EnforcedTokens.{meth} is missing — the ingestion path cannot "
+            f"produce token ids"
+        )
+
+
+def test_replay_ids_are_range_checked() -> None:
+    """Out-of-range replay ids must be rejected before they reach the engine.
+
+    This is the difference between a 400 and a dead worker: an id outside the
+    vocabulary reaches an embedding lookup, where it is a device-side assert
+    that takes down the process and every other request on it.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    validate = getattr(mod, "validate_enforced_token_ids", None)
+    assert validate is not None, (
+        "vllm.validation.validate_enforced_token_ids is missing — replay ids "
+        "would reach the embedding lookup unchecked"
+    )
+
+    vocab_size = 32000
+    validate([0, 1, vocab_size - 1], vocab_size)  # in range: must not raise
+
+    for bad in ([vocab_size], [-1], [-5]):
+        with pytest.raises(ValueError):
+            validate(bad, vocab_size)
+
+
+def test_replay_payload_is_size_bounded() -> None:
+    """The payload must have ceilings, so a large body cannot exhaust memory."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("MAX_ENFORCED_TOKENS", "MAX_TOP_TOKENS_PER_POSITION"):
+        limit = getattr(mod, name, None)
+        assert isinstance(limit, int) and limit > 0, (
+            f"vllm.validation.{name} is missing or not a positive int — the "
+            f"replay payload is unbounded"
+        )
+
+    with pytest.raises(ValueError):
+        mod.EnforcedTokens(
+            tokens=[{"token": "1"}] * (mod.MAX_ENFORCED_TOKENS + 1),
+        )
+
+
+def test_chat_request_carries_replay_fields() -> None:
+    """The request model must accept the replay fields.
+
+    If it does not, the payload is dropped during request parsing and the
+    validator gets an ordinary completion back while believing it verified
+    something.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.protocol")
+    cls = getattr(mod, "ChatCompletionRequest", None)
+    assert cls is not None, (
+        "ChatCompletionRequest is missing — the request protocol module was "
+        "restructured"
+    )
+    fields = set(getattr(cls, "model_fields", {}) or {})
+    if not fields:
+        fields = set(getattr(cls, "__annotations__", {}) or {})
+    for name in ("enforced_tokens", "enforced_str", "logprobs_mode"):
+        assert name in fields, (
+            f"ChatCompletionRequest.{name} is missing, so that part of a "
+            f"replay request is silently discarded"
+        )
+
+
+def test_sampling_params_carries_replay_ids() -> None:
+    """The field the ingestion path writes into must exist on SamplingParams.
+
+    Checked on the destination type rather than by reading the serving source,
+    so the test tracks the contract instead of a particular implementation.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.sampling_params")
+    cls = mod.SamplingParams
+    fields = set(getattr(cls, "__struct_fields__", ()) or ()) or set(
+        getattr(cls, "__annotations__", {}) or {}
+    )
+    assert "enforced_token_ids" in fields, (
+        "SamplingParams.enforced_token_ids is missing — the ingestion path has "
+        "nowhere to write decoded replay ids, so enforcement never fires"
+    )

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -256,7 +256,18 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
         tokenizer: TokenizerLike | None,
         return_as_token_id: bool = False,
     ) -> str:
-        return str(token_id)
+        if return_as_token_id:
+            return format_token_id_placeholder(token_id)
+
+        if logprob.decoded_token is not None:
+            return logprob.decoded_token
+
+        if tokenizer is None:
+            raise ValueError(
+                "Unable to get tokenizer because `skip_tokenizer_init=True`"
+            )
+
+        return tokenizer.decode([token_id])
 
 
 def format_token_id_placeholder(token_id: int) -> str:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -66,6 +66,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
 from vllm.utils.mistral import is_mistral_tool_parser
+from vllm.validation import validate_enforced_token_ids
 
 logger = init_logger(__name__)
 
@@ -329,8 +330,24 @@ class OpenAIServingChat(GenerateBaseServing):
                     enforced_ids = request.enforced_tokens.get_enforced_token_ids()
 
                 if enforced_ids:
-                    if enforced_ids[-1] != tokenizer.eos_token_id:
-                        enforced_ids.append(tokenizer.eos_token_id)
+                    # Untrusted input: these ids go straight into an embedding
+                    # lookup, where an out-of-range value is a device-side
+                    # assert that takes the worker down along with every other
+                    # request on it, rather than a rejected request.
+                    try:
+                        validate_enforced_token_ids(
+                            enforced_ids, self.model_config.get_vocab_size()
+                        )
+                    except ValueError as e:
+                        return self.create_error_response(
+                            str(e), param="enforced_tokens"
+                        )
+                    # TokenizerLike types eos_token_id as int, but it is None
+                    # for some models, and a None in the id list fails inside
+                    # the worker instead of failing the request.
+                    eos_token_id = tokenizer.eos_token_id
+                    if eos_token_id is not None and enforced_ids[-1] != eos_token_id:
+                        enforced_ids.append(eos_token_id)
                     sampling_params.enforced_token_ids = enforced_ids
                     if (
                         sampling_params.logprobs_mode is None

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""EnforcedToken support for gonka-style inference validation.
+"""Enforced-token support for replay-based inference validation.
 
 A validator replays a previously produced token sequence through this engine
 and compares the resulting logprobs against the originals. The ids arrive in
@@ -20,6 +20,25 @@ from pydantic import BaseModel, Field
 MAX_ENFORCED_TOKENS = 32768
 MAX_TOP_TOKENS_PER_POSITION = 64
 
+# Prefix vLLM uses when a request asks for token ids instead of text.
+_TOKEN_ID_PREFIX = "token_id:"
+
+
+def _parse_token_id(token: str) -> int | None:
+    """Return the id a token string denotes, or None if it denotes text.
+
+    Only a plain decimal is accepted, so forms that ``int()`` would otherwise
+    take -- underscores, non-ASCII digits, surrounding whitespace, a sign --
+    are treated as text and tokenized instead of being silently reinterpreted
+    as an id.
+    """
+    body = (
+        token[len(_TOKEN_ID_PREFIX) :] if token.startswith(_TOKEN_ID_PREFIX) else token
+    )
+    # isascii() matters: isdigit() alone is true for non-ASCII digits, so "٣"
+    # would resolve to id 3 instead of being tokenized as the text it is.
+    return int(body) if body.isascii() and body.isdigit() else None
+
 
 class EnforcedToken(BaseModel):
     token: str
@@ -30,22 +49,37 @@ class EnforcedToken(BaseModel):
     top_token_ids: list[int] = Field(default_factory=list, exclude=True)
 
     def encode(self, tokenizer) -> None:
-        """Convert token strings to token IDs.
-        Tokens from gonka API are already numeric strings (token IDs)."""
-        try:
-            self.token_id = int(self.token)
-            self.top_token_ids = [int(t) for t in self.top_tokens]
-        except ValueError:
-            # Fallback: tokenize the string
-            ids = tokenizer.encode(self.token, add_special_tokens=False)
-            # Left unresolved rather than mapped to id 0, which is a real
-            # token and would be indistinguishable downstream.
-            self.token_id = ids[0] if ids else None
-            self.top_token_ids = []
-            for t in self.top_tokens:
-                t_ids = tokenizer.encode(t, add_special_tokens=False)
-                if t_ids:
-                    self.top_token_ids.append(t_ids[0])
+        """Resolve the token strings in this position to token ids.
+
+        Accepts the ``token_id:N`` form that vLLM emits for a request with
+        ``return_tokens_as_token_ids``, which is how a validator should ask
+        for ids rather than text: it is the engine's own contract, it round
+        trips through ``resolve_token_id_placeholder``, and it does not
+        require changing what every other client sees.
+
+        A bare decimal string is also accepted, since that is what earlier
+        validators send. Anything else is treated as text and tokenized.
+        """
+        parsed = _parse_token_id(self.token)
+        if parsed is not None:
+            self.token_id = parsed
+            self.top_token_ids = [
+                tid
+                for tid in (_parse_token_id(t) for t in self.top_tokens)
+                if tid is not None
+            ]
+            return
+
+        # Text token: tokenize. A string that does not resolve to at least one
+        # id is left out rather than mapped to id 0, which would otherwise be
+        # indistinguishable from a genuine id 0 downstream.
+        ids = tokenizer.encode(self.token, add_special_tokens=False)
+        self.token_id = ids[0] if ids else None
+        self.top_token_ids = []
+        for t in self.top_tokens:
+            t_ids = tokenizer.encode(t, add_special_tokens=False)
+            if t_ids:
+                self.top_token_ids.append(t_ids[0])
 
 
 class EnforcedTokens(BaseModel):
@@ -68,8 +102,6 @@ class EnforcedTokens(BaseModel):
         if not self.tokens:
             raise ValueError("Enforced tokens are not encoded")
         ids = [token.token_id for token in self.tokens]
-        # Every position is checked, not just the first: a single unresolved
-        # token mid-sequence otherwise reaches the worker as None.
         if any(tid is None for tid in ids):
             raise ValueError("Enforced tokens are not encoded")
         return [tid for tid in ids if tid is not None]

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,13 +1,31 @@
-"""EnforcedToken support for gonka-style inference validation."""
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EnforcedToken support for gonka-style inference validation.
+
+A validator replays a previously produced token sequence through this engine
+and compares the resulting logprobs against the originals. The ids arrive in
+the request body, so they are untrusted: they end up in an embedding lookup,
+where an out-of-range value is not a rejected request but a device-side
+assert that takes the worker process -- and every other request on it -- down.
+"""
 
 from typing import Any
 
 from pydantic import BaseModel, Field
 
+# Ceilings on the replay payload, applied before any of it reaches the engine.
+# They do not bound the request body (that belongs to the proxy), but they do
+# stop a large body from being materialised as a huge number of models, and
+# they keep the per-position fan-out finite.
+MAX_ENFORCED_TOKENS = 32768
+MAX_TOP_TOKENS_PER_POSITION = 64
+
 
 class EnforcedToken(BaseModel):
     token: str
-    top_tokens: list[str] = Field(default_factory=list)
+    top_tokens: list[str] = Field(
+        default_factory=list, max_length=MAX_TOP_TOKENS_PER_POSITION
+    )
     token_id: int | None = Field(default=None, exclude=True)
     top_token_ids: list[int] = Field(default_factory=list, exclude=True)
 
@@ -20,7 +38,9 @@ class EnforcedToken(BaseModel):
         except ValueError:
             # Fallback: tokenize the string
             ids = tokenizer.encode(self.token, add_special_tokens=False)
-            self.token_id = ids[0] if ids else 0
+            # Left unresolved rather than mapped to id 0, which is a real
+            # token and would be indistinguishable downstream.
+            self.token_id = ids[0] if ids else None
             self.top_token_ids = []
             for t in self.top_tokens:
                 t_ids = tokenizer.encode(t, add_special_tokens=False)
@@ -29,7 +49,7 @@ class EnforcedToken(BaseModel):
 
 
 class EnforcedTokens(BaseModel):
-    tokens: list[EnforcedToken]
+    tokens: list[EnforcedToken] = Field(max_length=MAX_ENFORCED_TOKENS)
 
     def encode(self, tokenizer) -> None:
         for token in self.tokens:
@@ -45,9 +65,14 @@ class EnforcedTokens(BaseModel):
         return cls(tokens=tokens)
 
     def get_enforced_token_ids(self) -> list[int]:
-        if not self.tokens or self.tokens[0].token_id is None:
+        if not self.tokens:
             raise ValueError("Enforced tokens are not encoded")
-        return [token.token_id for token in self.tokens]
+        ids = [token.token_id for token in self.tokens]
+        # Every position is checked, not just the first: a single unresolved
+        # token mid-sequence otherwise reaches the worker as None.
+        if any(tid is None for tid in ids):
+            raise ValueError("Enforced tokens are not encoded")
+        return [tid for tid in ids if tid is not None]
 
     def detect_logprobs_mode(self, threshold: float = 0.10) -> str | None:
         """Classify original inference logprobs mode from top_token_ids.
@@ -73,3 +98,25 @@ class EnforcedTokens(BaseModel):
             return None
         ratio = low_id_count / total
         return "processed_logprobs" if ratio > threshold else "raw_logprobs"
+
+
+def validate_enforced_token_ids(token_ids: list[int], vocab_size: int) -> None:
+    """Reject replay ids the model cannot embed.
+
+    Raises ``ValueError`` so the caller can return a 400. Without this an
+    out-of-range id reaches the embedding lookup and aborts the worker.
+
+    Negative values are rejected wholesale: the sampler reserves ``-1`` as the
+    "no enforcement at this position" sentinel, so accepting it from a client
+    would silently disable enforcement instead of replaying.
+    """
+    for position, token_id in enumerate(token_ids):
+        if not isinstance(token_id, int) or isinstance(token_id, bool):
+            raise ValueError(
+                f"enforced token at position {position} is not an integer: {token_id!r}"
+            )
+        if token_id < 0 or token_id >= vocab_size:
+            raise ValueError(
+                f"enforced token at position {position} is out of range for "
+                f"this model: {token_id} not in [0, {vocab_size})"
+            )


### PR DESCRIPTION
Part 8/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

**Stacked on `fix/poc-validate-replay-ids`** — until that one merges, this diff shows both. Review the parent first.

_get_decoded_token returns str(token_id) unconditionally, so every
logprobs response from every endpoint carries numeric strings where the
OpenAI schema says text. Clients that read logprobs get digits back, and
the flag that exists for exactly this -- return_tokens_as_token_ids -- has
no effect either way.

This restores the upstream implementation and moves the replay path onto
the engine's own contract: a validator sets return_tokens_as_token_ids and
receives "token_id:N", which encode() now accepts. Bare decimals are still
accepted, so existing validators keep working.

Worth checking against your intent: if the numeric form is deliberate --
chosen so a validator needs no flag, accepting the effect on other clients
-- then say so and this can be dropped. It came into the residual from the
fat fork after the original migration had marked it dropped, on the
strength of a plugin-side serialiser that was never written, so it may
have been reinstated by accident rather than by decision.

Parsing is stricter than int(): underscores, non-ASCII digits, signs and
surrounding whitespace are treated as text and tokenized, rather than
being silently reinterpreted as ids.
