### PR TITLE
feat(poc): port replay hooks to the V2 model runner

### DIFF
--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -46,12 +46,6 @@ RUN INSTALLED=$(python3 -c "import vllm; print(vllm.__version__)") \
     && find . -name "*.py" | tar -cf - -T - | tar -xf - -C "$VLLM_DIR/" \
     && rm -rf /tmp/vllm-src
 
-# Select the V1 model runner. vLLM 0.25 ships a parallel V2 runner with its own
-# sampler, which does not implement enforced tokens or per-request logprobs
-# mode, so a replay request served by it would return a plausible completion
-# that enforced nothing.
-ENV VLLM_USE_V2_MODEL_RUNNER=0
-
 # The out-of-tree plugin, pinned to a tag rather than a branch, which would
 # resolve to whatever HEAD it has at build time. Lives in the gonka-ai
 # organisation as of 2026-07-28; the distribution is still named gonka-poc,

--- a/tests/contract/test_v2_replay_state.py
+++ b/tests/contract/test_v2_replay_state.py
@@ -82,3 +82,53 @@ def test_processed_mask_mixes_override_with_engine_default():
         True,
         False,
     ]
+
+
+def test_sampler_calls_replay_methods_with_the_signatures_they_declare():
+    """The sampler's call sites must match ReplayState's signatures.
+
+    Regression: the mode-mask call site passed three positional args to a
+    two-arg method, and passed the host-side index array where the body
+    indexes GPU buffers. Every replay request died with TypeError inside
+    the engine, while the tests above stayed green because they call the
+    methods directly. Signatures alone are checked here — no GPU, no
+    engine — so the mismatch cannot come back unnoticed.
+    """
+    import ast
+    import inspect
+    from pathlib import Path
+
+    from vllm.v1.worker.gpu.sample import replay as replay_mod
+
+    sampler_src = Path(inspect.getfile(replay_mod)).with_name("sampler.py").read_text()
+    tree = ast.parse(sampler_src)
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "replay_state"
+    ]
+    assert calls, "sampler.py no longer calls replay_state — did the hook move?"
+
+    for call in calls:
+        name = call.func.attr
+        method = getattr(ReplayState, name, None)
+        assert method is not None, f"sampler.py calls ReplayState.{name}, which is gone"
+        params = list(inspect.signature(method).parameters)[1:]  # drop self
+        passed = len(call.args) + len(call.keywords)
+        assert passed <= len(params), (
+            f"sampler.py passes {passed} args to ReplayState.{name}, "
+            f"which declares {len(params)} ({', '.join(params)})"
+        )
+        # Positional args must line up with the declared parameter names:
+        # passing idx_mapping_np where the body indexes GPU buffers is the
+        # exact mistake this guards against.
+        for pos, arg in enumerate(call.args):
+            if isinstance(arg, ast.Name) and params[pos].endswith("idx_mapping"):
+                assert arg.id.endswith("idx_mapping"), (
+                    f"ReplayState.{name} expects {params[pos]!r} at position "
+                    f"{pos}, but sampler.py passes {arg.id!r}"
+                )

--- a/tests/contract/test_v2_replay_state.py
+++ b/tests/contract/test_v2_replay_state.py
@@ -114,6 +114,7 @@ def test_sampler_calls_replay_methods_with_the_signatures_they_declare():
     assert calls, "sampler.py no longer calls replay_state — did the hook move?"
 
     for call in calls:
+        assert isinstance(call.func, ast.Attribute)
         name = call.func.attr
         method = getattr(ReplayState, name, None)
         assert method is not None, f"sampler.py calls ReplayState.{name}, which is gone"

