### PR TITLE
fix(sched): skip requests absent from req_id_to_index

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1575,7 +1575,13 @@ class Scheduler(SchedulerInterface):
                 # In this case, we use is_finished() to check.
                 continue
 
-            req_index = model_runner_output.req_id_to_index[req_id]
+            req_index = model_runner_output.req_id_to_index.get(req_id)
+            if req_index is None:
+                # Async-scheduling race: the request is in num_scheduled_tokens
+                # but the model runner produced no output for it this step
+                # (aborted or preempted between schedule and execution). Skip
+                # it instead of crashing EngineCore with a KeyError.
+                continue
             generated_token_ids = (
                 sampled_token_ids[req_index] if sampled_token_ids else []
             )


### PR DESCRIPTION
Upstreams kaitakuai/vllm#19 (same commit, clanster's authorship kept) — full analysis and risk assessment there.

Under async scheduling a request can sit in `num_scheduled_tokens` while the model runner produced no output for it that step; the direct `req_id_to_index[req_id]` lookup then raises KeyError and takes down EngineCore. First hit on the production DeepSeek-V4-Flash-0731 nodes.

New since the original PR: running in production since Aug 10 as a build-time layer in all 12 kaitaku images, on both the 0.20 and 0.25.1 lines — the crash has not recurred through a full epoch. Landing it here puts the fix in the base image instead, so every release build carries it.