### PR TITLE
chore(poc): update plugin to v0.1.3

### DIFF
--- a/docker/Dockerfile.gonka-poc
+++ b/docker/Dockerfile.gonka-poc
@@ -51,7 +51,7 @@ RUN INSTALLED=$(python3 -c "import vllm; print(vllm.__version__)") \
 # organisation as of 2026-07-28; the distribution is still named gonka-poc,
 # so only the source URL moved.
 ARG GONKA_POC_REPO=gonka-ai/gonka-vllm-plugins
-ARG GONKA_POC_REF=v0.1.2
+ARG GONKA_POC_REF=v0.1.3
 RUN pip install --no-cache-dir --no-deps \
       "gonka-poc @ https://github.com/${GONKA_POC_REPO}/archive/refs/tags/${GONKA_POC_REF}.tar.gz" \
     && pip install --no-cache-dir "aiohttp>=3.9" "scipy>=1.10"


### PR DESCRIPTION
## Why

Pin `gonka-poc` v0.1.3, which removes runtime MoE-workspace reallocation after CUDA graph capture. This pairs with #94's 32768-token API batch default: the standard PoC workspace is allocated before capture and retains stable addresses across inference → PoC → inference transitions.

Plugin change: https://github.com/gonka-ai/gonka-vllm-plugins/pull/5

## Duplicate-work check

This is the release-pin follow-up to #94 and plugin PR #5. No other open PR updates the image to v0.1.3.

## Verification

- vLLM pre-commit suite for the changed Dockerfile: passed.
- Plugin grep-lint and compile checks: passed.
- Plugin CPU tests available without vLLM: 5 passed, 12 skipped.
- Live 8×H100 MiniMax M2.7 lifecycle passed with CUDA graphs once the workspace was pre-sized to 32768; the previous runtime resize reproduced illegal memory access/XID 31.

AI assistance was used to prepare the pin and verification. The human submitter is responsible for reviewing and defending the change end-to-end.