--- a/tests/contract/test_v2_replay_state.py
+++ b/tests/contract/test_v2_replay_state.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The V2 sampler's replay bookkeeping, exercised without a GPU or engine.
+
+ReplayState touches exactly two RequestState tensors (total_len,
+prompt_len), so a two-field stand-in suffices; the test names state the
+pinned semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from vllm.v1.worker.gpu.sample.replay import ReplayState  # noqa: E402
+
+
+class _Field:
+    def __init__(self, values):
+        self.gpu = torch.tensor(values, dtype=torch.int32)
+
+
+class _ReqStates:
+    def __init__(self, total_len, prompt_len):
+        self.total_len = _Field(total_len)
+        self.prompt_len = _Field(prompt_len)
+
+
+class _Params:
+    def __init__(self, etids=None, mode=None):
+        self.enforced_token_ids = etids
+        self.logprobs_mode = mode
+
+
+def test_enforced_follows_emitted_position_and_exhausts_to_minus_one():
+    # Slot 0: replay [11, 22]; slot 1: plain request.
+    # total_len - prompt_len => emitted so far: slot0 has 1, slot1 has 5.
+    rs = ReplayState(
+        4,
+        _ReqStates(total_len=[6, 15, 0, 0], prompt_len=[5, 10, 0, 0]),
+        torch.device("cpu"),
+    )
+    rs.add_request(0, 5, _Params(etids=[11, 22]))
+    rs.add_request(1, 10, _Params())
+
+    rows = torch.tensor([0, 1], dtype=torch.int64)
+    out = rs.enforced_for_batch(rows).tolist()
+    assert out == [22, -1], "slot0 emitted 1 token, so position 1 => id 22"
+
+    # Advance slot0 past the end of the replay: nothing left to enforce.
+    rs.req_states.total_len.gpu[0] = 7
+    assert rs.enforced_for_batch(rows).tolist() == [-1, -1]
+
+
+def test_batch_predicate_is_slot_scoped():
+    rs = ReplayState(4, _ReqStates([0] * 4, [0] * 4), torch.device("cpu"))
+    rs.add_request(2, 1, _Params(etids=[7]))
+    import numpy as np
+
+    assert rs.batch_has_replay(np.array([2, 3]))
+    assert not rs.batch_has_replay(np.array([0, 1, 3]))
+    # Slot reuse must clear the flag.
+    rs.add_request(2, 1, _Params())
+    assert not rs.batch_has_replay(np.array([2]))
+
+
+def test_processed_mask_mixes_override_with_engine_default():
+    rs = ReplayState(4, _ReqStates([0] * 4, [0] * 4), torch.device("cpu"))
+    rs.add_request(0, 1, _Params(mode="raw_logprobs"))
+    rs.add_request(1, 1, _Params(mode="processed_logprobs"))
+    rs.add_request(2, 1, _Params())  # no override -> engine default
+
+    rows = torch.tensor([0, 1, 2], dtype=torch.int64)
+    assert rs.processed_rows_mask(rows, engine_processed=True).tolist() == [
+        False,
+        True,
+        True,
+    ]
+    assert rs.processed_rows_mask(rows, engine_processed=False).tolist() == [
+        False,
+        True,
+        False,
+    ]

