### PR TITLE
fix(deepseek_v4): keep DSpark draft experts off the NVFP4 path

### DIFF
--- a/vllm/models/deepseek_v4/quant_config.py
+++ b/vllm/models/deepseek_v4/quant_config.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from vllm.config import get_current_vllm_config
@@ -50,6 +51,7 @@ class DeepseekV4FP8Config(Fp8Config):
         super().__init__(*args, **kwargs)
         self._resolved_expert_dtype: str | None = None
         self._resolved_moe_quant_algo: str | None = None
+        self._nvfp4_expert_prefixes: set[str] | None = None
         self._nvfp4_config: ModelOptNvFp4Config | None = None
         # ``is_scale_e8m0`` is a property that resolves on first read,
         # by which time the current vllm_config has been set.
@@ -99,6 +101,53 @@ class DeepseekV4FP8Config(Fp8Config):
         self._resolve_moe_overrides()
         return self._resolved_moe_quant_algo or ""
 
+    def _nvfp4_expert_prefix_set(self) -> set[str]:
+        """Expert prefixes the checkpoint actually converted to NVFP4.
+
+        NVFP4 conversions of V4 (both ``nvidia/DeepSeek-V4-Flash-NVFP4`` and the
+        community 0731 port) convert only ``layers.0..N-1.ffn.experts`` and leave
+        the DSpark draft (``mtp.*``) experts in the source MXFP4 representation.
+        They declare that via ``ignore``, which ``Fp8Config`` does not read, so
+        ``moe_quant_algo`` alone would apply NVFP4 to the draft experts too.
+        ``quantized_layers`` is the authoritative per-layer map; empty means the
+        checkpoint tells us nothing and the caller keeps the old behaviour.
+        """
+        if self._nvfp4_expert_prefixes is None:
+            try:
+                hf_config = get_current_vllm_config().model_config.hf_config
+                quant_cfg = getattr(hf_config, "quantization_config", None) or {}
+            except Exception:
+                return set()
+            layers = quant_cfg.get("quantized_layers") or {}
+            self._nvfp4_expert_prefixes = {
+                name
+                for name, info in layers.items()
+                if str((info or {}).get("quant_algo", "")).upper() == "NVFP4"
+            }
+        return self._nvfp4_expert_prefixes
+
+    def _is_nvfp4_expert_layer(self, prefix: str) -> bool | None:
+        """True/False per the checkpoint map, or None when it has no map."""
+        converted = self._nvfp4_expert_prefix_set()
+        if not converted:
+            return None
+        # Runtime prefixes are "model.layers.<i>.ffn.experts"; the map keys drop
+        # the "model." Draft layers are built at index >= num_hidden_layers, but
+        # a checkpoint may name them in mtp space instead - accept either.
+        candidates = {prefix, prefix.removeprefix("model.")}
+        match = re.search(r"layers\.(\d+)\.(.*)$", prefix)
+        if match is not None:
+            try:
+                n_layers = int(
+                    get_current_vllm_config().model_config.hf_config.num_hidden_layers
+                )
+            except Exception:
+                n_layers = None
+            index = int(match.group(1))
+            if n_layers is not None and index >= n_layers:
+                candidates.add(f"mtp.{index - n_layers}.{match.group(2)}")
+        return bool(candidates & converted)
+
     def _get_nvfp4_config(self) -> ModelOptNvFp4Config:
         if self._nvfp4_config is None:
             from vllm.model_executor.layers.quantization.modelopt import (
@@ -140,7 +189,10 @@ class DeepseekV4FP8Config(Fp8Config):
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if self.expert_dtype == "fp4":
-                if self.moe_quant_algo == "NVFP4":
+                # Only take the NVFP4 path for experts the checkpoint really
+                # converted. None => no per-layer map, keep the old behaviour.
+                is_nvfp4 = self._is_nvfp4_expert_layer(prefix or "")
+                if self.moe_quant_algo == "NVFP4" and is_nvfp4 is not False:
                     from vllm.model_executor.layers.quantization.modelopt import (
                         ModelOptNvFp4FusedMoE,
                     )


### PR DESCRIPTION
Upstreams kaitakuai/vllm#20 (same commit, clanster's authorship kept) — measurements, per-checkpoint behaviour table and risk analysis there.

NVFP4 conversions of V4 leave the DSpark draft (`mtp.*`) experts in MXFP4 but `Fp8Config` never reads the checkpoint's `ignore` list, so NVFP4 kernels ran over MXFP4 weights and acceptance collapsed to ~1.2 tok/chunk. Consulting `quantized_layers` recovers 2.7–5.6x decode on 1xB300; the honest fp8 checkpoint has no `moe_quant_algo`, so its path is untouched.

Relevant here since NVFP4 became the technically-primary variant on B300: without this the primary configuration ships with speculation effectively dead. Already live in the kaitaku b300 image as a build-time layer producing this exact file, byte-for-byte.