### PR TITLE
fix(poc): restore 32768-token API batch default

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2427,7 +2427,7 @@ class EngineArgs:
             # For GPUs like H100 and MI300x, use larger default values.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 16384,
-                UsageContext.OPENAI_API_SERVER: 8192,
+                UsageContext.OPENAI_API_SERVER: 32768,
             }
             default_max_num_seqs = {
                 UsageContext.LLM_CLASS: 1024,
@@ -2437,7 +2437,7 @@ class EngineArgs:
             # TODO(woosuk): Tune the default values for other hardware.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 8192,
-                UsageContext.OPENAI_API_SERVER: 2048,
+                UsageContext.OPENAI_API_SERVER: 32768,
             }
             default_max_num_seqs = {
                 UsageContext.LLM_CLASS: 256,


### PR DESCRIPTION
## Why

The standard Gonka PoC batch is 32 × 1024 tokens. vLLM 0.25.1 currently starts the OpenAI server with an 8192-token default on large GPUs, so fused-MoE workspace warmup can capture CUDA graphs against a workspace smaller than PoC requires. Growing that workspace during PoC invalidates the captured inference pointers and can make the first post-PoC inference fail with an illegal memory access/XID 31.

Restore the Gonka v0.20 behavior by defaulting the OpenAI API server to 32768 batched tokens on both GPU-default branches. Explicit command-line values still override this default; LLM, TPU, and CPU defaults are unchanged.

## Duplicate-work check

No open Gonka vLLM PR was found for `max_num_batched_tokens`, `32768`, or the PoC MoE-workspace lifecycle failure. This restores an invariant previously carried by Gonka commit `557902af6` rather than duplicating an active change.

## Verification

- Full pre-commit suite for the changed file: passed.
- `.venv/bin/python -m compileall -q vllm/engine/arg_utils.py`: passed.
- `git diff --check`: passed.
- Live 8×H100 MiniMax M2.7 control: with `--max-num-batched-tokens 32768`, CUDA graphs enabled, the sequence inference → PoC → stop → inference passed without XID. The same image at the 8192 default reproduced post-PoC illegal-memory/XID failures.

AI assistance was used to inspect the regression history, prepare the two-line change, and run the checks. The human submitter is responsible for reviewing and defending the change end-to-end.