--- a/vllm/v1/worker/gpu/sample/replay.py
+++ b/vllm/v1/worker/gpu/sample/replay.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Replay support for the V2 sampler: enforced tokens + per-request logprobs mode.
+
+Port of the V1 residual hooks (``vllm/v1/worker/gpu_input_batch.py`` /
+``vllm/v1/sample/sampler.py``) onto the V2 model runner, so a validator's
+replay request behaves identically on either runner. Without this, the V2
+sampler silently ignored ``SamplingParams.enforced_token_ids`` and the
+per-request ``logprobs_mode`` — a replay came back as an ordinary completion
+with no error anywhere.
+
+Design notes, in V2 terms:
+
+- Replay ids stay on the host (a per-slot list). Padding them into a static
+  ``(max_num_reqs, MAX_ENFORCED)`` device tensor would cost ~128 MiB whether
+  or not the node ever validates; instead the position lookup transfers one
+  small vector per step, and only on steps whose batch actually contains a
+  replay row. Mining and plain serving never reach that path.
+- The replay position is ``total_len - prompt_len`` from ``RequestState`` —
+  the number of tokens already emitted. ``total_len`` is advanced by the
+  post-sampling kernel, so at sampling time it still reflects the previous
+  step, which is exactly the index the V1 code derived from
+  ``len(req_output_token_ids)``.
+- Past the end of the replay the sentinel is ``-1`` ("nothing to enforce"),
+  matching the V1 semantics after gonka-ai/vllm#83's review: the final
+  replay id is EOS by contract, so termination happens before exhaustion is
+  ever reached in a well-formed request.
+"""
+
+import numpy as np
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.states import RequestState
+
+
+class ReplayState:
+    """Per-slot replay bookkeeping for the V2 sampler.
+
+    Invariants — add_request maintains all of them on every call, slot
+    reuse included; update them together or not at all:
+
+    - ``use_replay[i] == bool(enforced_ids[i])``
+    - ``has_mode_override_gpu`` mirrors ``has_mode_override``;
+      ``wants_processed_gpu[i]`` is meaningful only where it is True.
+    """
+
+    def __init__(
+        self, max_num_reqs: int, req_states: RequestState, device: torch.device
+    ):
+        self.req_states = req_states
+        # Host side: variable-length replay ids + fast batch predicates.
+        self.enforced_ids: list[list[int] | None] = [None] * max_num_reqs
+        self.use_replay = np.zeros(max_num_reqs, dtype=bool)
+        self.has_mode_override = np.zeros(max_num_reqs, dtype=bool)
+        # Device side, so the row mask is built without any transfer.
+        self.has_mode_override_gpu = torch.zeros(
+            max_num_reqs, dtype=torch.bool, device=device
+        )
+        self.wants_processed_gpu = torch.zeros(
+            max_num_reqs, dtype=torch.bool, device=device
+        )
+
+    def add_request(
+        self, req_idx: int, prompt_len: int, sampling_params: SamplingParams
+    ) -> None:
+        etids = sampling_params.enforced_token_ids
+        self.enforced_ids[req_idx] = list(etids) if etids else None
+        self.use_replay[req_idx] = bool(etids)
+
+        mode = sampling_params.logprobs_mode
+        has_override = mode is not None
+        self.has_mode_override[req_idx] = has_override
+        self.has_mode_override_gpu[req_idx] = has_override
+        self.wants_processed_gpu[req_idx] = mode == "processed_logprobs"
+
+    def batch_has_replay(self, idx_mapping_np: np.ndarray) -> bool:
+        return bool(self.use_replay[idx_mapping_np].any())
+
+    def batch_has_mode_override(self, idx_mapping_np: np.ndarray) -> bool:
+        return bool(self.has_mode_override[idx_mapping_np].any())
+
+    def enforced_for_batch(self, expanded_idx_mapping: torch.Tensor) -> torch.Tensor:
+        """[num_rows] int64 tensor: replay id per row, -1 where none applies.
+
+        Rows follow ``expanded_idx_mapping`` (one entry per LOGIT row, which
+        exceeds num_reqs when neighbouring requests expand for prompt
+        logprobs), so the result always matches ``sampled``'s shape. Extra
+        rows of one request all pin the same position — idempotent.
+
+        The host loop is deliberate: replay id lists are variable-length, so
+        there is no vectorised gather for them, and this path only runs on
+        steps whose batch contains a replay row.
+        """
+        # One transfer: row->slot mapping and emitted-so-far, together.
+        exp_np = expanded_idx_mapping.cpu().numpy()
+        out_len = (
+            self.req_states.total_len.gpu[expanded_idx_mapping]
+            - self.req_states.prompt_len.gpu[expanded_idx_mapping]
+        )
+        out_len_np = out_len.cpu().numpy()
+
+        enforced = np.full(exp_np.shape[0], -1, dtype=np.int64)
+        for row, req_idx in enumerate(exp_np):
+            etids = self.enforced_ids[req_idx]
+            if not etids:
+                continue
+            k = int(out_len_np[row])
+            if 0 <= k < len(etids):
+                enforced[row] = etids[k]
+        return torch.from_numpy(enforced).to(expanded_idx_mapping.device)
+
+    def processed_rows_mask(
+        self, expanded_idx_mapping: torch.Tensor, engine_processed: bool
+    ) -> torch.Tensor:
+        """[num_rows] bool mask over LOGIT rows: which want processed logprobs.
+
+        Rows with an explicit override use it; the rest fall back to the
+        engine-level mode. Pure-GPU select — no transfer, no host loop.
+        """
+        has = self.has_mode_override_gpu[expanded_idx_mapping]
+        wants = self.wants_processed_gpu[expanded_idx_mapping]
+        if engine_processed:
+            return has.logical_not().logical_or(wants)
+        return has.logical_and(wants)

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -23,6 +23,7 @@ from vllm.v1.worker.gpu.sample.logprob import (
 )
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.penalties import PenaltiesState
+from vllm.v1.worker.gpu.sample.replay import ReplayState
 from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS, SamplingStates
 from vllm.v1.worker.gpu.states import RequestState
 
@@ -50,6 +51,7 @@ class Sampler:
         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
         self.bad_words_state = BadWordsState(req_states)
         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
+        self.replay_state = ReplayState(max_num_reqs, req_states, device)
         self.num_speculative_tokens = num_speculative_tokens
         self.use_flashinfer = flashinfer_sampler_supported()
 
@@ -61,6 +63,7 @@ class Sampler:
         self.logit_bias_state.add_request(req_idx, prompt_len, sampling_params)
         self.bad_words_state.add_request(req_idx, sampling_params)
         self.logprob_token_ids_state.add_request(req_idx, sampling_params)
+        self.replay_state.add_request(req_idx, prompt_len, sampling_params)
 
     def apply_staged_writes(self) -> None:
         self.sampling_states.apply_staged_writes()
@@ -101,8 +104,24 @@ class Sampler:
             return_logprobs=return_logprobs,
         )
 
+        # Replay (see replay.py): sampling runs unchanged above so the
+        # logprobs are exactly an ordinary generation's; only the emitted
+        # token is pinned. The host-side guard keeps non-replay batches free.
+        if self.replay_state.batch_has_replay(idx_mapping_np):
+            enforced = self.replay_state.enforced_for_batch(expanded_idx_mapping)
+            sampled = torch.where(enforced != -1, enforced, sampled)
+
         if return_logprobs:
-            if self.logprobs_mode == "processed_logprobs":
+            if self.replay_state.batch_has_mode_override(idx_mapping_np):
+                # Per-request logprobs mode: row-wise select between two
+                # tensors that both already exist — never a recompute.
+                row_mask = self.replay_state.processed_rows_mask(
+                    idx_mapping_np,
+                    self.logprobs_mode == "processed_logprobs",
+                    logits.device,
+                )
+                logits = torch.where(row_mask.unsqueeze(1), processed_logits, logits)
+            elif self.logprobs_mode == "processed_logprobs":
                 logits = processed_logits
             expanded_logits = logits.shape[0] != idx_mapping_np.shape[0]
             cu_num_logits = cu_num_logits_np.tolist() if expanded_logits else None

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -116,9 +116,8 @@ class Sampler:
                 # Per-request logprobs mode: row-wise select between two
                 # tensors that both already exist — never a recompute.
                 row_mask = self.replay_state.processed_rows_mask(
-                    idx_mapping_np,
+                    expanded_idx_mapping,
                     self.logprobs_mode == "processed_logprobs",
-                    logits.device,
                 )
                 logits = torch.where(row_mask.unsqueeze(1), processed_logits, logits)
             elif self.logprobs_mode == "processed_logprobs":

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -134,6 +134,29 @@ class RejectionSampler:
             use_fp64=self.sampler.use_fp64_gumbel,
             use_block_verification=self.use_block_verification,
         )
+        replay_state = getattr(self.sampler, "replay_state", None)
+        if replay_state is not None and replay_state.batch_has_replay(
+            input_batch.idx_mapping_np
+        ):
+            # A replaying request must emit exactly the pinned token for its
+            # current output position and accept no drafts. ReplayState pins
+            # every row of a request to the same position, so the request's
+            # first logit row carries the token to emit.
+            enforced_rows = replay_state.enforced_for_batch(
+                input_batch.expanded_idx_mapping
+            )
+            first_row = input_batch.cu_num_logits[:-1].long()
+            enforced_first = enforced_rows[first_row]
+            is_replay = enforced_first >= 0
+            if bool(is_replay.any()):
+                sampled = sampled.clone()
+                sampled[:, 0] = torch.where(
+                    is_replay, enforced_first.to(sampled.dtype), sampled[:, 0]
+                )
+                num_sampled = torch.where(
+                    is_replay, torch.ones_like(num_sampled), num_sampled
+                )
+
         logprobs_tensors = self._get_logprobs_tensors(
             input_batch,
             sampled,


### PR DESCRIPTION
Ports Gonka inference-validation replay to the V2 model runner. This is required for DeepSeek-V4-Flash-0731: DSpark uses V2, while the previous image-level `VLLM_USE_V2_MODEL_RUNNER=0` pin disabled that path.

## Changes

- Add slot-scoped V2 replay state for `enforced_token_ids`.
- Apply forced tokens after ordinary sampling so returned logprobs still come from the model distribution.
- Handle forced replay in the DSpark rejection-sampling path.
- Preserve per-request raw/processed selection in the ordinary V2 sampler. Under speculation, logprobs mode keeps the existing V1 behavior and uses the deployment-wide mode.
- Remove the V1 runner pin from the Gonka image.

Replay position is `total_len - prompt_len`, equivalent to V1's `len(req_output_token_ids)`. The path is entered only for inference-validation requests carrying `enforced_tokens`; normal inference and PoC execution are unchanged.

## Verification

- `pre-commit` and `pre-run-check`: passed on the current head.
- `tests/contract/test_v2_replay_state.py`: covers replay position, exhaustion, slot reuse, mode selection, and call-site signatures.
- DeepSeek-V4-Flash-0731, 100 prompts, executor 1x B300 TP=1 -> validator 2x H200 TP=2, DSpark enabled, raw logprobs: distance2 `0.0314`, length mismatches `0/100`, token IDs matched `100/100`.

This does not duplicate #78: #78 provides the V1/plugin integration; this PR adds the missing V2 replay path and incorporates the speculation fix from kaitakuai/vllm#18.

AI assistance was used. The human submitter reviewed the changes and test results.
