### PR TITLE
chore(poc): log the logprobs mode when it is inferred, not given

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -339,6 +339,16 @@ class OpenAIServingChat(GenerateBaseServing):
                         detected = request.enforced_tokens.detect_logprobs_mode()
                         if detected:
                             sampling_params.logprobs_mode = detected
+                            # The mode decides what the returned logprobs mean.
+                            # Inferring it from the shape of the payload rather
+                            # than reading an explicit field makes a wrong guess
+                            # impossible to spot in the response afterwards.
+                            logger.info(
+                                "Request %s: logprobs_mode not supplied, "
+                                "inferred %s from the replay payload",
+                                sub_request_id,
+                                detected,
+                            )
 
             self._log_inputs(
                 sub_request_id,


### PR DESCRIPTION
Part 9/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

detect_logprobs_mode guesses raw vs processed from how many low-numbered
ids the payload contains, against a fixed 0.10 threshold. The guess decides
what the returned logprobs mean, and nothing in the response records that
a guess was made -- a wrong one looks exactly like a correct one.

Logging it at least leaves a trail. The heuristic itself is left alone
here: the request already carries an explicit logprobs_mode field, and
whether inference should happen at all when that field is absent is a
contract question rather than a defect.
