### PR TITLE
feat(poc): accept replay fields on /v1/completions too

### DIFF
--- a/tests/contract/test_request_validation_surface.py
+++ b/tests/contract/test_request_validation_surface.py
@@ -119,3 +119,20 @@ def test_sampling_params_carries_replay_ids() -> None:
         "SamplingParams.enforced_token_ids is missing — the ingestion path has "
         "nowhere to write decoded replay ids, so enforcement never fires"
     )
+
+
+def test_completions_endpoint_carries_replay_fields() -> None:
+    """/v1/completions must accept the same replay fields as /v1/chat/completions.
+
+    A validator that points at the wrong endpoint would otherwise have its
+    payload silently dropped by the request model and get an ordinary
+    completion back -- indistinguishable from a verified replay.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.entrypoints.openai.completion.protocol")
+    fields = mod.CompletionRequest.model_fields
+    for name in ("enforced_tokens", "enforced_str", "logprobs_mode"):
+        assert name in fields, (
+            f"CompletionRequest is missing {name!r} — a replay sent to "
+            f"/v1/completions would be dropped during parsing"
+        )

--- a/tests/contract/test_request_validation_surface.py
+++ b/tests/contract/test_request_validation_surface.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pin the HTTP -> SamplingParams path for enforced-token replay.
+
+The sampler half of replay is pinned in ``test_sampler_surface.py``. This
+file pins the ingestion half: the request fields, the helper that decodes
+them, and the validation that keeps a replay id out of the embedding lookup
+unless the model can embed it.
+
+Both halves have to be present for replay to work, and the failure mode when
+the ingestion half is missing is silent — the payload is dropped by the
+request model and validation degrades into an ordinary generate, with no
+error anywhere. That is what these tests exist to make loud.
+
+Read-only: no GPU, no engine startup, no forward pass.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_validation_module_has_enforced_tokens() -> None:
+    """The helper that turns a replay payload into token ids must exist."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("EnforcedToken", "EnforcedTokens"):
+        assert getattr(mod, name, None) is not None, (
+            f"vllm.validation.{name} is missing, so a replay payload cannot be "
+            f"decoded and inference validation silently degrades to a plain "
+            f"generate"
+        )
+    for meth in ("encode", "get_enforced_token_ids"):
+        assert hasattr(mod.EnforcedTokens, meth), (
+            f"EnforcedTokens.{meth} is missing — the ingestion path cannot "
+            f"produce token ids"
+        )
+
+
+def test_replay_ids_are_range_checked() -> None:
+    """Out-of-range replay ids must be rejected before they reach the engine.
+
+    This is the difference between a 400 and a dead worker: an id outside the
+    vocabulary reaches an embedding lookup, where it is a device-side assert
+    that takes down the process and every other request on it.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    validate = getattr(mod, "validate_enforced_token_ids", None)
+    assert validate is not None, (
+        "vllm.validation.validate_enforced_token_ids is missing — replay ids "
+        "would reach the embedding lookup unchecked"
+    )
+
+    vocab_size = 32000
+    validate([0, 1, vocab_size - 1], vocab_size)  # in range: must not raise
+
+    for bad in ([vocab_size], [-1], [-5]):
+        with pytest.raises(ValueError):
+            validate(bad, vocab_size)
+
+
+def test_replay_payload_is_size_bounded() -> None:
+    """The payload must have ceilings, so a large body cannot exhaust memory."""
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.validation")
+    for name in ("MAX_ENFORCED_TOKENS", "MAX_TOP_TOKENS_PER_POSITION"):
+        limit = getattr(mod, name, None)
+        assert isinstance(limit, int) and limit > 0, (
+            f"vllm.validation.{name} is missing or not a positive int — the "
+            f"replay payload is unbounded"
+        )
+
+    with pytest.raises(ValueError):
+        mod.EnforcedTokens(
+            tokens=[{"token": "1"}] * (mod.MAX_ENFORCED_TOKENS + 1),
+        )
+
+
+def test_chat_request_carries_replay_fields() -> None:
+    """The request model must accept the replay fields.
+
+    If it does not, the payload is dropped during request parsing and the
+    validator gets an ordinary completion back while believing it verified
+    something.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.entrypoints.openai.chat_completion.protocol")
+    cls = getattr(mod, "ChatCompletionRequest", None)
+    assert cls is not None, (
+        "ChatCompletionRequest is missing — the request protocol module was "
+        "restructured"
+    )
+    fields = set(getattr(cls, "model_fields", {}) or {})
+    if not fields:
+        fields = set(getattr(cls, "__annotations__", {}) or {})
+    for name in ("enforced_tokens", "enforced_str", "logprobs_mode"):
+        assert name in fields, (
+            f"ChatCompletionRequest.{name} is missing, so that part of a "
+            f"replay request is silently discarded"
+        )
+
+
+def test_sampling_params_carries_replay_ids() -> None:
+    """The field the ingestion path writes into must exist on SamplingParams.
+
+    Checked on the destination type rather than by reading the serving source,
+    so the test tracks the contract instead of a particular implementation.
+    """
+    pytest.importorskip("vllm")
+    mod = importlib.import_module("vllm.sampling_params")
+    cls = mod.SamplingParams
+    fields = set(getattr(cls, "__struct_fields__", ()) or ()) or set(
+        getattr(cls, "__annotations__", {}) or {}
+    )
+    assert "enforced_token_ids" in fields, (
+        "SamplingParams.enforced_token_ids is missing — the ingestion path has "
+        "nowhere to write decoded replay ids, so enforcement never fires"
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -66,6 +66,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
 from vllm.utils.mistral import is_mistral_tool_parser
+from vllm.validation import validate_enforced_token_ids
 
 logger = init_logger(__name__)
 
@@ -329,8 +330,24 @@ class OpenAIServingChat(GenerateBaseServing):
                     enforced_ids = request.enforced_tokens.get_enforced_token_ids()
 
                 if enforced_ids:
-                    if enforced_ids[-1] != tokenizer.eos_token_id:
-                        enforced_ids.append(tokenizer.eos_token_id)
+                    # Untrusted input: these ids go straight into an embedding
+                    # lookup, where an out-of-range value is a device-side
+                    # assert that takes the worker down along with every other
+                    # request on it, rather than a rejected request.
+                    try:
+                        validate_enforced_token_ids(
+                            enforced_ids, self.model_config.get_vocab_size()
+                        )
+                    except ValueError as e:
+                        return self.create_error_response(
+                            str(e), param="enforced_tokens"
+                        )
+                    # TokenizerLike types eos_token_id as int, but it is None
+                    # for some models, and a None in the id list fails inside
+                    # the worker instead of failing the request.
+                    eos_token_id = tokenizer.eos_token_id
+                    if eos_token_id is not None and enforced_ids[-1] != eos_token_id:
+                        enforced_ids.append(eos_token_id)
                     sampling_params.enforced_token_ids = enforced_ids
                     if (
                         sampling_params.logprobs_mode is None

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -35,6 +35,7 @@ from vllm.sampling_params import (
     ThinkingTokenBudget,
 )
 from vllm.utils import random_uuid
+from vllm.validation import EnforcedTokens
 
 logger = init_logger(__name__)
 
@@ -185,6 +186,15 @@ class CompletionRequest(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",
+    )
+
+    enforced_tokens: EnforcedTokens | None = Field(
+        default=None,
+        description="Enforced token sequence for Gonka validation replay.",
+    )
+    enforced_str: str | None = Field(
+        default=None,
+        description="Enforced output string for Gonka validation replay.",
     )
 
     vllm_xargs: dict[str, str | int | float] | None = Field(

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -48,6 +48,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.async_utils import merge_async_iterators
 from vllm.utils.collection_utils import as_list
+from vllm.validation import validate_enforced_token_ids
 
 logger = init_logger(__name__)
 
@@ -128,6 +129,56 @@ class OpenAIServingCompletion(GenerateBaseServing):
             self._create_completion(request, raw_request), request, raw_request
         )
 
+    def _apply_enforced_tokens(
+        self,
+        request: CompletionRequest,
+        sampling_params: SamplingParams,
+    ) -> ErrorResponse | None:
+        """Resolve a replay payload onto sampling_params, or return a 400.
+
+        Mirrors the chat path. Kept here rather than shared with it because
+        the two request models have no common base carrying these fields.
+        """
+        tokenizer = self.renderer.tokenizer
+        enforced_ids: list[int] | None = None
+        if request.enforced_str:
+            if tokenizer is None:
+                return self.create_error_response(
+                    "enforced_str requires a tokenizer, but the server was "
+                    "started with skip_tokenizer_init=True",
+                    param="enforced_str",
+                )
+            enforced_ids = tokenizer.encode(
+                request.enforced_str, add_special_tokens=False
+            )
+        elif request.enforced_tokens:
+            request.enforced_tokens.encode(tokenizer)
+            enforced_ids = request.enforced_tokens.get_enforced_token_ids()
+
+        if not enforced_ids:
+            return None
+
+        # Untrusted input: these ids go straight into an embedding lookup,
+        # where an out-of-range value is a device-side assert that takes the
+        # worker down along with every other request on it.
+        try:
+            validate_enforced_token_ids(
+                enforced_ids, self.model_config.get_vocab_size()
+            )
+        except ValueError as e:
+            return self.create_error_response(str(e), param="enforced_tokens")
+
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if eos_token_id is not None and enforced_ids[-1] != eos_token_id:
+            enforced_ids.append(eos_token_id)
+        sampling_params.enforced_token_ids = enforced_ids
+
+        if sampling_params.logprobs_mode is None and request.enforced_tokens:
+            detected = request.enforced_tokens.detect_logprobs_mode()
+            if detected:
+                sampling_params.logprobs_mode = detected
+        return None
+
     async def _create_completion(
         self,
         request: CompletionRequest,
@@ -179,6 +230,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                error = self._apply_enforced_tokens(request, sampling_params)
+                if error is not None:
+                    return error
 
             request_id_item = f"{request_id}-{i}"
 

--- a/vllm/validation.py
+++ b/vllm/validation.py
@@ -1,13 +1,31 @@
-"""EnforcedToken support for gonka-style inference validation."""
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EnforcedToken support for gonka-style inference validation.
+
+A validator replays a previously produced token sequence through this engine
+and compares the resulting logprobs against the originals. The ids arrive in
+the request body, so they are untrusted: they end up in an embedding lookup,
+where an out-of-range value is not a rejected request but a device-side
+assert that takes the worker process -- and every other request on it -- down.
+"""
 
 from typing import Any
 
 from pydantic import BaseModel, Field
 
+# Ceilings on the replay payload, applied before any of it reaches the engine.
+# They do not bound the request body (that belongs to the proxy), but they do
+# stop a large body from being materialised as a huge number of models, and
+# they keep the per-position fan-out finite.
+MAX_ENFORCED_TOKENS = 32768
+MAX_TOP_TOKENS_PER_POSITION = 64
+
 
 class EnforcedToken(BaseModel):
     token: str
-    top_tokens: list[str] = Field(default_factory=list)
+    top_tokens: list[str] = Field(
+        default_factory=list, max_length=MAX_TOP_TOKENS_PER_POSITION
+    )
     token_id: int | None = Field(default=None, exclude=True)
     top_token_ids: list[int] = Field(default_factory=list, exclude=True)
 
@@ -20,7 +38,9 @@ class EnforcedToken(BaseModel):
         except ValueError:
             # Fallback: tokenize the string
             ids = tokenizer.encode(self.token, add_special_tokens=False)
-            self.token_id = ids[0] if ids else 0
+            # Left unresolved rather than mapped to id 0, which is a real
+            # token and would be indistinguishable downstream.
+            self.token_id = ids[0] if ids else None
             self.top_token_ids = []
             for t in self.top_tokens:
                 t_ids = tokenizer.encode(t, add_special_tokens=False)
@@ -29,7 +49,7 @@ class EnforcedToken(BaseModel):
 
 
 class EnforcedTokens(BaseModel):
-    tokens: list[EnforcedToken]
+    tokens: list[EnforcedToken] = Field(max_length=MAX_ENFORCED_TOKENS)
 
     def encode(self, tokenizer) -> None:
         for token in self.tokens:
@@ -45,9 +65,14 @@ class EnforcedTokens(BaseModel):
         return cls(tokens=tokens)
 
     def get_enforced_token_ids(self) -> list[int]:
-        if not self.tokens or self.tokens[0].token_id is None:
+        if not self.tokens:
             raise ValueError("Enforced tokens are not encoded")
-        return [token.token_id for token in self.tokens]
+        ids = [token.token_id for token in self.tokens]
+        # Every position is checked, not just the first: a single unresolved
+        # token mid-sequence otherwise reaches the worker as None.
+        if any(tid is None for tid in ids):
+            raise ValueError("Enforced tokens are not encoded")
+        return [tid for tid in ids if tid is not None]
 
     def detect_logprobs_mode(self, threshold: float = 0.10) -> str | None:
         """Classify original inference logprobs mode from top_token_ids.
@@ -73,3 +98,25 @@ class EnforcedTokens(BaseModel):
             return None
         ratio = low_id_count / total
         return "processed_logprobs" if ratio > threshold else "raw_logprobs"
+
+
+def validate_enforced_token_ids(token_ids: list[int], vocab_size: int) -> None:
+    """Reject replay ids the model cannot embed.
+
+    Raises ``ValueError`` so the caller can return a 400. Without this an
+    out-of-range id reaches the embedding lookup and aborts the worker.
+
+    Negative values are rejected wholesale: the sampler reserves ``-1`` as the
+    "no enforcement at this position" sentinel, so accepting it from a client
+    would silently disable enforcement instead of replaying.
+    """
+    for position, token_id in enumerate(token_ids):
+        if not isinstance(token_id, int) or isinstance(token_id, bool):
+            raise ValueError(
+                f"enforced token at position {position} is not an integer: {token_id!r}"
+            )
+        if token_id < 0 or token_id >= vocab_size:
+            raise ValueError(
+                f"enforced token at position {position} is out of range for "
+                f"this model: {token_id} not in [0, {vocab_size})"
+            )


### PR DESCRIPTION
Part 10/10 of the series mapped in #78 ([the table](https://github.com/gonka-ai/vllm/pull/78#issuecomment-5089020588)). One finding per PR so any that turns out to be your design can be rejected alone.

**Stacked on `fix/poc-validate-replay-ids`** — until that one merges, this diff shows both. Review the parent first.

Requested by @Vladikshokoladick on #78.

enforced_tokens and enforced_str existed only on the chat endpoint. A
replay sent to /v1/completions was dropped during request parsing -- no
error, just an ordinary completion, which is indistinguishable from a
verified replay to the caller. (logprobs_mode reached this endpoint in
91f6acb74, on the port branch itself; this adds the two fields that
carry the replay.)

Note this is not a piece the 0.25.1 port left behind: the fields were
never on this endpoint, including in the 0.20 fat fork running in
production. It is new surface, which is why it is a separate PR rather
than a fix to the port.

The ingestion helper mirrors the chat path, including the range check --
the ids reach an embedding lookup either way, so the new endpoint gets
the same guard rather than repeating the old mistake. It is duplicated
rather than shared because the two request models have no common base
carrying these fields.
